### PR TITLE
Add StyleProvider and StyleConsumer

### DIFF
--- a/lib/build/recipe/components/featureWrapper.d.ts
+++ b/lib/build/recipe/components/featureWrapper.d.ts
@@ -1,9 +1,7 @@
 /// <reference types="react" />
-import { NormalisedDefaultStyles } from "../emailpassword/types";
 declare type FeatureWrapperProps = {
-    defaultStyles: NormalisedDefaultStyles;
     children: JSX.Element;
     useShadowDom?: boolean;
 };
-export default function FeatureWrapper({ children, defaultStyles, useShadowDom }: FeatureWrapperProps): JSX.Element;
+export default function FeatureWrapper({ children, useShadowDom }: FeatureWrapperProps): JSX.Element;
 export {};

--- a/lib/build/recipe/components/featureWrapper.js
+++ b/lib/build/recipe/components/featureWrapper.js
@@ -31,6 +31,8 @@ var _errorBoundary = _interopRequireDefault(require("./errorBoundary"));
 
 var _core = require("@emotion/core");
 
+var _styleContext = require("../emailpassword/styles/styleContext");
+
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
 }
@@ -100,7 +102,6 @@ function _interopRequireWildcard(obj) {
  */
 function FeatureWrapper(_ref) {
     var children = _ref.children,
-        defaultStyles = _ref.defaultStyles,
         useShadowDom = _ref.useShadowDom;
 
     /*
@@ -112,7 +113,6 @@ function FeatureWrapper(_ref) {
         (0, _core.jsx)(
             WithOrWithoutShadowDom,
             {
-                defaultStyles: defaultStyles,
                 useShadowDom: useShadowDom
             },
             (0, _core.jsx)(
@@ -131,27 +131,32 @@ function FeatureWrapper(_ref) {
 
 function WithOrWithoutShadowDom(_ref2) {
     var children = _ref2.children,
-        defaultStyles = _ref2.defaultStyles,
         useShadowDom = _ref2.useShadowDom;
 
     // If explicitely specified to not use shadow dom.
     if (useShadowDom === false) {
+        return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref3) {
+            var defaultStyles = _ref3.defaultStyles;
+            return (0, _core.jsx)(
+                "div",
+                {
+                    css: defaultStyles.root,
+                    id: _constants.ST_ROOT_CONTAINER
+                },
+                children
+            );
+        });
+    } // Otherwise, use shadow dom.
+
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref4) {
+        var defaultStyles = _ref4.defaultStyles;
         return (0, _core.jsx)(
-            "div",
+            _emotion["default"].div,
             {
                 css: defaultStyles.root,
                 id: _constants.ST_ROOT_CONTAINER
             },
             children
         );
-    } // Otherwise, use shadow dom.
-
-    return (0, _core.jsx)(
-        _emotion["default"].div,
-        {
-            css: defaultStyles.root,
-            id: _constants.ST_ROOT_CONTAINER
-        },
-        children
-    );
+    });
 }

--- a/lib/build/recipe/components/featureWrapper.js
+++ b/lib/build/recipe/components/featureWrapper.js
@@ -135,12 +135,11 @@ function WithOrWithoutShadowDom(_ref2) {
 
     // If explicitely specified to not use shadow dom.
     if (useShadowDom === false) {
-        return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref3) {
-            var defaultStyles = _ref3.defaultStyles;
+        return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
             return (0, _core.jsx)(
                 "div",
                 {
-                    css: defaultStyles.root,
+                    css: styles.root,
                     id: _constants.ST_ROOT_CONTAINER
                 },
                 children
@@ -148,12 +147,11 @@ function WithOrWithoutShadowDom(_ref2) {
         });
     } // Otherwise, use shadow dom.
 
-    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref4) {
-        var defaultStyles = _ref4.defaultStyles;
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
         return (0, _core.jsx)(
             _emotion["default"].div,
             {
-                css: defaultStyles.root,
+                css: styles.root,
                 id: _constants.ST_ROOT_CONTAINER
             },
             children

--- a/lib/build/recipe/emailpassword/components/library/FormBase.js
+++ b/lib/build/recipe/emailpassword/components/library/FormBase.js
@@ -13,6 +13,8 @@ var _core = require("@emotion/core");
 
 var _constants = require("../../constants");
 
+var _styleContext = require("../../styles/styleContext");
+
 function _getRequireWildcardCache() {
     if (typeof WeakMap !== "function") return null;
     var cache = new WeakMap();
@@ -480,8 +482,6 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
                 var _this2 = this;
 
                 var _this$props = this.props,
-                    defaultStyles = _this$props.defaultStyles,
-                    palette = _this$props.palette,
                     header = _this$props.header,
                     footer = _this$props.footer,
                     buttonLabel = _this$props.buttonLabel,
@@ -491,110 +491,106 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
                     generalError = _this$state.generalError,
                     formFields = _this$state.formFields,
                     isLoading = _this$state.isLoading;
-                return (0, _core.jsx)(
-                    "div",
-                    {
-                        className: "container",
-                        css: [defaultStyles.container, styleFromInit.container]
-                    },
-                    (0, _core.jsx)(
+                return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref3) {
+                    var defaultStyles = _ref3.defaultStyles;
+                    return (0, _core.jsx)(
                         "div",
                         {
-                            className: "row",
-                            css: [defaultStyles.row, styleFromInit.row]
+                            className: "container",
+                            css: [defaultStyles.container, styleFromInit.container]
                         },
-                        header,
-                        generalError &&
-                            (0, _core.jsx)(
-                                "div",
-                                {
-                                    className: "generalError",
-                                    css: [defaultStyles.generalError, styleFromInit.generalError]
-                                },
-                                generalError
-                            ),
                         (0, _core.jsx)(
-                            "form",
+                            "div",
                             {
-                                autoComplete: "on",
-                                noValidate: true,
-                                onSubmit: this.onFormSubmit
+                                className: "row",
+                                css: [defaultStyles.row, styleFromInit.row]
                             },
-                            formFields.map(function(field) {
-                                var type = "text"; // If email or password, replace field type.
+                            header,
+                            generalError &&
+                                (0, _core.jsx)(
+                                    "div",
+                                    {
+                                        className: "generalError",
+                                        css: [defaultStyles.generalError, styleFromInit.generalError]
+                                    },
+                                    generalError
+                                ),
+                            (0, _core.jsx)(
+                                "form",
+                                {
+                                    autoComplete: "on",
+                                    noValidate: true,
+                                    onSubmit: _this2.onFormSubmit
+                                },
+                                formFields.map(function(field) {
+                                    var type = "text"; // If email or password, replace field type.
 
-                                if (_constants.MANDATORY_FORM_FIELDS_ID_ARRAY.includes(field.id)) {
-                                    type = field.id;
-                                }
+                                    if (_constants.MANDATORY_FORM_FIELDS_ID_ARRAY.includes(field.id)) {
+                                        type = field.id;
+                                    }
 
-                                if (field.id === "confirm-password") {
-                                    type = "password";
-                                }
+                                    if (field.id === "confirm-password") {
+                                        type = "password";
+                                    }
 
-                                return (0, _core.jsx)(
+                                    return (0, _core.jsx)(
+                                        _.FormRow,
+                                        {
+                                            style: styleFromInit.formRow,
+                                            key: field.id
+                                        },
+                                        (0, _core.jsx)(
+                                            React.Fragment,
+                                            null,
+                                            showLabels &&
+                                                (0, _core.jsx)(_.Label, {
+                                                    style: styleFromInit.label,
+                                                    value: field.label,
+                                                    showIsRequired: field.showIsRequired
+                                                }),
+                                            (0, _core.jsx)(_.Input, {
+                                                style: styleFromInit.input,
+                                                errorStyle: styleFromInit.inputError,
+                                                adornmentStyle: styleFromInit.inputAdornment,
+                                                type: type,
+                                                name: field.id,
+                                                placeholder: field.placeholder,
+                                                ref: field.ref,
+                                                onChange: _this2.handleInputChange,
+                                                hasError: field.error !== undefined,
+                                                validated: field.validated
+                                            }),
+                                            field.error &&
+                                                (0, _core.jsx)(_.InputError, {
+                                                    style: styleFromInit.inputErrorMessage,
+                                                    error: field.error
+                                                })
+                                        )
+                                    );
+                                }),
+                                (0, _core.jsx)(
                                     _.FormRow,
                                     {
                                         style: styleFromInit.formRow,
-                                        key: field.id,
-                                        defaultStyles: defaultStyles
+                                        key: "form-button"
                                     },
                                     (0, _core.jsx)(
                                         React.Fragment,
                                         null,
-                                        showLabels &&
-                                            (0, _core.jsx)(_.Label, {
-                                                style: styleFromInit.label,
-                                                value: field.label,
-                                                showIsRequired: field.showIsRequired,
-                                                defaultStyles: defaultStyles
-                                            }),
-                                        (0, _core.jsx)(_.Input, {
-                                            style: styleFromInit.input,
-                                            errorStyle: styleFromInit.inputError,
-                                            adornmentStyle: styleFromInit.inputAdornment,
-                                            type: type,
-                                            name: field.id,
-                                            placeholder: field.placeholder,
-                                            ref: field.ref,
-                                            onChange: _this2.handleInputChange,
-                                            hasError: field.error !== undefined,
-                                            validated: field.validated,
-                                            defaultStyles: defaultStyles,
-                                            palette: palette
+                                        (0, _core.jsx)(_.Button, {
+                                            style: styleFromInit.button,
+                                            disabled: isLoading,
+                                            isLoading: isLoading,
+                                            type: "submit",
+                                            label: buttonLabel
                                         }),
-                                        field.error &&
-                                            (0, _core.jsx)(_.InputError, {
-                                                style: styleFromInit.inputErrorMessage,
-                                                error: field.error,
-                                                defaultStyles: defaultStyles
-                                            })
+                                        footer
                                     )
-                                );
-                            }),
-                            (0, _core.jsx)(
-                                _.FormRow,
-                                {
-                                    style: styleFromInit.formRow,
-                                    key: "form-button",
-                                    defaultStyles: defaultStyles
-                                },
-                                (0, _core.jsx)(
-                                    React.Fragment,
-                                    null,
-                                    (0, _core.jsx)(_.Button, {
-                                        defaultStyles: defaultStyles,
-                                        style: styleFromInit.button,
-                                        disabled: isLoading,
-                                        isLoading: isLoading,
-                                        type: "submit",
-                                        label: buttonLabel
-                                    }),
-                                    footer
                                 )
                             )
                         )
-                    )
-                );
+                    );
+                });
             }
         }
     ]);

--- a/lib/build/recipe/emailpassword/components/library/FormBase.js
+++ b/lib/build/recipe/emailpassword/components/library/FormBase.js
@@ -486,24 +486,22 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
                     footer = _this$props.footer,
                     buttonLabel = _this$props.buttonLabel,
                     showLabels = _this$props.showLabels;
-                var styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
                 var _this$state = this.state,
                     generalError = _this$state.generalError,
                     formFields = _this$state.formFields,
                     isLoading = _this$state.isLoading;
-                return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref3) {
-                    var defaultStyles = _ref3.defaultStyles;
+                return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
                     return (0, _core.jsx)(
                         "div",
                         {
                             className: "container",
-                            css: [defaultStyles.container, styleFromInit.container]
+                            css: styles.container
                         },
                         (0, _core.jsx)(
                             "div",
                             {
                                 className: "row",
-                                css: [defaultStyles.row, styleFromInit.row]
+                                css: styles.row
                             },
                             header,
                             generalError &&
@@ -511,7 +509,7 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
                                     "div",
                                     {
                                         className: "generalError",
-                                        css: [defaultStyles.generalError, styleFromInit.generalError]
+                                        css: styles.generalError
                                     },
                                     generalError
                                 ),
@@ -536,7 +534,6 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
                                     return (0, _core.jsx)(
                                         _.FormRow,
                                         {
-                                            style: styleFromInit.formRow,
                                             key: field.id
                                         },
                                         (0, _core.jsx)(
@@ -544,14 +541,10 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
                                             null,
                                             showLabels &&
                                                 (0, _core.jsx)(_.Label, {
-                                                    style: styleFromInit.label,
                                                     value: field.label,
                                                     showIsRequired: field.showIsRequired
                                                 }),
                                             (0, _core.jsx)(_.Input, {
-                                                style: styleFromInit.input,
-                                                errorStyle: styleFromInit.inputError,
-                                                adornmentStyle: styleFromInit.inputAdornment,
                                                 type: type,
                                                 name: field.id,
                                                 placeholder: field.placeholder,
@@ -562,7 +555,6 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
                                             }),
                                             field.error &&
                                                 (0, _core.jsx)(_.InputError, {
-                                                    style: styleFromInit.inputErrorMessage,
                                                     error: field.error
                                                 })
                                         )
@@ -571,14 +563,12 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
                                 (0, _core.jsx)(
                                     _.FormRow,
                                     {
-                                        style: styleFromInit.formRow,
                                         key: "form-button"
                                     },
                                     (0, _core.jsx)(
                                         React.Fragment,
                                         null,
                                         (0, _core.jsx)(_.Button, {
-                                            style: styleFromInit.button,
                                             disabled: isLoading,
                                             isLoading: isLoading,
                                             type: "submit",

--- a/lib/build/recipe/emailpassword/components/library/button.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/button.d.ts
@@ -1,12 +1,10 @@
 /// <reference types="react" />
-import { CSSObject } from "@emotion/serialize/types/index";
 declare type ButtonProps = {
-    style: CSSObject;
     label: string;
     isLoading: boolean;
     disabled?: boolean;
     type: "submit" | "button" | "reset" | undefined;
     onClick?: () => void;
 };
-export default function Button({ style, type, label, disabled, isLoading, onClick }: ButtonProps): JSX.Element;
+export default function Button({ type, label, disabled, isLoading, onClick }: ButtonProps): JSX.Element;
 export {};

--- a/lib/build/recipe/emailpassword/components/library/button.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/button.d.ts
@@ -1,14 +1,12 @@
 /// <reference types="react" />
 import { CSSObject } from "@emotion/serialize/types/index";
-import { NormalisedDefaultStyles } from "../../types";
 declare type ButtonProps = {
     style: CSSObject;
     label: string;
     isLoading: boolean;
     disabled?: boolean;
     type: "submit" | "button" | "reset" | undefined;
-    defaultStyles: NormalisedDefaultStyles;
     onClick?: () => void;
 };
-export default function Button({ style, type, label, disabled, isLoading, defaultStyles, onClick }: ButtonProps): JSX.Element;
+export default function Button({ style, type, label, disabled, isLoading, onClick }: ButtonProps): JSX.Element;
 export {};

--- a/lib/build/recipe/emailpassword/components/library/button.js
+++ b/lib/build/recipe/emailpassword/components/library/button.js
@@ -25,6 +25,8 @@ var _core = require("@emotion/core");
 
 var React = _interopRequireWildcard(require("react"));
 
+var _styleContext = require("../../styles/styleContext");
+
 function _getRequireWildcardCache() {
     if (typeof WeakMap !== "function") return null;
     var cache = new WeakMap();
@@ -94,23 +96,25 @@ function Button(_ref) {
         label = _ref.label,
         disabled = _ref.disabled,
         isLoading = _ref.isLoading,
-        defaultStyles = _ref.defaultStyles,
         onClick = _ref.onClick;
 
     if (disabled === undefined) {
         disabled = false;
     }
 
-    return (0, _core.jsx)(
-        "button",
-        {
-            type: type,
-            disabled: disabled,
-            onClick: onClick,
-            css: [defaultStyles.button, style],
-            className: "button"
-        },
-        label,
-        isLoading && "..."
-    );
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref2) {
+        var defaultStyles = _ref2.defaultStyles;
+        return (0, _core.jsx)(
+            "button",
+            {
+                type: type,
+                disabled: disabled,
+                onClick: onClick,
+                css: [defaultStyles.button, style],
+                className: "button"
+            },
+            label,
+            isLoading && "..."
+        );
+    });
 }

--- a/lib/build/recipe/emailpassword/components/library/button.js
+++ b/lib/build/recipe/emailpassword/components/library/button.js
@@ -91,8 +91,7 @@ function _interopRequireWildcard(obj) {
  * Component.
  */
 function Button(_ref) {
-    var style = _ref.style,
-        type = _ref.type,
+    var type = _ref.type,
         label = _ref.label,
         disabled = _ref.disabled,
         isLoading = _ref.isLoading,
@@ -102,15 +101,14 @@ function Button(_ref) {
         disabled = false;
     }
 
-    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref2) {
-        var defaultStyles = _ref2.defaultStyles;
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
         return (0, _core.jsx)(
             "button",
             {
                 type: type,
                 disabled: disabled,
                 onClick: onClick,
-                css: [defaultStyles.button, style],
+                css: styles.button,
                 className: "button"
             },
             label,

--- a/lib/build/recipe/emailpassword/components/library/formRow.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/formRow.d.ts
@@ -1,10 +1,8 @@
 /// <reference types="react" />
 import { CSSObject } from "@emotion/serialize/types/index";
-import { NormalisedDefaultStyles } from "../../types";
 declare type FormRowProps = {
     style: CSSObject;
     children: JSX.Element;
-    defaultStyles: NormalisedDefaultStyles;
 };
-export default function FormRow({ style, children, defaultStyles }: FormRowProps): JSX.Element;
+export default function FormRow({ style, children }: FormRowProps): JSX.Element;
 export {};

--- a/lib/build/recipe/emailpassword/components/library/formRow.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/formRow.d.ts
@@ -1,8 +1,6 @@
 /// <reference types="react" />
-import { CSSObject } from "@emotion/serialize/types/index";
 declare type FormRowProps = {
-    style: CSSObject;
     children: JSX.Element;
 };
-export default function FormRow({ style, children }: FormRowProps): JSX.Element;
+export default function FormRow({ children }: FormRowProps): JSX.Element;
 export {};

--- a/lib/build/recipe/emailpassword/components/library/formRow.js
+++ b/lib/build/recipe/emailpassword/components/library/formRow.js
@@ -91,15 +91,13 @@ function _interopRequireWildcard(obj) {
  * Component.
  */
 function FormRow(_ref) {
-    var style = _ref.style,
-        children = _ref.children;
-    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref2) {
-        var defaultStyles = _ref2.defaultStyles;
+    var children = _ref.children;
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
         return (0, _core.jsx)(
             "div",
             {
                 className: "formRow",
-                css: [defaultStyles.formRow, style]
+                css: styles.formRow
             },
             children
         );

--- a/lib/build/recipe/emailpassword/components/library/formRow.js
+++ b/lib/build/recipe/emailpassword/components/library/formRow.js
@@ -25,6 +25,8 @@ var _core = require("@emotion/core");
 
 var React = _interopRequireWildcard(require("react"));
 
+var _styleContext = require("../../styles/styleContext");
+
 function _getRequireWildcardCache() {
     if (typeof WeakMap !== "function") return null;
     var cache = new WeakMap();
@@ -90,14 +92,16 @@ function _interopRequireWildcard(obj) {
  */
 function FormRow(_ref) {
     var style = _ref.style,
-        children = _ref.children,
-        defaultStyles = _ref.defaultStyles;
-    return (0, _core.jsx)(
-        "div",
-        {
-            className: "formRow",
-            css: [defaultStyles.formRow, style]
-        },
-        children
-    );
+        children = _ref.children;
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref2) {
+        var defaultStyles = _ref2.defaultStyles;
+        return (0, _core.jsx)(
+            "div",
+            {
+                className: "formRow",
+                css: [defaultStyles.formRow, style]
+            },
+            children
+        );
+    });
 }

--- a/lib/build/recipe/emailpassword/components/library/input.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/input.d.ts
@@ -3,7 +3,6 @@ import { CSSObject } from "@emotion/core";
 import * as React from "react";
 import { RefObject } from "react";
 import { APIFormField } from "../../../../types";
-import { NormalisedDefaultStyles, NormalisedPalette } from "../../types";
 declare type InputProps = {
     style?: CSSObject;
     errorStyle?: CSSObject;
@@ -13,10 +12,8 @@ declare type InputProps = {
     name: string;
     hasError: boolean;
     placeholder: string;
-    defaultStyles: NormalisedDefaultStyles;
-    palette: NormalisedPalette;
     ref: RefObject<any>;
     onChange?: (field: APIFormField) => void;
 };
-declare const _default: React.ForwardRefExoticComponent<Pick<InputProps, "style" | "name" | "type" | "onChange" | "placeholder" | "hasError" | "defaultStyles" | "palette" | "adornmentStyle" | "validated" | "errorStyle"> & React.RefAttributes<any>>;
+declare const _default: React.ForwardRefExoticComponent<Pick<InputProps, "style" | "name" | "type" | "onChange" | "placeholder" | "hasError" | "adornmentStyle" | "validated" | "errorStyle"> & React.RefAttributes<any>>;
 export default _default;

--- a/lib/build/recipe/emailpassword/components/library/input.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/input.d.ts
@@ -15,5 +15,5 @@ declare type InputProps = {
     ref: RefObject<any>;
     onChange?: (field: APIFormField) => void;
 };
-declare const _default: React.ForwardRefExoticComponent<Pick<InputProps, "style" | "name" | "type" | "onChange" | "placeholder" | "hasError" | "adornmentStyle" | "validated" | "errorStyle"> & React.RefAttributes<any>>;
+declare const _default: React.ForwardRefExoticComponent<Pick<InputProps, "style" | "name" | "type" | "onChange" | "placeholder" | "hasError" | "validated" | "errorStyle" | "adornmentStyle"> & React.RefAttributes<any>>;
 export default _default;

--- a/lib/build/recipe/emailpassword/components/library/input.js
+++ b/lib/build/recipe/emailpassword/components/library/input.js
@@ -68,59 +68,37 @@ function _interopRequireWildcard(obj) {
     return newObj;
 }
 
-function ownKeys(object, enumerableOnly) {
-    var keys = Object.keys(object);
-    if (Object.getOwnPropertySymbols) {
-        var symbols = Object.getOwnPropertySymbols(object);
-        if (enumerableOnly)
-            symbols = symbols.filter(function(sym) {
-                return Object.getOwnPropertyDescriptor(object, sym).enumerable;
-            });
-        keys.push.apply(keys, symbols);
-    }
-    return keys;
-}
+/* Copyright (c) 2020, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 
-function _objectSpread(target) {
-    for (var i = 1; i < arguments.length; i++) {
-        var source = arguments[i] != null ? arguments[i] : {};
-        if (i % 2) {
-            ownKeys(Object(source), true).forEach(function(key) {
-                _defineProperty(target, key, source[key]);
-            });
-        } else if (Object.getOwnPropertyDescriptors) {
-            Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
-        } else {
-            ownKeys(Object(source)).forEach(function(key) {
-                Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
-            });
-        }
-    }
-    return target;
-}
+/*
+ * Imports.
+ */
 
-function _defineProperty(obj, key, value) {
-    if (key in obj) {
-        Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true });
-    } else {
-        obj[key] = value;
-    }
-    return obj;
-}
+/** @jsx jsx */
 
 /*
  * Component.
  */
 function Input(_ref, ref) {
-    var style = _ref.style,
-        type = _ref.type,
+    var type = _ref.type,
         name = _ref.name,
         hasError = _ref.hasError,
-        adornmentStyle = _ref.adornmentStyle,
         onChange = _ref.onChange,
         placeholder = _ref.placeholder,
-        validated = _ref.validated,
-        errorStyle = _ref.errorStyle;
+        validated = _ref.validated;
 
     /*
      * Method.
@@ -137,15 +115,8 @@ function Input(_ref, ref) {
      * Render.
      */
 
-    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref2) {
-        var defaultStyles = _ref2.defaultStyles;
-
-        if (hasError !== true) {
-            errorStyle = undefined;
-        } else {
-            errorStyle = _objectSpread(_objectSpread({}, defaultStyles.inputError), errorStyle);
-        }
-
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
+        var errorStyle = hasError === true ? styles.inputError : undefined;
         var adornmentType = undefined;
 
         if (validated) {
@@ -156,11 +127,11 @@ function Input(_ref, ref) {
             "div",
             {
                 className: "inputWrapper",
-                css: [defaultStyles.inputWrapper]
+                css: [styles.inputWrapper]
             },
             (0, _core.jsx)("input", {
                 className: "input inputError",
-                css: [defaultStyles.input, style, errorStyle],
+                css: [styles.input, errorStyle],
                 onFocus: handleChange,
                 type: type,
                 name: name,
@@ -168,7 +139,6 @@ function Input(_ref, ref) {
                 ref: ref
             }),
             (0, _core.jsx)(_.InputAdornment, {
-                style: adornmentStyle,
                 type: adornmentType
             })
         );

--- a/lib/build/recipe/emailpassword/components/library/input.js
+++ b/lib/build/recipe/emailpassword/components/library/input.js
@@ -27,6 +27,8 @@ var React = _interopRequireWildcard(require("react"));
 
 var _ = require(".");
 
+var _styleContext = require("../../styles/styleContext");
+
 function _getRequireWildcardCache() {
     if (typeof WeakMap !== "function") return null;
     var cache = new WeakMap();
@@ -118,25 +120,11 @@ function Input(_ref, ref) {
         onChange = _ref.onChange,
         placeholder = _ref.placeholder,
         validated = _ref.validated,
-        defaultStyles = _ref.defaultStyles,
-        palette = _ref.palette,
         errorStyle = _ref.errorStyle;
 
-    if (hasError !== true) {
-        errorStyle = undefined;
-    } else {
-        errorStyle = _objectSpread(_objectSpread({}, defaultStyles.inputError), errorStyle);
-    }
-
-    var adornmentType = undefined;
-
-    if (validated) {
-        adornmentType = hasError ? "error" : "success";
-    }
     /*
      * Method.
      */
-
     function handleChange() {
         if (onChange) {
             onChange({
@@ -149,28 +137,42 @@ function Input(_ref, ref) {
      * Render.
      */
 
-    return (0, _core.jsx)(
-        "div",
-        {
-            className: "inputWrapper",
-            css: [defaultStyles.inputWrapper]
-        },
-        (0, _core.jsx)("input", {
-            className: "input inputError",
-            css: [defaultStyles.input, style, errorStyle],
-            onFocus: handleChange,
-            type: type,
-            name: name,
-            placeholder: placeholder,
-            ref: ref
-        }),
-        (0, _core.jsx)(_.InputAdornment, {
-            defaultStyles: defaultStyles,
-            palette: palette,
-            style: adornmentStyle,
-            type: adornmentType
-        })
-    );
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref2) {
+        var defaultStyles = _ref2.defaultStyles;
+
+        if (hasError !== true) {
+            errorStyle = undefined;
+        } else {
+            errorStyle = _objectSpread(_objectSpread({}, defaultStyles.inputError), errorStyle);
+        }
+
+        var adornmentType = undefined;
+
+        if (validated) {
+            adornmentType = hasError ? "error" : "success";
+        }
+
+        return (0, _core.jsx)(
+            "div",
+            {
+                className: "inputWrapper",
+                css: [defaultStyles.inputWrapper]
+            },
+            (0, _core.jsx)("input", {
+                className: "input inputError",
+                css: [defaultStyles.input, style, errorStyle],
+                onFocus: handleChange,
+                type: type,
+                name: name,
+                placeholder: placeholder,
+                ref: ref
+            }),
+            (0, _core.jsx)(_.InputAdornment, {
+                style: adornmentStyle,
+                type: adornmentType
+            })
+        );
+    });
 }
 
 var _default = /*#__PURE__*/ (0, React.forwardRef)(Input);

--- a/lib/build/recipe/emailpassword/components/library/inputAdornment.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/inputAdornment.d.ts
@@ -1,12 +1,9 @@
 /// <reference types="react" />
 import { CSSObject } from "@emotion/serialize/types/index";
-import { NormalisedDefaultStyles, NormalisedPalette } from "../../types";
 export declare type AdornmentType = "success" | "error" | undefined;
 declare type InputAdornmentProps = {
     style?: CSSObject;
     type: AdornmentType;
-    defaultStyles: NormalisedDefaultStyles;
-    palette: NormalisedPalette;
 };
-export default function InputAdornment({ type, style, defaultStyles, palette }: InputAdornmentProps): JSX.Element;
+export default function InputAdornment({ type, style }: InputAdornmentProps): JSX.Element;
 export {};

--- a/lib/build/recipe/emailpassword/components/library/inputAdornment.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/inputAdornment.d.ts
@@ -1,9 +1,7 @@
 /// <reference types="react" />
-import { CSSObject } from "@emotion/serialize/types/index";
 export declare type AdornmentType = "success" | "error" | undefined;
 declare type InputAdornmentProps = {
-    style?: CSSObject;
     type: AdornmentType;
 };
-export default function InputAdornment({ type, style }: InputAdornmentProps): JSX.Element;
+export default function InputAdornment({ type }: InputAdornmentProps): JSX.Element;
 export {};

--- a/lib/build/recipe/emailpassword/components/library/inputAdornment.js
+++ b/lib/build/recipe/emailpassword/components/library/inputAdornment.js
@@ -29,6 +29,8 @@ var _error = _interopRequireDefault(require("../../assets/error"));
 
 var React = _interopRequireWildcard(require("react"));
 
+var _styleContext = require("../../styles/styleContext");
+
 function _getRequireWildcardCache() {
     if (typeof WeakMap !== "function") return null;
     var cache = new WeakMap();
@@ -98,26 +100,28 @@ function _interopRequireDefault(obj) {
  */
 function InputAdornment(_ref) {
     var type = _ref.type,
-        style = _ref.style,
-        defaultStyles = _ref.defaultStyles,
-        palette = _ref.palette;
+        style = _ref.style;
 
     /*
      * Render.
      */
-    return (0, _core.jsx)(
-        "div",
-        {
-            className: "inputAdornment",
-            css: [defaultStyles.inputAdornment, style]
-        },
-        type === "success" &&
-            (0, _core.jsx)(_checked["default"], {
-                color: palette.colors.primary
-            }),
-        type === "error" &&
-            (0, _core.jsx)(_error["default"], {
-                color: palette.colors.error
-            })
-    );
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref2) {
+        var defaultStyles = _ref2.defaultStyles,
+            palette = _ref2.palette;
+        return (0, _core.jsx)(
+            "div",
+            {
+                className: "inputAdornment",
+                css: [defaultStyles.inputAdornment, style]
+            },
+            type === "success" &&
+                (0, _core.jsx)(_checked["default"], {
+                    color: palette.colors.primary
+                }),
+            type === "error" &&
+                (0, _core.jsx)(_error["default"], {
+                    color: palette.colors.error
+                })
+        );
+    });
 }

--- a/lib/build/recipe/emailpassword/components/library/inputAdornment.js
+++ b/lib/build/recipe/emailpassword/components/library/inputAdornment.js
@@ -99,28 +99,25 @@ function _interopRequireDefault(obj) {
  * Component.
  */
 function InputAdornment(_ref) {
-    var type = _ref.type,
-        style = _ref.style;
+    var type = _ref.type;
 
     /*
      * Render.
      */
-    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref2) {
-        var defaultStyles = _ref2.defaultStyles,
-            palette = _ref2.palette;
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
         return (0, _core.jsx)(
             "div",
             {
                 className: "inputAdornment",
-                css: [defaultStyles.inputAdornment, style]
+                css: styles.inputAdornment
             },
             type === "success" &&
                 (0, _core.jsx)(_checked["default"], {
-                    color: palette.colors.primary
+                    color: styles.palette.colors.primary
                 }),
             type === "error" &&
                 (0, _core.jsx)(_error["default"], {
-                    color: palette.colors.error
+                    color: styles.palette.colors.error
                 })
         );
     });

--- a/lib/build/recipe/emailpassword/components/library/inputError.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/inputError.d.ts
@@ -1,10 +1,8 @@
 /// <reference types="react" />
 import { CSSObject } from "@emotion/serialize/types/index";
-import { NormalisedDefaultStyles } from "../../types";
 declare type InputErrorProps = {
     style: CSSObject;
     error: string;
-    defaultStyles: NormalisedDefaultStyles;
 };
-export default function InputError({ style, error, defaultStyles }: InputErrorProps): JSX.Element;
+export default function InputError({ style, error }: InputErrorProps): JSX.Element;
 export {};

--- a/lib/build/recipe/emailpassword/components/library/inputError.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/inputError.d.ts
@@ -1,8 +1,6 @@
 /// <reference types="react" />
-import { CSSObject } from "@emotion/serialize/types/index";
 declare type InputErrorProps = {
-    style: CSSObject;
     error: string;
 };
-export default function InputError({ style, error }: InputErrorProps): JSX.Element;
+export default function InputError({ error }: InputErrorProps): JSX.Element;
 export {};

--- a/lib/build/recipe/emailpassword/components/library/inputError.js
+++ b/lib/build/recipe/emailpassword/components/library/inputError.js
@@ -91,19 +91,17 @@ function _interopRequireWildcard(obj) {
  * Component.
  */
 function InputError(_ref) {
-    var style = _ref.style,
-        error = _ref.error;
+    var error = _ref.error;
 
     /*
      * Render.
      */
-    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref2) {
-        var defaultStyles = _ref2.defaultStyles;
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
         return (0, _core.jsx)(
             "div",
             {
                 className: "inputErrorMessage",
-                css: [defaultStyles.inputErrorMessage, style]
+                css: styles.inputErrorMessage
             },
             error
         );

--- a/lib/build/recipe/emailpassword/components/library/inputError.js
+++ b/lib/build/recipe/emailpassword/components/library/inputError.js
@@ -25,6 +25,8 @@ var _core = require("@emotion/core");
 
 var React = _interopRequireWildcard(require("react"));
 
+var _styleContext = require("../../styles/styleContext");
+
 function _getRequireWildcardCache() {
     if (typeof WeakMap !== "function") return null;
     var cache = new WeakMap();
@@ -90,18 +92,20 @@ function _interopRequireWildcard(obj) {
  */
 function InputError(_ref) {
     var style = _ref.style,
-        error = _ref.error,
-        defaultStyles = _ref.defaultStyles;
+        error = _ref.error;
 
     /*
      * Render.
      */
-    return (0, _core.jsx)(
-        "div",
-        {
-            className: "inputErrorMessage",
-            css: [defaultStyles.inputErrorMessage, style]
-        },
-        error
-    );
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref2) {
+        var defaultStyles = _ref2.defaultStyles;
+        return (0, _core.jsx)(
+            "div",
+            {
+                className: "inputErrorMessage",
+                css: [defaultStyles.inputErrorMessage, style]
+            },
+            error
+        );
+    });
 }

--- a/lib/build/recipe/emailpassword/components/library/label.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/label.d.ts
@@ -1,9 +1,7 @@
 /// <reference types="react" />
-import { CSSObject } from "@emotion/serialize/types/index";
 declare type LabelProps = {
-    style: CSSObject;
     value: string;
     showIsRequired?: boolean;
 };
-export default function Label({ style, value, showIsRequired }: LabelProps): JSX.Element;
+export default function Label({ value, showIsRequired }: LabelProps): JSX.Element;
 export {};

--- a/lib/build/recipe/emailpassword/components/library/label.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/label.d.ts
@@ -1,11 +1,9 @@
 /// <reference types="react" />
 import { CSSObject } from "@emotion/serialize/types/index";
-import { NormalisedDefaultStyles } from "../../types";
 declare type LabelProps = {
     style: CSSObject;
     value: string;
     showIsRequired?: boolean;
-    defaultStyles: NormalisedDefaultStyles;
 };
-export default function Label({ style, value, showIsRequired, defaultStyles }: LabelProps): JSX.Element;
+export default function Label({ style, value, showIsRequired }: LabelProps): JSX.Element;
 export {};

--- a/lib/build/recipe/emailpassword/components/library/label.js
+++ b/lib/build/recipe/emailpassword/components/library/label.js
@@ -91,20 +91,18 @@ function _interopRequireWildcard(obj) {
  * Component.
  */
 function Label(_ref) {
-    var style = _ref.style,
-        value = _ref.value,
+    var value = _ref.value,
         showIsRequired = _ref.showIsRequired;
 
     /*
      * Render.
      */
-    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref2) {
-        var defaultStyles = _ref2.defaultStyles;
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
         return (0, _core.jsx)(
             "div",
             {
                 className: "label",
-                css: [defaultStyles.label, style]
+                css: styles.label
             },
             value,
             ":",

--- a/lib/build/recipe/emailpassword/components/library/label.js
+++ b/lib/build/recipe/emailpassword/components/library/label.js
@@ -25,6 +25,8 @@ var _core = require("@emotion/core");
 
 var React = _interopRequireWildcard(require("react"));
 
+var _styleContext = require("../../styles/styleContext");
+
 function _getRequireWildcardCache() {
     if (typeof WeakMap !== "function") return null;
     var cache = new WeakMap();
@@ -91,20 +93,22 @@ function _interopRequireWildcard(obj) {
 function Label(_ref) {
     var style = _ref.style,
         value = _ref.value,
-        showIsRequired = _ref.showIsRequired,
-        defaultStyles = _ref.defaultStyles;
+        showIsRequired = _ref.showIsRequired;
 
     /*
      * Render.
      */
-    return (0, _core.jsx)(
-        "div",
-        {
-            className: "label",
-            css: [defaultStyles.label, style]
-        },
-        value,
-        ":",
-        showIsRequired && " *"
-    );
+    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref2) {
+        var defaultStyles = _ref2.defaultStyles;
+        return (0, _core.jsx)(
+            "div",
+            {
+                className: "label",
+                css: [defaultStyles.label, style]
+            },
+            value,
+            ":",
+            showIsRequired && " *"
+        );
+    });
 }

--- a/lib/build/recipe/emailpassword/components/resetPasswordUsingToken/resetPasswordUsingToken.js
+++ b/lib/build/recipe/emailpassword/components/resetPasswordUsingToken/resetPasswordUsingToken.js
@@ -15,13 +15,13 @@ var _featureWrapper = _interopRequireDefault(require("../../../components/featur
 
 var _core = require("@emotion/core");
 
-var _styles = require("../../styles/styles");
-
 var _constants = require("../../constants");
 
 var _utils = require("../../../../utils");
 
 var _api = require("./api");
+
+var _styleContext = require("../../styles/styleContext");
 
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
@@ -437,26 +437,18 @@ var ResetPasswordUsingToken = /*#__PURE__*/ (function(_PureComponent) {
             var submitNewPasswordFormFeature = _this.getRecipeInstanceOrThrow().getConfig()
                 .resetPasswordUsingTokenFeature.submitNewPasswordForm;
 
-            var defaultStyles = (0, _styles.getDefaultStyles)(_this.getRecipeInstanceOrThrow().getConfig().palette);
-
-            var palette = _this.getRecipeInstanceOrThrow().getConfig().palette;
-
             var submitNewPasswordForm = {
                 styleFromInit: submitNewPasswordFormFeature.style,
                 formFields: submitNewPasswordFormFeature.formFields,
                 callAPI: _this.submitNewPassword,
                 onSuccess: _this.onSubmitNewPasswordFormSuccess,
-                defaultStyles: defaultStyles,
-                palette: palette,
                 onSignInClicked: _this.onSignInClicked
             };
             var enterEmailForm = {
                 styleFromInit: enterEmailFormFeature.style,
                 formFields: enterEmailFormFeature.formFields,
                 onSuccess: _this.onEnterEmailFormSuccess,
-                callAPI: _this.enterEmail,
-                defaultStyles: defaultStyles,
-                palette: palette
+                callAPI: _this.enterEmail
             };
 
             var useShadowDom = _this.getRecipeInstanceOrThrow().getConfig().useShadowDom;
@@ -467,26 +459,29 @@ var ResetPasswordUsingToken = /*#__PURE__*/ (function(_PureComponent) {
              */
 
             return (0, _core.jsx)(
-                _featureWrapper["default"],
-                {
-                    useShadowDom: useShadowDom,
-                    defaultStyles: defaultStyles
-                },
+                _styleContext.StyleProvider,
+                null,
                 (0, _core.jsx)(
-                    React.Fragment,
-                    null,
-                    _this.props.children === undefined &&
-                        (0, _core.jsx)(_.ResetPasswordUsingTokenTheme, {
-                            submitNewPassword: submitNewPasswordForm,
-                            enterEmail: enterEmailForm,
-                            hasToken: hasToken
-                        }),
-                    _this.props.children &&
-                        /*#__PURE__*/ React.cloneElement(_this.props.children, {
-                            submitNewPasswordForm: submitNewPasswordForm,
-                            enterEmailForm: enterEmailForm,
-                            hasToken: hasToken
-                        })
+                    _featureWrapper["default"],
+                    {
+                        useShadowDom: useShadowDom
+                    },
+                    (0, _core.jsx)(
+                        React.Fragment,
+                        null,
+                        _this.props.children === undefined &&
+                            (0, _core.jsx)(_.ResetPasswordUsingTokenTheme, {
+                                submitNewPassword: submitNewPasswordForm,
+                                enterEmail: enterEmailForm,
+                                hasToken: hasToken
+                            }),
+                        _this.props.children &&
+                            /*#__PURE__*/ React.cloneElement(_this.props.children, {
+                                submitNewPasswordForm: submitNewPasswordForm,
+                                enterEmailForm: enterEmailForm,
+                                hasToken: hasToken
+                            })
+                    )
                 )
             );
         };

--- a/lib/build/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/enterEmail.js
+++ b/lib/build/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/enterEmail.js
@@ -306,87 +306,89 @@ var EnterEmailTheme = /*#__PURE__*/ (function(_PureComponent) {
                     formFields = _this$state.formFields,
                     emailSent = _this$state.emailSent;
                 var styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
-                return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref) {
-                    var defaultStyles = _ref.defaultStyles,
-                        palette = _ref.palette;
-                    var styles = getStyles(palette); // If email sent, show success UI.
+                return (0, _core.jsx)(
+                    _styleContext.StyleProvider,
+                    {
+                        styleFromInit: styleFromInit
+                    },
+                    (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
+                        var componentStyles = getStyles(styles.palette); // If email sent, show success UI.
 
-                    if (emailSent === true) {
-                        return (0, _core.jsx)(
-                            "div",
-                            {
-                                className: "container",
-                                css: [defaultStyles.container, styleFromInit.container]
-                            },
-                            (0, _core.jsx)(
+                        if (emailSent === true) {
+                            return (0, _core.jsx)(
                                 "div",
                                 {
-                                    className: "row",
-                                    css: [defaultStyles.row, styleFromInit.row]
+                                    className: "container",
+                                    css: styles.container
                                 },
                                 (0, _core.jsx)(
                                     "div",
                                     {
-                                        className: "primaryText successMessage",
-                                        css: [
-                                            defaultStyles.primaryText,
-                                            styleFromInit.primaryText,
-                                            styles.successMessage,
-                                            styleFromInit.successMessage
-                                        ]
+                                        className: "row",
+                                        css: styles.row
                                     },
-                                    "You will receive a password recovery link at your email address in a few minutes.",
-                                    " ",
                                     (0, _core.jsx)(
-                                        "span",
+                                        "div",
                                         {
-                                            className: "link",
-                                            css: [defaultStyles.link, styleFromInit.link],
-                                            onClick: _this2.resend
+                                            className: "primaryText successMessage",
+                                            css: [
+                                                styles.primaryText,
+                                                componentStyles.successMessage,
+                                                styles.successMessage
+                                            ]
                                         },
-                                        "Resend"
+                                        "You will receive a password recovery link at your email address in a few minutes.",
+                                        " ",
+                                        (0, _core.jsx)(
+                                            "span",
+                                            {
+                                                className: "link",
+                                                css: styles.link,
+                                                onClick: _this2.resend
+                                            },
+                                            "Resend"
+                                        )
+                                    )
+                                )
+                            );
+                        } // Otherwise, return Form.
+
+                        return (0, _core.jsx)(_FormBase["default"], {
+                            formFields: formFields,
+                            buttonLabel: "Email me",
+                            onSuccess: _this2.onSuccess,
+                            callAPI: callAPI,
+                            showLabels: false,
+                            header: (0, _core.jsx)(
+                                React.Fragment,
+                                null,
+                                (0, _core.jsx)(
+                                    "div",
+                                    {
+                                        className: "headerTitle",
+                                        css: [componentStyles.headerTitle, styles.headerTitle]
+                                    },
+                                    "Reset your password"
+                                ),
+                                (0, _core.jsx)(
+                                    "div",
+                                    {
+                                        className: "headerSubtitle",
+                                        css: [componentStyles.headerSubTitle, styles.headerSubtitle]
+                                    },
+                                    (0, _core.jsx)(
+                                        "div",
+                                        {
+                                            className: "secondaryText",
+                                            css: styles.secondaryText
+                                        },
+                                        "We will send you an email to reset your password"
                                     )
                                 )
                             )
-                        );
-                    } // Otherwise, return Form.
-
-                    return (0, _core.jsx)(_FormBase["default"], {
-                        formFields: formFields,
-                        styleFromInit: styleFromInit,
-                        buttonLabel: "Email me",
-                        onSuccess: _this2.onSuccess,
-                        callAPI: callAPI,
-                        showLabels: false,
-                        header: (0, _core.jsx)(
-                            React.Fragment,
-                            null,
-                            (0, _core.jsx)(
-                                "div",
-                                {
-                                    className: "headerTitle",
-                                    css: [styles.headerTitle, styleFromInit.headerTitle]
-                                },
-                                "Reset your password"
-                            ),
-                            (0, _core.jsx)(
-                                "div",
-                                {
-                                    className: "headerSubtitle",
-                                    css: [styles.headerSubTitle, styleFromInit.headerSubtitle]
-                                },
-                                (0, _core.jsx)(
-                                    "div",
-                                    {
-                                        className: "secondaryText",
-                                        css: [defaultStyles.secondaryText, styleFromInit.secondaryText]
-                                    },
-                                    "We will send you an email to reset your password"
-                                )
-                            )
-                        )
-                    });
-                });
+                        });
+                    })
+                );
             }
         }
     ]);

--- a/lib/build/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/enterEmail.js
+++ b/lib/build/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/enterEmail.js
@@ -11,6 +11,8 @@ var _core = require("@emotion/core");
 
 var _FormBase = _interopRequireDefault(require("../../../library/FormBase"));
 
+var _styleContext = require("../../../../styles/styleContext");
+
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
 }
@@ -297,92 +299,93 @@ var EnterEmailTheme = /*#__PURE__*/ (function(_PureComponent) {
              * Render.
              */
             value: function render() {
-                var _this$props = this.props,
-                    defaultStyles = _this$props.defaultStyles,
-                    palette = _this$props.palette,
-                    callAPI = _this$props.callAPI;
+                var _this2 = this;
+
+                var callAPI = this.props.callAPI;
                 var _this$state = this.state,
                     formFields = _this$state.formFields,
                     emailSent = _this$state.emailSent;
                 var styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
-                var styles = getStyles(palette); // If email sent, show success UI.
+                return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref) {
+                    var defaultStyles = _ref.defaultStyles,
+                        palette = _ref.palette;
+                    var styles = getStyles(palette); // If email sent, show success UI.
 
-                if (emailSent === true) {
-                    return (0, _core.jsx)(
-                        "div",
-                        {
-                            className: "container",
-                            css: [defaultStyles.container, styleFromInit.container]
-                        },
-                        (0, _core.jsx)(
+                    if (emailSent === true) {
+                        return (0, _core.jsx)(
                             "div",
                             {
-                                className: "row",
-                                css: [defaultStyles.row, styleFromInit.row]
+                                className: "container",
+                                css: [defaultStyles.container, styleFromInit.container]
                             },
                             (0, _core.jsx)(
                                 "div",
                                 {
-                                    className: "primaryText successMessage",
-                                    css: [
-                                        defaultStyles.primaryText,
-                                        styleFromInit.primaryText,
-                                        styles.successMessage,
-                                        styleFromInit.successMessage
-                                    ]
+                                    className: "row",
+                                    css: [defaultStyles.row, styleFromInit.row]
                                 },
-                                "You will receive a password recovery link at your email address in a few minutes.",
-                                " ",
                                 (0, _core.jsx)(
-                                    "span",
+                                    "div",
                                     {
-                                        className: "link",
-                                        css: [defaultStyles.link, styleFromInit.link],
-                                        onClick: this.resend
+                                        className: "primaryText successMessage",
+                                        css: [
+                                            defaultStyles.primaryText,
+                                            styleFromInit.primaryText,
+                                            styles.successMessage,
+                                            styleFromInit.successMessage
+                                        ]
                                     },
-                                    "Resend"
+                                    "You will receive a password recovery link at your email address in a few minutes.",
+                                    " ",
+                                    (0, _core.jsx)(
+                                        "span",
+                                        {
+                                            className: "link",
+                                            css: [defaultStyles.link, styleFromInit.link],
+                                            onClick: _this2.resend
+                                        },
+                                        "Resend"
+                                    )
+                                )
+                            )
+                        );
+                    } // Otherwise, return Form.
+
+                    return (0, _core.jsx)(_FormBase["default"], {
+                        formFields: formFields,
+                        styleFromInit: styleFromInit,
+                        buttonLabel: "Email me",
+                        onSuccess: _this2.onSuccess,
+                        callAPI: callAPI,
+                        showLabels: false,
+                        header: (0, _core.jsx)(
+                            React.Fragment,
+                            null,
+                            (0, _core.jsx)(
+                                "div",
+                                {
+                                    className: "headerTitle",
+                                    css: [styles.headerTitle, styleFromInit.headerTitle]
+                                },
+                                "Reset your password"
+                            ),
+                            (0, _core.jsx)(
+                                "div",
+                                {
+                                    className: "headerSubtitle",
+                                    css: [styles.headerSubTitle, styleFromInit.headerSubtitle]
+                                },
+                                (0, _core.jsx)(
+                                    "div",
+                                    {
+                                        className: "secondaryText",
+                                        css: [defaultStyles.secondaryText, styleFromInit.secondaryText]
+                                    },
+                                    "We will send you an email to reset your password"
                                 )
                             )
                         )
-                    );
-                } // Otherwise, return Form.
-
-                return (0, _core.jsx)(_FormBase["default"], {
-                    formFields: formFields,
-                    defaultStyles: defaultStyles,
-                    styleFromInit: styleFromInit,
-                    palette: palette,
-                    buttonLabel: "Email me",
-                    onSuccess: this.onSuccess,
-                    callAPI: callAPI,
-                    showLabels: false,
-                    header: (0, _core.jsx)(
-                        React.Fragment,
-                        null,
-                        (0, _core.jsx)(
-                            "div",
-                            {
-                                className: "headerTitle",
-                                css: [styles.headerTitle, styleFromInit.headerTitle]
-                            },
-                            "Reset your password"
-                        ),
-                        (0, _core.jsx)(
-                            "div",
-                            {
-                                className: "headerSubtitle",
-                                css: [styles.headerSubTitle, styleFromInit.headerSubtitle]
-                            },
-                            (0, _core.jsx)(
-                                "div",
-                                {
-                                    className: "secondaryText",
-                                    css: [defaultStyles.secondaryText, styleFromInit.secondaryText]
-                                },
-                                "We will send you an email to reset your password"
-                            )
-                        )
-                    )
+                    });
                 });
             }
         }

--- a/lib/build/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/submitNewPassword.js
+++ b/lib/build/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/submitNewPassword.js
@@ -299,104 +299,104 @@ var SubmitNewPasswordTheme = /*#__PURE__*/ (function(_PureComponent) {
                 var _this$state = this.state,
                     formFields = _this$state.formFields,
                     hasNewPassword = _this$state.hasNewPassword;
-                return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref) {
-                    var defaultStyles = _ref.defaultStyles,
-                        palette = _ref.palette;
-                    var styles = getStyles(palette);
+                return (0, _core.jsx)(
+                    _styleContext.StyleProvider,
+                    {
+                        styleFromInit: styleFromInit
+                    },
+                    (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
+                        var componentStyles = getStyles(styles.palette);
 
-                    if (hasNewPassword === true) {
-                        return (0, _core.jsx)(
-                            "div",
-                            {
-                                className: "container",
-                                css: [defaultStyles.container, styleFromInit.container]
-                            },
-                            (0, _core.jsx)(
+                        if (hasNewPassword === true) {
+                            return (0, _core.jsx)(
                                 "div",
                                 {
-                                    className: "row",
-                                    css: [defaultStyles.row, styleFromInit.row]
+                                    className: "container",
+                                    css: styles.container
                                 },
+                                (0, _core.jsx)(
+                                    "div",
+                                    {
+                                        className: "row",
+                                        css: styles.row
+                                    },
+                                    (0, _core.jsx)(
+                                        "div",
+                                        {
+                                            className: "headerTitle",
+                                            css: [styles.headerTitle, styleFromInit.headerTitle]
+                                        },
+                                        "Success!"
+                                    ),
+                                    (0, _core.jsx)(
+                                        _library.FormRow,
+                                        {
+                                            key: "form-button"
+                                        },
+                                        (0, _core.jsx)(
+                                            React.Fragment,
+                                            null,
+                                            (0, _core.jsx)(
+                                                "div",
+                                                {
+                                                    className: "primaryText successMessage",
+                                                    css: [
+                                                        styles.primaryText,
+                                                        componentStyles.successMessage,
+                                                        styles.successMessage
+                                                    ]
+                                                },
+                                                "Your password has been updated successfully"
+                                            ),
+                                            (0, _core.jsx)(_library.Button, {
+                                                disabled: false,
+                                                isLoading: false,
+                                                type: "button",
+                                                onClick: onSignInClicked,
+                                                label: "SIGN IN"
+                                            })
+                                        )
+                                    )
+                                )
+                            );
+                        }
+
+                        return (0, _core.jsx)(_FormBase["default"], {
+                            formFields: formFields,
+                            buttonLabel: "Change password",
+                            onSuccess: _this2.onSuccess,
+                            callAPI: callAPI,
+                            showLabels: false,
+                            header: (0, _core.jsx)(
+                                React.Fragment,
+                                null,
                                 (0, _core.jsx)(
                                     "div",
                                     {
                                         className: "headerTitle",
-                                        css: [styles.headerTitle, styleFromInit.headerTitle]
+                                        css: [componentStyles.headerTitle, styles.headerTitle]
                                     },
-                                    "Success!"
+                                    "Change your password"
                                 ),
-                                (0, _core.jsx)(
-                                    _library.FormRow,
-                                    {
-                                        style: styleFromInit.formRow,
-                                        key: "form-button"
-                                    },
-                                    (0, _core.jsx)(
-                                        React.Fragment,
-                                        null,
-                                        (0, _core.jsx)(
-                                            "div",
-                                            {
-                                                className: "primaryText successMessage",
-                                                css: [
-                                                    defaultStyles.primaryText,
-                                                    styleFromInit.primaryText,
-                                                    styles.successMessage,
-                                                    styleFromInit.successMessage
-                                                ]
-                                            },
-                                            "Your password has been updated successfully"
-                                        ),
-                                        (0, _core.jsx)(_library.Button, {
-                                            style: styleFromInit.button,
-                                            disabled: false,
-                                            isLoading: false,
-                                            type: "button",
-                                            onClick: onSignInClicked,
-                                            label: "SIGN IN"
-                                        })
-                                    )
-                                )
-                            )
-                        );
-                    }
-
-                    return (0, _core.jsx)(_FormBase["default"], {
-                        formFields: formFields,
-                        styleFromInit: styleFromInit,
-                        buttonLabel: "Change password",
-                        onSuccess: _this2.onSuccess,
-                        callAPI: callAPI,
-                        showLabels: false,
-                        header: (0, _core.jsx)(
-                            React.Fragment,
-                            null,
-                            (0, _core.jsx)(
-                                "div",
-                                {
-                                    className: "headerTitle",
-                                    css: [styles.headerTitle, styleFromInit.headerTitle]
-                                },
-                                "Change your password"
-                            ),
-                            (0, _core.jsx)(
-                                "div",
-                                {
-                                    className: "headerSubtitle",
-                                    css: [styles.headerSubTitle, styleFromInit.headerSubtitle]
-                                },
                                 (0, _core.jsx)(
                                     "div",
                                     {
-                                        className: "secondaryText",
-                                        css: [defaultStyles.secondaryText, styleFromInit.secondaryText]
+                                        className: "headerSubtitle",
+                                        css: styles.headerSubTitle
                                     },
-                                    "Enter a new password below to change your password"
+                                    (0, _core.jsx)(
+                                        "div",
+                                        {
+                                            className: "secondaryText",
+                                            css: styles.secondaryText
+                                        },
+                                        "Enter a new password below to change your password"
+                                    )
                                 )
                             )
-                        )
-                    });
-                });
+                        });
+                    })
+                );
             }
         }
     ]);

--- a/lib/build/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/submitNewPassword.js
+++ b/lib/build/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/submitNewPassword.js
@@ -13,6 +13,8 @@ var _FormBase = _interopRequireDefault(require("../../../library/FormBase"));
 
 var _library = require("../../../library");
 
+var _styleContext = require("../../../../styles/styleContext");
+
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
 }
@@ -288,112 +290,112 @@ var SubmitNewPasswordTheme = /*#__PURE__*/ (function(_PureComponent) {
              * Render.
              */
             value: function render() {
+                var _this2 = this;
+
                 var _this$props = this.props,
-                    defaultStyles = _this$props.defaultStyles,
-                    palette = _this$props.palette,
                     callAPI = _this$props.callAPI,
                     onSignInClicked = _this$props.onSignInClicked;
                 var styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
                 var _this$state = this.state,
                     formFields = _this$state.formFields,
                     hasNewPassword = _this$state.hasNewPassword;
-                var styles = getStyles(palette);
+                return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref) {
+                    var defaultStyles = _ref.defaultStyles,
+                        palette = _ref.palette;
+                    var styles = getStyles(palette);
 
-                if (hasNewPassword === true) {
-                    return (0, _core.jsx)(
-                        "div",
-                        {
-                            className: "container",
-                            css: [defaultStyles.container, styleFromInit.container]
-                        },
-                        (0, _core.jsx)(
+                    if (hasNewPassword === true) {
+                        return (0, _core.jsx)(
                             "div",
                             {
-                                className: "row",
-                                css: [defaultStyles.row, styleFromInit.row]
+                                className: "container",
+                                css: [defaultStyles.container, styleFromInit.container]
                             },
+                            (0, _core.jsx)(
+                                "div",
+                                {
+                                    className: "row",
+                                    css: [defaultStyles.row, styleFromInit.row]
+                                },
+                                (0, _core.jsx)(
+                                    "div",
+                                    {
+                                        className: "headerTitle",
+                                        css: [styles.headerTitle, styleFromInit.headerTitle]
+                                    },
+                                    "Success!"
+                                ),
+                                (0, _core.jsx)(
+                                    _library.FormRow,
+                                    {
+                                        style: styleFromInit.formRow,
+                                        key: "form-button"
+                                    },
+                                    (0, _core.jsx)(
+                                        React.Fragment,
+                                        null,
+                                        (0, _core.jsx)(
+                                            "div",
+                                            {
+                                                className: "primaryText successMessage",
+                                                css: [
+                                                    defaultStyles.primaryText,
+                                                    styleFromInit.primaryText,
+                                                    styles.successMessage,
+                                                    styleFromInit.successMessage
+                                                ]
+                                            },
+                                            "Your password has been updated successfully"
+                                        ),
+                                        (0, _core.jsx)(_library.Button, {
+                                            style: styleFromInit.button,
+                                            disabled: false,
+                                            isLoading: false,
+                                            type: "button",
+                                            onClick: onSignInClicked,
+                                            label: "SIGN IN"
+                                        })
+                                    )
+                                )
+                            )
+                        );
+                    }
+
+                    return (0, _core.jsx)(_FormBase["default"], {
+                        formFields: formFields,
+                        styleFromInit: styleFromInit,
+                        buttonLabel: "Change password",
+                        onSuccess: _this2.onSuccess,
+                        callAPI: callAPI,
+                        showLabels: false,
+                        header: (0, _core.jsx)(
+                            React.Fragment,
+                            null,
                             (0, _core.jsx)(
                                 "div",
                                 {
                                     className: "headerTitle",
                                     css: [styles.headerTitle, styleFromInit.headerTitle]
                                 },
-                                "Success!"
+                                "Change your password"
                             ),
-                            (0, _core.jsx)(
-                                _library.FormRow,
-                                {
-                                    style: styleFromInit.formRow,
-                                    key: "form-button",
-                                    defaultStyles: defaultStyles
-                                },
-                                (0, _core.jsx)(
-                                    React.Fragment,
-                                    null,
-                                    (0, _core.jsx)(
-                                        "div",
-                                        {
-                                            className: "primaryText successMessage",
-                                            css: [
-                                                defaultStyles.primaryText,
-                                                styleFromInit.primaryText,
-                                                styles.successMessage,
-                                                styleFromInit.successMessage
-                                            ]
-                                        },
-                                        "Your password has been updated successfully"
-                                    ),
-                                    (0, _core.jsx)(_library.Button, {
-                                        defaultStyles: defaultStyles,
-                                        style: styleFromInit.button,
-                                        disabled: false,
-                                        isLoading: false,
-                                        type: "button",
-                                        onClick: onSignInClicked,
-                                        label: "SIGN IN"
-                                    })
-                                )
-                            )
-                        )
-                    );
-                }
-
-                return (0, _core.jsx)(_FormBase["default"], {
-                    formFields: formFields,
-                    defaultStyles: defaultStyles,
-                    styleFromInit: styleFromInit,
-                    palette: palette,
-                    buttonLabel: "Change password",
-                    onSuccess: this.onSuccess,
-                    callAPI: callAPI,
-                    showLabels: false,
-                    header: (0, _core.jsx)(
-                        React.Fragment,
-                        null,
-                        (0, _core.jsx)(
-                            "div",
-                            {
-                                className: "headerTitle",
-                                css: [styles.headerTitle, styleFromInit.headerTitle]
-                            },
-                            "Change your password"
-                        ),
-                        (0, _core.jsx)(
-                            "div",
-                            {
-                                className: "headerSubtitle",
-                                css: [styles.headerSubTitle, styleFromInit.headerSubtitle]
-                            },
                             (0, _core.jsx)(
                                 "div",
                                 {
-                                    className: "secondaryText",
-                                    css: [defaultStyles.secondaryText, styleFromInit.secondaryText]
+                                    className: "headerSubtitle",
+                                    css: [styles.headerSubTitle, styleFromInit.headerSubtitle]
                                 },
-                                "Enter a new password below to change your password"
+                                (0, _core.jsx)(
+                                    "div",
+                                    {
+                                        className: "secondaryText",
+                                        css: [defaultStyles.secondaryText, styleFromInit.secondaryText]
+                                    },
+                                    "Enter a new password below to change your password"
+                                )
                             )
                         )
-                    )
+                    });
                 });
             }
         }

--- a/lib/build/recipe/emailpassword/components/signInAndUp/SignInAndUp.js
+++ b/lib/build/recipe/emailpassword/components/signInAndUp/SignInAndUp.js
@@ -19,8 +19,6 @@ var _featureWrapper = _interopRequireDefault(require("../../../components/featur
 
 var _core = require("@emotion/core");
 
-var _styles = require("../../styles/styles");
-
 var _utils = require("../../../../utils");
 
 var _superTokens = _interopRequireDefault(require("../../../../superTokens"));
@@ -28,6 +26,8 @@ var _superTokens = _interopRequireDefault(require("../../../../superTokens"));
 var _api = require("./api");
 
 var _constants2 = require("../../../../constants");
+
+var _styleContext = require("../../styles/styleContext");
 
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
@@ -661,19 +661,13 @@ var SignInAndUp = /*#__PURE__*/ (function(_PureComponent) {
 
             var signInFeature = _this.getRecipeInstanceOrThrow().getConfig().signInAndUpFeature.signInForm;
 
-            var defaultStyles = (0, _styles.getDefaultStyles)(_this.getRecipeInstanceOrThrow().getConfig().palette);
-
-            var palette = _this.getRecipeInstanceOrThrow().getConfig().palette;
-
             var signInForm = {
                 styleFromInit: signInFeature.style,
                 formFields: signInFeature.formFields,
                 resetPasswordURL: signInFeature.resetPasswordURL,
                 callAPI: _this.signIn,
                 onSuccess: _this.onSignInSuccess,
-                forgotPasswordClick: _this.onHandleForgotPasswordClicked,
-                defaultStyles: defaultStyles,
-                palette: palette
+                forgotPasswordClick: _this.onHandleForgotPasswordClicked
             };
             var signUpForm = {
                 styleFromInit: signUpFeature.style,
@@ -681,9 +675,7 @@ var SignInAndUp = /*#__PURE__*/ (function(_PureComponent) {
                 privacyPolicyLink: signUpFeature.privacyPolicyLink,
                 termsAndConditionsLink: signUpFeature.termsAndConditionsLink,
                 onSuccess: _this.onSignUpSuccess,
-                callAPI: _this.signUp,
-                defaultStyles: defaultStyles,
-                palette: palette
+                callAPI: _this.signUp
             };
 
             var useShadowDom = _this.getRecipeInstanceOrThrow().getConfig().useShadowDom; // Before session is verified, return empty fragment, prevent UI glitch.
@@ -696,24 +688,27 @@ var SignInAndUp = /*#__PURE__*/ (function(_PureComponent) {
              */
 
             return (0, _core.jsx)(
-                _featureWrapper["default"],
-                {
-                    useShadowDom: useShadowDom,
-                    defaultStyles: defaultStyles
-                },
+                _styleContext.StyleProvider,
+                null,
                 (0, _core.jsx)(
-                    React.Fragment,
-                    null,
-                    _this.props.children === undefined &&
-                        (0, _core.jsx)(_.SignInAndUpTheme, {
-                            signInForm: signInForm,
-                            signUpForm: signUpForm
-                        }),
-                    _this.props.children &&
-                        /*#__PURE__*/ React.cloneElement(_this.props.children, {
-                            signInForm: signInForm,
-                            signUpForm: signUpForm
-                        })
+                    _featureWrapper["default"],
+                    {
+                        useShadowDom: useShadowDom
+                    },
+                    (0, _core.jsx)(
+                        React.Fragment,
+                        null,
+                        _this.props.children === undefined &&
+                            (0, _core.jsx)(_.SignInAndUpTheme, {
+                                signInForm: signInForm,
+                                signUpForm: signUpForm
+                            }),
+                        _this.props.children &&
+                            /*#__PURE__*/ React.cloneElement(_this.props.children, {
+                                signInForm: signInForm,
+                                signUpForm: signUpForm
+                            })
+                    )
                 )
             );
         };

--- a/lib/build/recipe/emailpassword/components/signInAndUp/themes/default/SignIn.js
+++ b/lib/build/recipe/emailpassword/components/signInAndUp/themes/default/SignIn.js
@@ -11,6 +11,8 @@ var _core = require("@emotion/core");
 
 var _FormBase = _interopRequireDefault(require("../../../library/FormBase"));
 
+var _styleContext = require("../../../../styles/styleContext");
+
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
 }
@@ -267,78 +269,78 @@ var SignInTheme = /*#__PURE__*/ (function(_PureComponent) {
                 var _this$props = this.props,
                     signUpClicked = _this$props.signUpClicked,
                     forgotPasswordClick = _this$props.forgotPasswordClick,
-                    defaultStyles = _this$props.defaultStyles,
-                    palette = _this$props.palette,
                     onSuccess = _this$props.onSuccess,
                     callAPI = _this$props.callAPI;
                 var styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
                 var formFields = this.state.formFields;
-                var styles = getStyles(palette);
-                return (0, _core.jsx)(_FormBase["default"], {
-                    formFields: formFields,
-                    defaultStyles: defaultStyles,
-                    styleFromInit: styleFromInit,
-                    palette: palette,
-                    buttonLabel: "SIGN IN",
-                    onSuccess: onSuccess,
-                    callAPI: callAPI,
-                    showLabels: true,
-                    header: (0, _core.jsx)(
-                        React.Fragment,
-                        null,
-                        (0, _core.jsx)(
-                            "div",
-                            {
-                                className: "headerTitle",
-                                css: [styles.headerTitle, styleFromInit.headerTitle]
-                            },
-                            "Sign In"
-                        ),
-                        (0, _core.jsx)(
-                            "div",
-                            {
-                                className: "headerSubtitle",
-                                css: [styles.headerSubTitle, styleFromInit.headerSubtitle]
-                            },
+                return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref) {
+                    var palette = _ref.palette,
+                        defaultStyles = _ref.defaultStyles;
+                    var styles = getStyles(palette);
+                    return (0, _core.jsx)(_FormBase["default"], {
+                        formFields: formFields,
+                        styleFromInit: styleFromInit,
+                        buttonLabel: "SIGN IN",
+                        onSuccess: onSuccess,
+                        callAPI: callAPI,
+                        showLabels: true,
+                        header: (0, _core.jsx)(
+                            React.Fragment,
+                            null,
                             (0, _core.jsx)(
                                 "div",
                                 {
-                                    className: "secondaryText",
-                                    css: [defaultStyles.secondaryText, styleFromInit.secondaryText]
+                                    className: "headerTitle",
+                                    css: [styles.headerTitle, styleFromInit.headerTitle]
                                 },
-                                "Not registered yet?",
+                                "Sign In"
+                            ),
+                            (0, _core.jsx)(
+                                "div",
+                                {
+                                    className: "headerSubtitle",
+                                    css: [styles.headerSubTitle, styleFromInit.headerSubtitle]
+                                },
                                 (0, _core.jsx)(
-                                    "span",
+                                    "div",
                                     {
-                                        className: "link",
-                                        onClick: signUpClicked,
-                                        css: [defaultStyles.link, styleFromInit.link]
+                                        className: "secondaryText",
+                                        css: [defaultStyles.secondaryText, styleFromInit.secondaryText]
                                     },
-                                    "Sign Up"
+                                    "Not registered yet?",
+                                    (0, _core.jsx)(
+                                        "span",
+                                        {
+                                            className: "link",
+                                            onClick: signUpClicked,
+                                            css: [defaultStyles.link, styleFromInit.link]
+                                        },
+                                        "Sign Up"
+                                    )
                                 )
-                            )
+                            ),
+                            (0, _core.jsx)("div", {
+                                className: "divider",
+                                css: [defaultStyles.divider, styleFromInit.divider]
+                            })
                         ),
-                        (0, _core.jsx)("div", {
-                            className: "divider",
-                            css: [defaultStyles.divider, styleFromInit.divider]
-                        })
-                    ),
-                    footer: (0, _core.jsx)(
-                        "div",
-                        {
-                            className: "link secondaryText forgotPasswordLink",
-                            css: [
-                                defaultStyles.link,
-                                defaultStyles.secondaryText,
-                                styles.forgotPasswordLink,
-                                styleFromInit.link,
-                                styleFromInit.secondaryText,
-                                styleFromInit.forgotPasswordLink
-                            ],
-                            onClick: forgotPasswordClick
-                        },
-                        "Forgot password?"
-                    )
+                        footer: (0, _core.jsx)(
+                            "div",
+                            {
+                                className: "link secondaryText forgotPasswordLink",
+                                css: [
+                                    defaultStyles.link,
+                                    defaultStyles.secondaryText,
+                                    styles.forgotPasswordLink,
+                                    styleFromInit.link,
+                                    styleFromInit.secondaryText,
+                                    styleFromInit.forgotPasswordLink
+                                ],
+                                onClick: forgotPasswordClick
+                            },
+                            "Forgot password?"
+                        )
+                    });
                 });
             }
         }

--- a/lib/build/recipe/emailpassword/components/signInAndUp/themes/default/SignIn.js
+++ b/lib/build/recipe/emailpassword/components/signInAndUp/themes/default/SignIn.js
@@ -269,79 +269,80 @@ var SignInTheme = /*#__PURE__*/ (function(_PureComponent) {
                 var _this$props = this.props,
                     signUpClicked = _this$props.signUpClicked,
                     forgotPasswordClick = _this$props.forgotPasswordClick,
+                    styleFromInit = _this$props.styleFromInit,
                     onSuccess = _this$props.onSuccess,
                     callAPI = _this$props.callAPI;
-                var styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
                 var formFields = this.state.formFields;
-                return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref) {
-                    var palette = _ref.palette,
-                        defaultStyles = _ref.defaultStyles;
-                    var styles = getStyles(palette);
-                    return (0, _core.jsx)(_FormBase["default"], {
-                        formFields: formFields,
-                        styleFromInit: styleFromInit,
-                        buttonLabel: "SIGN IN",
-                        onSuccess: onSuccess,
-                        callAPI: callAPI,
-                        showLabels: true,
-                        header: (0, _core.jsx)(
-                            React.Fragment,
-                            null,
-                            (0, _core.jsx)(
-                                "div",
-                                {
-                                    className: "headerTitle",
-                                    css: [styles.headerTitle, styleFromInit.headerTitle]
-                                },
-                                "Sign In"
-                            ),
-                            (0, _core.jsx)(
-                                "div",
-                                {
-                                    className: "headerSubtitle",
-                                    css: [styles.headerSubTitle, styleFromInit.headerSubtitle]
-                                },
+                return (0, _core.jsx)(
+                    _styleContext.StyleProvider,
+                    {
+                        styleFromInit: styleFromInit
+                    },
+                    (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
+                        var componentStyle = getStyles(styles.palette);
+                        return (0, _core.jsx)(_FormBase["default"], {
+                            formFields: formFields,
+                            buttonLabel: "SIGN IN",
+                            onSuccess: onSuccess,
+                            callAPI: callAPI,
+                            showLabels: true,
+                            header: (0, _core.jsx)(
+                                React.Fragment,
+                                null,
                                 (0, _core.jsx)(
                                     "div",
                                     {
-                                        className: "secondaryText",
-                                        css: [defaultStyles.secondaryText, styleFromInit.secondaryText]
+                                        className: "headerTitle",
+                                        css: [componentStyle.headerTitle, styles.headerTitle]
                                     },
-                                    "Not registered yet?",
+                                    "Sign In"
+                                ),
+                                (0, _core.jsx)(
+                                    "div",
+                                    {
+                                        className: "headerSubtitle",
+                                        css: [componentStyle.headerSubTitle, styles.headerSubtitle]
+                                    },
                                     (0, _core.jsx)(
-                                        "span",
+                                        "div",
                                         {
-                                            className: "link",
-                                            onClick: signUpClicked,
-                                            css: [defaultStyles.link, styleFromInit.link]
+                                            className: "secondaryText",
+                                            css: styles.secondaryText
                                         },
-                                        "Sign Up"
+                                        "Not registered yet?",
+                                        (0, _core.jsx)(
+                                            "span",
+                                            {
+                                                className: "link",
+                                                onClick: signUpClicked,
+                                                css: styles.link
+                                            },
+                                            "Sign Up"
+                                        )
                                     )
-                                )
+                                ),
+                                (0, _core.jsx)("div", {
+                                    className: "divider",
+                                    css: styles.divider
+                                })
                             ),
-                            (0, _core.jsx)("div", {
-                                className: "divider",
-                                css: [defaultStyles.divider, styleFromInit.divider]
-                            })
-                        ),
-                        footer: (0, _core.jsx)(
-                            "div",
-                            {
-                                className: "link secondaryText forgotPasswordLink",
-                                css: [
-                                    defaultStyles.link,
-                                    defaultStyles.secondaryText,
-                                    styles.forgotPasswordLink,
-                                    styleFromInit.link,
-                                    styleFromInit.secondaryText,
-                                    styleFromInit.forgotPasswordLink
-                                ],
-                                onClick: forgotPasswordClick
-                            },
-                            "Forgot password?"
-                        )
-                    });
-                });
+                            footer: (0, _core.jsx)(
+                                "div",
+                                {
+                                    className: "link secondaryText forgotPasswordLink",
+                                    css: [
+                                        styles.link,
+                                        styles.secondaryText,
+                                        componentStyle.forgotPasswordLink,
+                                        styles.forgotPasswordLink
+                                    ],
+                                    onClick: forgotPasswordClick
+                                },
+                                "Forgot password?"
+                            )
+                        });
+                    })
+                );
             }
         }
     ]);

--- a/lib/build/recipe/emailpassword/components/signInAndUp/themes/default/SignUp.js
+++ b/lib/build/recipe/emailpassword/components/signInAndUp/themes/default/SignUp.js
@@ -13,6 +13,8 @@ var _utils = require("../../../../../../utils");
 
 var _FormBase = _interopRequireDefault(require("../../../library/FormBase"));
 
+var _styleContext = require("../../../../styles/styleContext");
+
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
 }
@@ -279,98 +281,98 @@ var SignUpTheme = /*#__PURE__*/ (function(_PureComponent) {
                     privacyPolicyLink = _this$props.privacyPolicyLink,
                     termsAndConditionsLink = _this$props.termsAndConditionsLink,
                     signInClicked = _this$props.signInClicked,
-                    defaultStyles = _this$props.defaultStyles,
-                    palette = _this$props.palette,
                     onSuccess = _this$props.onSuccess,
                     callAPI = _this$props.callAPI;
                 var formFields = this.state.formFields;
                 var styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
-                var styles = getStyles(palette);
-                return (0, _core.jsx)(_FormBase["default"], {
-                    formFields: formFields,
-                    defaultStyles: defaultStyles,
-                    styleFromInit: styleFromInit,
-                    palette: palette,
-                    buttonLabel: "SIGN UP",
-                    onSuccess: onSuccess,
-                    callAPI: callAPI,
-                    showLabels: true,
-                    header: (0, _core.jsx)(
-                        React.Fragment,
-                        null,
-                        (0, _core.jsx)(
-                            "div",
-                            {
-                                className: "headerTitle",
-                                css: [styles.headerTitle, styleFromInit.headerTitle]
-                            },
-                            "Sign Up"
-                        ),
-                        (0, _core.jsx)(
-                            "div",
-                            {
-                                className: "headerSubtitle",
-                                css: [styles.headerSubTitle, styleFromInit.headerSubtitle]
-                            },
+                return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref) {
+                    var defaultStyles = _ref.defaultStyles,
+                        palette = _ref.palette;
+                    var styles = getStyles(palette);
+                    return (0, _core.jsx)(_FormBase["default"], {
+                        formFields: formFields,
+                        styleFromInit: styleFromInit,
+                        buttonLabel: "SIGN UP",
+                        onSuccess: onSuccess,
+                        callAPI: callAPI,
+                        showLabels: true,
+                        header: (0, _core.jsx)(
+                            React.Fragment,
+                            null,
                             (0, _core.jsx)(
                                 "div",
                                 {
-                                    className: "secondaryText",
-                                    css: [defaultStyles.secondaryText, styleFromInit.secondaryText]
+                                    className: "headerTitle",
+                                    css: [styles.headerTitle, styleFromInit.headerTitle]
                                 },
-                                "Already have an account?",
+                                "Sign Up"
+                            ),
+                            (0, _core.jsx)(
+                                "div",
+                                {
+                                    className: "headerSubtitle",
+                                    css: [styles.headerSubTitle, styleFromInit.headerSubtitle]
+                                },
                                 (0, _core.jsx)(
-                                    "span",
+                                    "div",
                                     {
-                                        className: "link",
-                                        onClick: signInClicked,
-                                        css: [defaultStyles.link, styleFromInit.link]
+                                        className: "secondaryText",
+                                        css: [defaultStyles.secondaryText, styleFromInit.secondaryText]
                                     },
-                                    "Sign In"
+                                    "Already have an account?",
+                                    (0, _core.jsx)(
+                                        "span",
+                                        {
+                                            className: "link",
+                                            onClick: signInClicked,
+                                            css: [defaultStyles.link, styleFromInit.link]
+                                        },
+                                        "Sign In"
+                                    )
                                 )
+                            ),
+                            (0, _core.jsx)("div", {
+                                className: "divider",
+                                css: [defaultStyles.divider, styleFromInit.divider]
+                            })
+                        ),
+                        footer: (0, _core.jsx)(
+                            "div",
+                            {
+                                className: "privacyPolicyAndTermsAndConditions secondaryText",
+                                css: [
+                                    defaultStyles.secondaryText,
+                                    styles.privacyPolicyAndTermsAndConditions,
+                                    styleFromInit.secondaryText,
+                                    styleFromInit.privacyPolicyAndTermsAndConditions
+                                ]
+                            },
+                            "By signin up, you agree to our",
+                            (0, _core.jsx)(
+                                "span",
+                                {
+                                    className: "link",
+                                    css: [defaultStyles.link, styleFromInit.link],
+                                    onClick: function onClick() {
+                                        return (0, _utils.openExternalLink)(termsAndConditionsLink);
+                                    }
+                                },
+                                "Terms of Service"
+                            ),
+                            "and",
+                            (0, _core.jsx)(
+                                "span",
+                                {
+                                    className: "link",
+                                    css: [defaultStyles.link, styleFromInit.link],
+                                    onClick: function onClick() {
+                                        return (0, _utils.openExternalLink)(privacyPolicyLink);
+                                    }
+                                },
+                                "Privacy Policy"
                             )
-                        ),
-                        (0, _core.jsx)("div", {
-                            className: "divider",
-                            css: [defaultStyles.divider, styleFromInit.divider]
-                        })
-                    ),
-                    footer: (0, _core.jsx)(
-                        "div",
-                        {
-                            className: "privacyPolicyAndTermsAndConditions secondaryText",
-                            css: [
-                                defaultStyles.secondaryText,
-                                styles.privacyPolicyAndTermsAndConditions,
-                                styleFromInit.secondaryText,
-                                styleFromInit.privacyPolicyAndTermsAndConditions
-                            ]
-                        },
-                        "By signin up, you agree to our",
-                        (0, _core.jsx)(
-                            "span",
-                            {
-                                className: "link",
-                                css: [defaultStyles.link, styleFromInit.link],
-                                onClick: function onClick() {
-                                    return (0, _utils.openExternalLink)(termsAndConditionsLink);
-                                }
-                            },
-                            "Terms of Service"
-                        ),
-                        "and",
-                        (0, _core.jsx)(
-                            "span",
-                            {
-                                className: "link",
-                                css: [defaultStyles.link, styleFromInit.link],
-                                onClick: function onClick() {
-                                    return (0, _utils.openExternalLink)(privacyPolicyLink);
-                                }
-                            },
-                            "Privacy Policy"
                         )
-                    )
+                    });
                 });
             }
         }

--- a/lib/build/recipe/emailpassword/components/signInAndUp/themes/default/SignUp.js
+++ b/lib/build/recipe/emailpassword/components/signInAndUp/themes/default/SignUp.js
@@ -280,100 +280,103 @@ var SignUpTheme = /*#__PURE__*/ (function(_PureComponent) {
                 var _this$props = this.props,
                     privacyPolicyLink = _this$props.privacyPolicyLink,
                     termsAndConditionsLink = _this$props.termsAndConditionsLink,
+                    styleFromInit = _this$props.styleFromInit,
                     signInClicked = _this$props.signInClicked,
                     onSuccess = _this$props.onSuccess,
                     callAPI = _this$props.callAPI;
                 var formFields = this.state.formFields;
-                var styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
-                return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(_ref) {
-                    var defaultStyles = _ref.defaultStyles,
-                        palette = _ref.palette;
-                    var styles = getStyles(palette);
-                    return (0, _core.jsx)(_FormBase["default"], {
-                        formFields: formFields,
-                        styleFromInit: styleFromInit,
-                        buttonLabel: "SIGN UP",
-                        onSuccess: onSuccess,
-                        callAPI: callAPI,
-                        showLabels: true,
-                        header: (0, _core.jsx)(
-                            React.Fragment,
-                            null,
-                            (0, _core.jsx)(
-                                "div",
-                                {
-                                    className: "headerTitle",
-                                    css: [styles.headerTitle, styleFromInit.headerTitle]
-                                },
-                                "Sign Up"
-                            ),
-                            (0, _core.jsx)(
-                                "div",
-                                {
-                                    className: "headerSubtitle",
-                                    css: [styles.headerSubTitle, styleFromInit.headerSubtitle]
-                                },
+                console.log(styleFromInit);
+                return (0, _core.jsx)(
+                    _styleContext.StyleProvider,
+                    {
+                        styleFromInit: styleFromInit
+                    },
+                    (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
+                        var componentStyles = getStyles(styles.palette);
+                        return (0, _core.jsx)(_FormBase["default"], {
+                            formFields: formFields,
+                            buttonLabel: "SIGN UP",
+                            onSuccess: onSuccess,
+                            callAPI: callAPI,
+                            showLabels: true,
+                            header: (0, _core.jsx)(
+                                React.Fragment,
+                                null,
                                 (0, _core.jsx)(
                                     "div",
                                     {
-                                        className: "secondaryText",
-                                        css: [defaultStyles.secondaryText, styleFromInit.secondaryText]
+                                        className: "headerTitle",
+                                        css: [componentStyles.headerTitle, styles.headerTitle]
                                     },
-                                    "Already have an account?",
+                                    "Sign Up"
+                                ),
+                                (0, _core.jsx)(
+                                    "div",
+                                    {
+                                        className: "headerSubtitle",
+                                        css: [componentStyles.headerSubTitle, styles.headerSubtitle]
+                                    },
                                     (0, _core.jsx)(
-                                        "span",
+                                        "div",
                                         {
-                                            className: "link",
-                                            onClick: signInClicked,
-                                            css: [defaultStyles.link, styleFromInit.link]
+                                            className: "secondaryText",
+                                            css: styles.secondaryText
                                         },
-                                        "Sign In"
+                                        "Already have an account?",
+                                        (0, _core.jsx)(
+                                            "span",
+                                            {
+                                                className: "link",
+                                                onClick: signInClicked,
+                                                css: styles.link
+                                            },
+                                            "Sign In"
+                                        )
                                     )
+                                ),
+                                (0, _core.jsx)("div", {
+                                    className: "divider",
+                                    css: styles.divider
+                                })
+                            ),
+                            footer: (0, _core.jsx)(
+                                "div",
+                                {
+                                    className: "secondaryText privacyPolicyAndTermsAndConditions",
+                                    css: [
+                                        componentStyles.privacyPolicyAndTermsAndConditions,
+                                        styles.secondaryText,
+                                        styles.privacyPolicyAndTermsAndConditions
+                                    ]
+                                },
+                                "By signin up, you agree to our",
+                                (0, _core.jsx)(
+                                    "span",
+                                    {
+                                        className: "link",
+                                        css: styles.link,
+                                        onClick: function onClick() {
+                                            return (0, _utils.openExternalLink)(termsAndConditionsLink);
+                                        }
+                                    },
+                                    "Terms of Service"
+                                ),
+                                "and",
+                                (0, _core.jsx)(
+                                    "span",
+                                    {
+                                        className: "link",
+                                        css: styles.link,
+                                        onClick: function onClick() {
+                                            return (0, _utils.openExternalLink)(privacyPolicyLink);
+                                        }
+                                    },
+                                    "Privacy Policy"
                                 )
-                            ),
-                            (0, _core.jsx)("div", {
-                                className: "divider",
-                                css: [defaultStyles.divider, styleFromInit.divider]
-                            })
-                        ),
-                        footer: (0, _core.jsx)(
-                            "div",
-                            {
-                                className: "privacyPolicyAndTermsAndConditions secondaryText",
-                                css: [
-                                    defaultStyles.secondaryText,
-                                    styles.privacyPolicyAndTermsAndConditions,
-                                    styleFromInit.secondaryText,
-                                    styleFromInit.privacyPolicyAndTermsAndConditions
-                                ]
-                            },
-                            "By signin up, you agree to our",
-                            (0, _core.jsx)(
-                                "span",
-                                {
-                                    className: "link",
-                                    css: [defaultStyles.link, styleFromInit.link],
-                                    onClick: function onClick() {
-                                        return (0, _utils.openExternalLink)(termsAndConditionsLink);
-                                    }
-                                },
-                                "Terms of Service"
-                            ),
-                            "and",
-                            (0, _core.jsx)(
-                                "span",
-                                {
-                                    className: "link",
-                                    css: [defaultStyles.link, styleFromInit.link],
-                                    onClick: function onClick() {
-                                        return (0, _utils.openExternalLink)(privacyPolicyLink);
-                                    }
-                                },
-                                "Privacy Policy"
                             )
-                        )
-                    });
-                });
+                        });
+                    })
+                );
             }
         }
     ]);

--- a/lib/build/recipe/emailpassword/styles/styleContext.d.ts
+++ b/lib/build/recipe/emailpassword/styles/styleContext.d.ts
@@ -1,0 +1,8 @@
+import React from "react";
+export declare function StyleProvider({ children }: {
+    children: JSX.Element;
+}): JSX.Element;
+export declare const StyleConsumer: React.ExoticComponent<React.ConsumerProps<{
+    palette: import("../types").NormalisedPalette;
+    defaultStyles: import("../types").NormalisedDefaultStyles;
+}>>;

--- a/lib/build/recipe/emailpassword/styles/styleContext.d.ts
+++ b/lib/build/recipe/emailpassword/styles/styleContext.d.ts
@@ -1,8 +1,14 @@
+import { CSSObject } from "@emotion/core";
 import React from "react";
-export declare function StyleProvider({ children }: {
+import { Styles } from "../../../types";
+import { NormalisedPalette } from "../types";
+declare type NormalisedStyle = {
+    palette: NormalisedPalette;
+    [x: string]: CSSObject;
+};
+export declare function StyleProvider({ children, styleFromInit }: {
     children: JSX.Element;
+    styleFromInit?: Styles;
 }): JSX.Element;
-export declare const StyleConsumer: React.ExoticComponent<React.ConsumerProps<{
-    palette: import("../types").NormalisedPalette;
-    defaultStyles: import("../types").NormalisedDefaultStyles;
-}>>;
+export declare const StyleConsumer: React.ExoticComponent<React.ConsumerProps<NormalisedStyle>>;
+export {};

--- a/lib/build/recipe/emailpassword/styles/styleContext.js
+++ b/lib/build/recipe/emailpassword/styles/styleContext.js
@@ -16,37 +16,80 @@ function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
 }
 
-/* Copyright (c) 2020, VRAI Labs and/or its affiliates. All rights reserved.
- *
- * This software is licensed under the Apache License, Version 2.0 (the
- * "License") as published by the Apache Software Foundation.
- *
- * You may not use this file except in compliance with the License. You may
- * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-var StyleContext = /*#__PURE__*/ _react["default"].createContext({
-    palette: _styles.defaultPalette,
-    defaultStyles: (0, _styles.getDefaultStyles)(_styles.defaultPalette)
-});
+function ownKeys(object, enumerableOnly) {
+    var keys = Object.keys(object);
+    if (Object.getOwnPropertySymbols) {
+        var symbols = Object.getOwnPropertySymbols(object);
+        if (enumerableOnly)
+            symbols = symbols.filter(function(sym) {
+                return Object.getOwnPropertyDescriptor(object, sym).enumerable;
+            });
+        keys.push.apply(keys, symbols);
+    }
+    return keys;
+}
+
+function _objectSpread(target) {
+    for (var i = 1; i < arguments.length; i++) {
+        var source = arguments[i] != null ? arguments[i] : {};
+        if (i % 2) {
+            ownKeys(Object(source), true).forEach(function(key) {
+                _defineProperty(target, key, source[key]);
+            });
+        } else if (Object.getOwnPropertyDescriptors) {
+            Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
+        } else {
+            ownKeys(Object(source)).forEach(function(key) {
+                Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
+            });
+        }
+    }
+    return target;
+}
+
+function _defineProperty(obj, key, value) {
+    if (key in obj) {
+        Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true });
+    } else {
+        obj[key] = value;
+    }
+    return obj;
+}
+
+var StyleContext = /*#__PURE__*/ _react["default"].createContext(
+    _objectSpread(
+        {
+            palette: _styles.defaultPalette
+        },
+        (0, _styles.getDefaultStyles)(_styles.defaultPalette)
+    )
+);
 
 function StyleProvider(_ref) {
-    var children = _ref.children;
+    var children = _ref.children,
+        styleFromInit = _ref.styleFromInit;
 
     var palette = _emailPassword["default"].getInstanceOrThrow().getConfig().palette;
+
+    var styles = _objectSpread(
+        {
+            palette: palette
+        },
+        (0, _styles.getDefaultStyles)(palette)
+    );
+
+    if (styleFromInit !== undefined) {
+        // Palette is a reserved word, delete it if exists.
+        delete styleFromInit.palette;
+        Object.keys(styleFromInit).forEach(function(key) {
+            return [(styles[key] = _objectSpread(_objectSpread({}, styles[key]), styleFromInit[key]))];
+        });
+    }
 
     return /*#__PURE__*/ _react["default"].createElement(
         StyleContext.Provider,
         {
-            value: {
-                palette: palette,
-                defaultStyles: (0, _styles.getDefaultStyles)(palette)
-            }
+            value: styles
         },
         children
     );

--- a/lib/build/recipe/emailpassword/styles/styleContext.js
+++ b/lib/build/recipe/emailpassword/styles/styleContext.js
@@ -1,0 +1,56 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.StyleProvider = StyleProvider;
+exports.StyleConsumer = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+var _emailPassword = _interopRequireDefault(require("../emailPassword"));
+
+var _styles = require("./styles");
+
+function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : { default: obj };
+}
+
+/* Copyright (c) 2020, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+var StyleContext = /*#__PURE__*/ _react["default"].createContext({
+    palette: _styles.defaultPalette,
+    defaultStyles: (0, _styles.getDefaultStyles)(_styles.defaultPalette)
+});
+
+function StyleProvider(_ref) {
+    var children = _ref.children;
+
+    var palette = _emailPassword["default"].getInstanceOrThrow().getConfig().palette;
+
+    return /*#__PURE__*/ _react["default"].createElement(
+        StyleContext.Provider,
+        {
+            value: {
+                palette: palette,
+                defaultStyles: (0, _styles.getDefaultStyles)(palette)
+            }
+        },
+        children
+    );
+}
+
+var StyleConsumer = StyleContext.Consumer;
+exports.StyleConsumer = StyleConsumer;

--- a/lib/build/recipe/emailpassword/styles/styles.js
+++ b/lib/build/recipe/emailpassword/styles/styles.js
@@ -122,13 +122,15 @@ function getDefaultStyles(palette) {
         inputAdornment: {
             float: "right",
             left: "-2%",
-            top: "-33px",
+            top: "-24px",
             position: "relative",
             borderRadius: "12px",
             display: "flex",
-            alignItems: "center"
+            alignItems: "center",
+            height: "0px"
         },
         inputErrorMessage: {
+            paddingTop: "10px",
             color: palette.colors.error,
             lineHeight: "24px",
             fontWeight: 400,

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -265,7 +265,6 @@ export declare type FormBaseProps = {
     buttonLabel: string;
     onSuccess?: () => void;
     callAPI: (fields: APIFormField[]) => Promise<SignInThemeResponse | SignUpThemeResponse | SubmitNewPasswordThemeResponse | EnterEmailThemeResponse>;
-    styleFromInit?: Styles;
 };
 export declare type SignUpAPI = (requestJson: RequestJson, headers: HeadersInit) => Promise<SignUpAPIResponse>;
 export declare type SignInAPI = (requestJson: RequestJson, headers: HeadersInit) => Promise<SignInAPIResponse>;

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -95,8 +95,6 @@ export declare type onHandleResetPasswordUsingTokenSuccessContext = {
 declare type ThemeBaseProps = {
     styleFromInit?: Styles;
     formFields: FormFieldThemeProps[];
-    defaultStyles: NormalisedDefaultStyles;
-    palette: NormalisedPalette;
     onSuccess?: () => void;
 };
 export declare type SignInThemeProps = ThemeBaseProps & {
@@ -267,8 +265,6 @@ export declare type FormBaseProps = {
     buttonLabel: string;
     onSuccess?: () => void;
     callAPI: (fields: APIFormField[]) => Promise<SignInThemeResponse | SignUpThemeResponse | SubmitNewPasswordThemeResponse | EnterEmailThemeResponse>;
-    defaultStyles: NormalisedDefaultStyles;
-    palette: NormalisedPalette;
     styleFromInit?: Styles;
 };
 export declare type SignUpAPI = (requestJson: RequestJson, headers: HeadersInit) => Promise<SignUpAPIResponse>;

--- a/lib/ts/recipe/components/featureWrapper.tsx
+++ b/lib/ts/recipe/components/featureWrapper.tsx
@@ -24,15 +24,14 @@ import ErrorBoundary from "./errorBoundary";
 
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
-import { NormalisedDefaultStyles } from "../emailpassword/types";
 import { Fragment } from "react";
+import { StyleConsumer } from "../emailpassword/styles/styleContext";
 
 /*
  * Props.
  */
 
 type FeatureWrapperProps = {
-    defaultStyles: NormalisedDefaultStyles;
     children: JSX.Element;
     useShadowDom?: boolean;
 };
@@ -41,13 +40,13 @@ type FeatureWrapperProps = {
  * Component.
  */
 
-export default function FeatureWrapper({ children, defaultStyles, useShadowDom }: FeatureWrapperProps): JSX.Element {
+export default function FeatureWrapper({ children, useShadowDom }: FeatureWrapperProps): JSX.Element {
     /*
      * Render.
      */
     return (
         <ErrorBoundary>
-            <WithOrWithoutShadowDom defaultStyles={defaultStyles} useShadowDom={useShadowDom}>
+            <WithOrWithoutShadowDom useShadowDom={useShadowDom}>
                 <Fragment>
                     {children}
                     <link
@@ -60,20 +59,28 @@ export default function FeatureWrapper({ children, defaultStyles, useShadowDom }
     );
 }
 
-function WithOrWithoutShadowDom({ children, defaultStyles, useShadowDom }: FeatureWrapperProps): JSX.Element {
+function WithOrWithoutShadowDom({ children, useShadowDom }: FeatureWrapperProps): JSX.Element {
     // If explicitely specified to not use shadow dom.
     if (useShadowDom === false) {
         return (
-            <div css={defaultStyles.root} id={ST_ROOT_CONTAINER}>
-                {children}
-            </div>
+            <StyleConsumer>
+                {({ defaultStyles }) => (
+                    <div css={defaultStyles.root} id={ST_ROOT_CONTAINER}>
+                        {children}
+                    </div>
+                )}
+            </StyleConsumer>
         );
     }
 
     // Otherwise, use shadow dom.
     return (
-        <root.div css={defaultStyles.root} id={ST_ROOT_CONTAINER}>
-            {children}
-        </root.div>
+        <StyleConsumer>
+            {({ defaultStyles }) => (
+                <root.div css={defaultStyles.root} id={ST_ROOT_CONTAINER}>
+                    {children}
+                </root.div>
+            )}
+        </StyleConsumer>
     );
 }

--- a/lib/ts/recipe/components/featureWrapper.tsx
+++ b/lib/ts/recipe/components/featureWrapper.tsx
@@ -64,8 +64,8 @@ function WithOrWithoutShadowDom({ children, useShadowDom }: FeatureWrapperProps)
     if (useShadowDom === false) {
         return (
             <StyleConsumer>
-                {({ defaultStyles }) => (
-                    <div css={defaultStyles.root} id={ST_ROOT_CONTAINER}>
+                {styles => (
+                    <div css={styles.root} id={ST_ROOT_CONTAINER}>
                         {children}
                     </div>
                 )}
@@ -76,8 +76,8 @@ function WithOrWithoutShadowDom({ children, useShadowDom }: FeatureWrapperProps)
     // Otherwise, use shadow dom.
     return (
         <StyleConsumer>
-            {({ defaultStyles }) => (
-                <root.div css={defaultStyles.root} id={ST_ROOT_CONTAINER}>
+            {styles => (
+                <root.div css={styles.root} id={ST_ROOT_CONTAINER}>
                     {children}
                 </root.div>
             )}

--- a/lib/ts/recipe/emailpassword/components/library/FormBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/FormBase.tsx
@@ -153,19 +153,16 @@ export default class FormBase extends PureComponent<FormBaseProps, FormBaseState
      */
     render(): JSX.Element {
         const { header, footer, buttonLabel, showLabels } = this.props;
-        const styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
         const { generalError, formFields, isLoading } = this.state;
 
         return (
             <StyleConsumer>
-                {({ defaultStyles }) => (
-                    <div className="container" css={[defaultStyles.container, styleFromInit.container]}>
-                        <div className="row" css={[defaultStyles.row, styleFromInit.row]}>
+                {styles => (
+                    <div className="container" css={styles.container}>
+                        <div className="row" css={styles.row}>
                             {header}
                             {generalError && (
-                                <div
-                                    className="generalError"
-                                    css={[defaultStyles.generalError, styleFromInit.generalError]}>
+                                <div className="generalError" css={styles.generalError}>
                                     {generalError}
                                 </div>
                             )}
@@ -186,20 +183,13 @@ export default class FormBase extends PureComponent<FormBaseProps, FormBaseState
                                     }
 
                                     return (
-                                        <FormRow style={styleFromInit.formRow} key={field.id}>
+                                        <FormRow key={field.id}>
                                             <Fragment>
                                                 {showLabels && (
-                                                    <Label
-                                                        style={styleFromInit.label}
-                                                        value={field.label}
-                                                        showIsRequired={field.showIsRequired}
-                                                    />
+                                                    <Label value={field.label} showIsRequired={field.showIsRequired} />
                                                 )}
 
                                                 <Input
-                                                    style={styleFromInit.input}
-                                                    errorStyle={styleFromInit.inputError}
-                                                    adornmentStyle={styleFromInit.inputAdornment}
                                                     type={type}
                                                     name={field.id}
                                                     placeholder={field.placeholder}
@@ -209,21 +199,15 @@ export default class FormBase extends PureComponent<FormBaseProps, FormBaseState
                                                     validated={field.validated}
                                                 />
 
-                                                {field.error && (
-                                                    <InputError
-                                                        style={styleFromInit.inputErrorMessage}
-                                                        error={field.error}
-                                                    />
-                                                )}
+                                                {field.error && <InputError error={field.error} />}
                                             </Fragment>
                                         </FormRow>
                                     );
                                 })}
 
-                                <FormRow style={styleFromInit.formRow} key="form-button">
+                                <FormRow key="form-button">
                                     <Fragment>
                                         <Button
-                                            style={styleFromInit.button}
                                             disabled={isLoading}
                                             isLoading={isLoading}
                                             type="submit"

--- a/lib/ts/recipe/emailpassword/components/library/FormBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/FormBase.tsx
@@ -25,6 +25,7 @@ import { APIFormField } from "../../../../types";
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
 import { API_RESPONSE_STATUS, MANDATORY_FORM_FIELDS_ID, MANDATORY_FORM_FIELDS_ID_ARRAY } from "../../constants";
+import { StyleConsumer } from "../../styles/styleContext";
 
 /*
  * Component.
@@ -151,88 +152,91 @@ export default class FormBase extends PureComponent<FormBaseProps, FormBaseState
      * Render.
      */
     render(): JSX.Element {
-        const { defaultStyles, palette, header, footer, buttonLabel, showLabels } = this.props;
+        const { header, footer, buttonLabel, showLabels } = this.props;
         const styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
         const { generalError, formFields, isLoading } = this.state;
 
         return (
-            <div className="container" css={[defaultStyles.container, styleFromInit.container]}>
-                <div className="row" css={[defaultStyles.row, styleFromInit.row]}>
-                    {header}
-                    {generalError && (
-                        <div className="generalError" css={[defaultStyles.generalError, styleFromInit.generalError]}>
-                            {generalError}
-                        </div>
-                    )}
+            <StyleConsumer>
+                {({ defaultStyles }) => (
+                    <div className="container" css={[defaultStyles.container, styleFromInit.container]}>
+                        <div className="row" css={[defaultStyles.row, styleFromInit.row]}>
+                            {header}
+                            {generalError && (
+                                <div
+                                    className="generalError"
+                                    css={[defaultStyles.generalError, styleFromInit.generalError]}>
+                                    {generalError}
+                                </div>
+                            )}
 
-                    <form autoComplete="on" noValidate onSubmit={this.onFormSubmit}>
-                        {formFields.map(field => {
-                            let type = "text";
-                            // If email or password, replace field type.
-                            if (
-                                MANDATORY_FORM_FIELDS_ID_ARRAY.includes((field as { id: MANDATORY_FORM_FIELDS_ID }).id)
-                            ) {
-                                type = field.id;
-                            }
-                            if (field.id === "confirm-password") {
-                                type = "password";
-                            }
+                            <form autoComplete="on" noValidate onSubmit={this.onFormSubmit}>
+                                {formFields.map(field => {
+                                    let type = "text";
+                                    // If email or password, replace field type.
+                                    if (
+                                        MANDATORY_FORM_FIELDS_ID_ARRAY.includes(
+                                            (field as { id: MANDATORY_FORM_FIELDS_ID }).id
+                                        )
+                                    ) {
+                                        type = field.id;
+                                    }
+                                    if (field.id === "confirm-password") {
+                                        type = "password";
+                                    }
 
-                            return (
-                                <FormRow style={styleFromInit.formRow} key={field.id} defaultStyles={defaultStyles}>
+                                    return (
+                                        <FormRow style={styleFromInit.formRow} key={field.id}>
+                                            <Fragment>
+                                                {showLabels && (
+                                                    <Label
+                                                        style={styleFromInit.label}
+                                                        value={field.label}
+                                                        showIsRequired={field.showIsRequired}
+                                                    />
+                                                )}
+
+                                                <Input
+                                                    style={styleFromInit.input}
+                                                    errorStyle={styleFromInit.inputError}
+                                                    adornmentStyle={styleFromInit.inputAdornment}
+                                                    type={type}
+                                                    name={field.id}
+                                                    placeholder={field.placeholder}
+                                                    ref={field.ref}
+                                                    onChange={this.handleInputChange}
+                                                    hasError={field.error !== undefined}
+                                                    validated={field.validated}
+                                                />
+
+                                                {field.error && (
+                                                    <InputError
+                                                        style={styleFromInit.inputErrorMessage}
+                                                        error={field.error}
+                                                    />
+                                                )}
+                                            </Fragment>
+                                        </FormRow>
+                                    );
+                                })}
+
+                                <FormRow style={styleFromInit.formRow} key="form-button">
                                     <Fragment>
-                                        {showLabels && (
-                                            <Label
-                                                style={styleFromInit.label}
-                                                value={field.label}
-                                                showIsRequired={field.showIsRequired}
-                                                defaultStyles={defaultStyles}
-                                            />
-                                        )}
-
-                                        <Input
-                                            style={styleFromInit.input}
-                                            errorStyle={styleFromInit.inputError}
-                                            adornmentStyle={styleFromInit.inputAdornment}
-                                            type={type}
-                                            name={field.id}
-                                            placeholder={field.placeholder}
-                                            ref={field.ref}
-                                            onChange={this.handleInputChange}
-                                            hasError={field.error !== undefined}
-                                            validated={field.validated}
-                                            defaultStyles={defaultStyles}
-                                            palette={palette}
+                                        <Button
+                                            style={styleFromInit.button}
+                                            disabled={isLoading}
+                                            isLoading={isLoading}
+                                            type="submit"
+                                            label={buttonLabel}
                                         />
-
-                                        {field.error && (
-                                            <InputError
-                                                style={styleFromInit.inputErrorMessage}
-                                                error={field.error}
-                                                defaultStyles={defaultStyles}
-                                            />
-                                        )}
+                                        {footer}
                                     </Fragment>
                                 </FormRow>
-                            );
-                        })}
-
-                        <FormRow style={styleFromInit.formRow} key="form-button" defaultStyles={defaultStyles}>
-                            <Fragment>
-                                <Button
-                                    defaultStyles={defaultStyles}
-                                    style={styleFromInit.button}
-                                    disabled={isLoading}
-                                    isLoading={isLoading}
-                                    type="submit"
-                                    label={buttonLabel}
-                                />
-                                {footer}
-                            </Fragment>
-                        </FormRow>
-                    </form>
-                </div>
-            </div>
+                            </form>
+                        </div>
+                    </div>
+                )}
+            </StyleConsumer>
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/components/library/button.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/button.tsx
@@ -22,7 +22,7 @@ import { jsx } from "@emotion/core";
 
 import * as React from "react";
 import { CSSObject } from "@emotion/serialize/types/index";
-import { NormalisedDefaultStyles } from "../../types";
+import { StyleConsumer } from "../../styles/styleContext";
 
 /*
  * Props.
@@ -34,7 +34,6 @@ type ButtonProps = {
     isLoading: boolean;
     disabled?: boolean;
     type: "submit" | "button" | "reset" | undefined;
-    defaultStyles: NormalisedDefaultStyles;
     onClick?: () => void;
 };
 
@@ -42,27 +41,23 @@ type ButtonProps = {
  * Component.
  */
 
-export default function Button({
-    style,
-    type,
-    label,
-    disabled,
-    isLoading,
-    defaultStyles,
-    onClick
-}: ButtonProps): JSX.Element {
+export default function Button({ style, type, label, disabled, isLoading, onClick }: ButtonProps): JSX.Element {
     if (disabled === undefined) {
         disabled = false;
     }
     return (
-        <button
-            type={type}
-            disabled={disabled}
-            onClick={onClick}
-            css={[defaultStyles.button, style]}
-            className="button">
-            {label}
-            {isLoading && "..."}
-        </button>
+        <StyleConsumer>
+            {({ defaultStyles }) => (
+                <button
+                    type={type}
+                    disabled={disabled}
+                    onClick={onClick}
+                    css={[defaultStyles.button, style]}
+                    className="button">
+                    {label}
+                    {isLoading && "..."}
+                </button>
+            )}
+        </StyleConsumer>
     );
 }

--- a/lib/ts/recipe/emailpassword/components/library/button.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/button.tsx
@@ -21,7 +21,6 @@
 import { jsx } from "@emotion/core";
 
 import * as React from "react";
-import { CSSObject } from "@emotion/serialize/types/index";
 import { StyleConsumer } from "../../styles/styleContext";
 
 /*
@@ -29,7 +28,6 @@ import { StyleConsumer } from "../../styles/styleContext";
  */
 
 type ButtonProps = {
-    style: CSSObject;
     label: string;
     isLoading: boolean;
     disabled?: boolean;
@@ -41,19 +39,14 @@ type ButtonProps = {
  * Component.
  */
 
-export default function Button({ style, type, label, disabled, isLoading, onClick }: ButtonProps): JSX.Element {
+export default function Button({ type, label, disabled, isLoading, onClick }: ButtonProps): JSX.Element {
     if (disabled === undefined) {
         disabled = false;
     }
     return (
         <StyleConsumer>
-            {({ defaultStyles }) => (
-                <button
-                    type={type}
-                    disabled={disabled}
-                    onClick={onClick}
-                    css={[defaultStyles.button, style]}
-                    className="button">
+            {styles => (
+                <button type={type} disabled={disabled} onClick={onClick} css={styles.button} className="button">
                     {label}
                     {isLoading && "..."}
                 </button>

--- a/lib/ts/recipe/emailpassword/components/library/formRow.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formRow.tsx
@@ -21,7 +21,7 @@
 import { jsx } from "@emotion/core";
 import * as React from "react";
 import { CSSObject } from "@emotion/serialize/types/index";
-import { NormalisedDefaultStyles } from "../../types";
+import { StyleConsumer } from "../../styles/styleContext";
 
 /*
  * Props.
@@ -30,17 +30,20 @@ import { NormalisedDefaultStyles } from "../../types";
 type FormRowProps = {
     style: CSSObject;
     children: JSX.Element;
-    defaultStyles: NormalisedDefaultStyles;
 };
 
 /*
  * Component.
  */
 
-export default function FormRow({ style, children, defaultStyles }: FormRowProps): JSX.Element {
+export default function FormRow({ style, children }: FormRowProps): JSX.Element {
     return (
-        <div className="formRow" css={[defaultStyles.formRow, style]}>
-            {children}
-        </div>
+        <StyleConsumer>
+            {({ defaultStyles }) => (
+                <div className="formRow" css={[defaultStyles.formRow, style]}>
+                    {children}
+                </div>
+            )}
+        </StyleConsumer>
     );
 }

--- a/lib/ts/recipe/emailpassword/components/library/formRow.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formRow.tsx
@@ -20,7 +20,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
 import * as React from "react";
-import { CSSObject } from "@emotion/serialize/types/index";
 import { StyleConsumer } from "../../styles/styleContext";
 
 /*
@@ -28,7 +27,6 @@ import { StyleConsumer } from "../../styles/styleContext";
  */
 
 type FormRowProps = {
-    style: CSSObject;
     children: JSX.Element;
 };
 
@@ -36,11 +34,11 @@ type FormRowProps = {
  * Component.
  */
 
-export default function FormRow({ style, children }: FormRowProps): JSX.Element {
+export default function FormRow({ children }: FormRowProps): JSX.Element {
     return (
         <StyleConsumer>
-            {({ defaultStyles }) => (
-                <div className="formRow" css={[defaultStyles.formRow, style]}>
+            {styles => (
+                <div className="formRow" css={styles.formRow}>
                     {children}
                 </div>
             )}

--- a/lib/ts/recipe/emailpassword/components/library/input.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/input.tsx
@@ -25,7 +25,7 @@ import { forwardRef, RefObject } from "react";
 import { APIFormField } from "../../../../types";
 import { InputAdornment } from ".";
 import { AdornmentType } from "./inputAdornment";
-import { NormalisedDefaultStyles, NormalisedPalette } from "../../types";
+import { StyleConsumer } from "../../styles/styleContext";
 
 /*
  * Props.
@@ -40,8 +40,6 @@ type InputProps = {
     name: string;
     hasError: boolean;
     placeholder: string;
-    defaultStyles: NormalisedDefaultStyles;
-    palette: NormalisedPalette;
     ref: RefObject<any>;
     onChange?: (field: APIFormField) => void;
 };
@@ -51,36 +49,9 @@ type InputProps = {
  */
 
 function Input(
-    {
-        style,
-        type,
-        name,
-        hasError,
-        adornmentStyle,
-        onChange,
-        placeholder,
-        validated,
-        defaultStyles,
-        palette,
-        errorStyle
-    }: InputProps,
+    { style, type, name, hasError, adornmentStyle, onChange, placeholder, validated, errorStyle }: InputProps,
     ref: RefObject<any>
 ): JSX.Element {
-    if (hasError !== true) {
-        errorStyle = undefined;
-    } else {
-        errorStyle = {
-            ...defaultStyles.inputError,
-            ...errorStyle
-        };
-    }
-
-    let adornmentType: AdornmentType = undefined;
-
-    if (validated) {
-        adornmentType = hasError ? "error" : "success";
-    }
-
     /*
      * Method.
      */
@@ -98,23 +69,39 @@ function Input(
      * Render.
      */
     return (
-        <div className="inputWrapper" css={[defaultStyles.inputWrapper]}>
-            <input
-                className="input inputError"
-                css={[defaultStyles.input, style, errorStyle]}
-                onFocus={handleChange}
-                type={type}
-                name={name}
-                placeholder={placeholder}
-                ref={ref}
-            />
-            <InputAdornment
-                defaultStyles={defaultStyles}
-                palette={palette}
-                style={adornmentStyle}
-                type={adornmentType}
-            />
-        </div>
+        <StyleConsumer>
+            {({ defaultStyles }) => {
+                if (hasError !== true) {
+                    errorStyle = undefined;
+                } else {
+                    errorStyle = {
+                        ...defaultStyles.inputError,
+                        ...errorStyle
+                    };
+                }
+
+                let adornmentType: AdornmentType = undefined;
+
+                if (validated) {
+                    adornmentType = hasError ? "error" : "success";
+                }
+
+                return (
+                    <div className="inputWrapper" css={[defaultStyles.inputWrapper]}>
+                        <input
+                            className="input inputError"
+                            css={[defaultStyles.input, style, errorStyle]}
+                            onFocus={handleChange}
+                            type={type}
+                            name={name}
+                            placeholder={placeholder}
+                            ref={ref}
+                        />
+                        <InputAdornment style={adornmentStyle} type={adornmentType} />
+                    </div>
+                );
+            }}
+        </StyleConsumer>
     );
 }
 

--- a/lib/ts/recipe/emailpassword/components/library/input.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/input.tsx
@@ -49,7 +49,7 @@ type InputProps = {
  */
 
 function Input(
-    { style, type, name, hasError, adornmentStyle, onChange, placeholder, validated, errorStyle }: InputProps,
+    { type, name, hasError, onChange, placeholder, validated }: InputProps,
     ref: RefObject<any>
 ): JSX.Element {
     /*
@@ -70,16 +70,8 @@ function Input(
      */
     return (
         <StyleConsumer>
-            {({ defaultStyles }) => {
-                if (hasError !== true) {
-                    errorStyle = undefined;
-                } else {
-                    errorStyle = {
-                        ...defaultStyles.inputError,
-                        ...errorStyle
-                    };
-                }
-
+            {styles => {
+                const errorStyle: CSSObject | undefined = hasError === true ? styles.inputError : undefined;
                 let adornmentType: AdornmentType = undefined;
 
                 if (validated) {
@@ -87,17 +79,17 @@ function Input(
                 }
 
                 return (
-                    <div className="inputWrapper" css={[defaultStyles.inputWrapper]}>
+                    <div className="inputWrapper" css={[styles.inputWrapper]}>
                         <input
                             className="input inputError"
-                            css={[defaultStyles.input, style, errorStyle]}
+                            css={[styles.input, errorStyle]}
                             onFocus={handleChange}
                             type={type}
                             name={name}
                             placeholder={placeholder}
                             ref={ref}
                         />
-                        <InputAdornment style={adornmentStyle} type={adornmentType} />
+                        <InputAdornment type={adornmentType} />
                     </div>
                 );
             }}

--- a/lib/ts/recipe/emailpassword/components/library/inputAdornment.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/inputAdornment.tsx
@@ -23,7 +23,7 @@ import Checked from "../../assets/checked";
 import Error from "../../assets/error";
 import * as React from "react";
 import { CSSObject } from "@emotion/serialize/types/index";
-import { NormalisedDefaultStyles, NormalisedPalette } from "../../types";
+import { StyleConsumer } from "../../styles/styleContext";
 
 export type AdornmentType = "success" | "error" | undefined;
 
@@ -34,23 +34,24 @@ export type AdornmentType = "success" | "error" | undefined;
 type InputAdornmentProps = {
     style?: CSSObject;
     type: AdornmentType;
-    defaultStyles: NormalisedDefaultStyles;
-    palette: NormalisedPalette;
 };
 
 /*
  * Component.
  */
 
-export default function InputAdornment({ type, style, defaultStyles, palette }: InputAdornmentProps): JSX.Element {
+export default function InputAdornment({ type, style }: InputAdornmentProps): JSX.Element {
     /*
      * Render.
      */
-
     return (
-        <div className="inputAdornment" css={[defaultStyles.inputAdornment, style]}>
-            {type === "success" && <Checked color={palette.colors.primary} />}
-            {type === "error" && <Error color={palette.colors.error} />}
-        </div>
+        <StyleConsumer>
+            {({ defaultStyles, palette }) => (
+                <div className="inputAdornment" css={[defaultStyles.inputAdornment, style]}>
+                    {type === "success" && <Checked color={palette.colors.primary} />}
+                    {type === "error" && <Error color={palette.colors.error} />}
+                </div>
+            )}
+        </StyleConsumer>
     );
 }

--- a/lib/ts/recipe/emailpassword/components/library/inputAdornment.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/inputAdornment.tsx
@@ -22,7 +22,6 @@ import { jsx } from "@emotion/core";
 import Checked from "../../assets/checked";
 import Error from "../../assets/error";
 import * as React from "react";
-import { CSSObject } from "@emotion/serialize/types/index";
 import { StyleConsumer } from "../../styles/styleContext";
 
 export type AdornmentType = "success" | "error" | undefined;
@@ -32,7 +31,6 @@ export type AdornmentType = "success" | "error" | undefined;
  */
 
 type InputAdornmentProps = {
-    style?: CSSObject;
     type: AdornmentType;
 };
 
@@ -40,16 +38,16 @@ type InputAdornmentProps = {
  * Component.
  */
 
-export default function InputAdornment({ type, style }: InputAdornmentProps): JSX.Element {
+export default function InputAdornment({ type }: InputAdornmentProps): JSX.Element {
     /*
      * Render.
      */
     return (
         <StyleConsumer>
-            {({ defaultStyles, palette }) => (
-                <div className="inputAdornment" css={[defaultStyles.inputAdornment, style]}>
-                    {type === "success" && <Checked color={palette.colors.primary} />}
-                    {type === "error" && <Error color={palette.colors.error} />}
+            {styles => (
+                <div className="inputAdornment" css={styles.inputAdornment}>
+                    {type === "success" && <Checked color={styles.palette.colors.primary} />}
+                    {type === "error" && <Error color={styles.palette.colors.error} />}
                 </div>
             )}
         </StyleConsumer>

--- a/lib/ts/recipe/emailpassword/components/library/inputError.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/inputError.tsx
@@ -20,7 +20,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
 import * as React from "react";
-import { CSSObject } from "@emotion/serialize/types/index";
 import { StyleConsumer } from "../../styles/styleContext";
 
 /*
@@ -28,7 +27,6 @@ import { StyleConsumer } from "../../styles/styleContext";
  */
 
 type InputErrorProps = {
-    style: CSSObject;
     error: string;
 };
 
@@ -36,15 +34,15 @@ type InputErrorProps = {
  * Component.
  */
 
-export default function InputError({ style, error }: InputErrorProps): JSX.Element {
+export default function InputError({ error }: InputErrorProps): JSX.Element {
     /*
      * Render.
      */
 
     return (
         <StyleConsumer>
-            {({ defaultStyles }) => (
-                <div className="inputErrorMessage" css={[defaultStyles.inputErrorMessage, style]}>
+            {styles => (
+                <div className="inputErrorMessage" css={styles.inputErrorMessage}>
                     {error}
                 </div>
             )}

--- a/lib/ts/recipe/emailpassword/components/library/label.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/label.tsx
@@ -21,7 +21,6 @@
 import { jsx } from "@emotion/core";
 
 import * as React from "react";
-import { CSSObject } from "@emotion/serialize/types/index";
 import { StyleConsumer } from "../../styles/styleContext";
 
 /*
@@ -29,7 +28,6 @@ import { StyleConsumer } from "../../styles/styleContext";
  */
 
 type LabelProps = {
-    style: CSSObject;
     value: string;
     showIsRequired?: boolean;
 };
@@ -38,15 +36,15 @@ type LabelProps = {
  * Component.
  */
 
-export default function Label({ style, value, showIsRequired }: LabelProps): JSX.Element {
+export default function Label({ value, showIsRequired }: LabelProps): JSX.Element {
     /*
      * Render.
      */
 
     return (
         <StyleConsumer>
-            {({ defaultStyles }) => (
-                <div className="label" css={[defaultStyles.label, style]}>
+            {styles => (
+                <div className="label" css={styles.label}>
                     {value}
                     {":"}
                     {showIsRequired && " *"}

--- a/lib/ts/recipe/emailpassword/components/library/label.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/label.tsx
@@ -22,7 +22,7 @@ import { jsx } from "@emotion/core";
 
 import * as React from "react";
 import { CSSObject } from "@emotion/serialize/types/index";
-import { NormalisedDefaultStyles } from "../../types";
+import { StyleConsumer } from "../../styles/styleContext";
 
 /*
  * Props.
@@ -32,23 +32,26 @@ type LabelProps = {
     style: CSSObject;
     value: string;
     showIsRequired?: boolean;
-    defaultStyles: NormalisedDefaultStyles;
 };
 
 /*
  * Component.
  */
 
-export default function Label({ style, value, showIsRequired, defaultStyles }: LabelProps): JSX.Element {
+export default function Label({ style, value, showIsRequired }: LabelProps): JSX.Element {
     /*
      * Render.
      */
 
     return (
-        <div className="label" css={[defaultStyles.label, style]}>
-            {value}
-            {":"}
-            {showIsRequired && " *"}
-        </div>
+        <StyleConsumer>
+            {({ defaultStyles }) => (
+                <div className="label" css={[defaultStyles.label, style]}>
+                    {value}
+                    {":"}
+                    {showIsRequired && " *"}
+                </div>
+            )}
+        </StyleConsumer>
     );
 }

--- a/lib/ts/recipe/emailpassword/components/resetPasswordUsingToken/resetPasswordUsingToken.tsx
+++ b/lib/ts/recipe/emailpassword/components/resetPasswordUsingToken/resetPasswordUsingToken.tsx
@@ -20,8 +20,6 @@ import * as React from "react";
 import { PureComponent, Fragment } from "react";
 import {
     EnterEmailThemeResponse,
-    NormalisedDefaultStyles,
-    NormalisedPalette,
     SubmitNewPasswordThemeProps,
     ResetPasswordUsingTokenProps,
     onHandleResetPasswordUsingTokenSuccessContext,
@@ -36,10 +34,10 @@ import FeatureWrapper from "../../../components/featureWrapper";
 
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
-import { getDefaultStyles } from "../../styles/styles";
 import { API_RESPONSE_STATUS, SUCCESS_ACTION } from "../../constants";
 import { redirectToInApp } from "../../../../utils";
 import { handleEnterEmailAPI, handleSubmitNewPasswordAPI } from "./api";
+import { StyleProvider } from "../../styles/styleContext";
 
 /*
  * Component.
@@ -187,18 +185,11 @@ class ResetPasswordUsingToken extends PureComponent<ResetPasswordUsingTokenProps
         const submitNewPasswordFormFeature = this.getRecipeInstanceOrThrow().getConfig().resetPasswordUsingTokenFeature
             .submitNewPasswordForm;
 
-        const defaultStyles: NormalisedDefaultStyles = getDefaultStyles(
-            this.getRecipeInstanceOrThrow().getConfig().palette
-        );
-        const palette: NormalisedPalette = this.getRecipeInstanceOrThrow().getConfig().palette;
-
         const submitNewPasswordForm: SubmitNewPasswordThemeProps = {
             styleFromInit: submitNewPasswordFormFeature.style,
             formFields: submitNewPasswordFormFeature.formFields,
             callAPI: this.submitNewPassword,
             onSuccess: this.onSubmitNewPasswordFormSuccess,
-            defaultStyles,
-            palette,
             onSignInClicked: this.onSignInClicked
         };
 
@@ -206,9 +197,7 @@ class ResetPasswordUsingToken extends PureComponent<ResetPasswordUsingTokenProps
             styleFromInit: enterEmailFormFeature.style,
             formFields: enterEmailFormFeature.formFields,
             onSuccess: this.onEnterEmailFormSuccess,
-            callAPI: this.enterEmail,
-            defaultStyles,
-            palette
+            callAPI: this.enterEmail
         };
         const useShadowDom = this.getRecipeInstanceOrThrow().getConfig().useShadowDom;
 
@@ -218,25 +207,27 @@ class ResetPasswordUsingToken extends PureComponent<ResetPasswordUsingTokenProps
          * Render.
          */
         return (
-            <FeatureWrapper useShadowDom={useShadowDom} defaultStyles={defaultStyles}>
-                <Fragment>
-                    {/* No custom theme, use default. */}
-                    {this.props.children === undefined && (
-                        <ResetPasswordUsingTokenTheme
-                            submitNewPassword={submitNewPasswordForm}
-                            enterEmail={enterEmailForm}
-                            hasToken={hasToken}
-                        />
-                    )}
-                    {/* Otherwise, custom theme is provided, propagate props. */}
-                    {this.props.children &&
-                        React.cloneElement(this.props.children, {
-                            submitNewPasswordForm,
-                            enterEmailForm,
-                            hasToken
-                        })}
-                </Fragment>
-            </FeatureWrapper>
+            <StyleProvider>
+                <FeatureWrapper useShadowDom={useShadowDom}>
+                    <Fragment>
+                        {/* No custom theme, use default. */}
+                        {this.props.children === undefined && (
+                            <ResetPasswordUsingTokenTheme
+                                submitNewPassword={submitNewPasswordForm}
+                                enterEmail={enterEmailForm}
+                                hasToken={hasToken}
+                            />
+                        )}
+                        {/* Otherwise, custom theme is provided, propagate props. */}
+                        {this.props.children &&
+                            React.cloneElement(this.props.children, {
+                                submitNewPasswordForm,
+                                enterEmailForm,
+                                hasToken
+                            })}
+                    </Fragment>
+                </FeatureWrapper>
+            </StyleProvider>
         );
     };
 }

--- a/lib/ts/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/enterEmail.tsx
+++ b/lib/ts/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/enterEmail.tsx
@@ -24,7 +24,7 @@ import { CSSObject } from "@emotion/serialize/types";
 import { jsx } from "@emotion/core";
 import FormBase from "../../../library/FormBase";
 import { Styles } from "../../../../../../types";
-import { StyleConsumer } from "../../../../styles/styleContext";
+import { StyleConsumer, StyleProvider } from "../../../../styles/styleContext";
 
 /*
  * Styles.
@@ -104,66 +104,63 @@ export default class EnterEmailTheme extends PureComponent<EnterEmailThemeProps,
         const styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
 
         return (
-            <StyleConsumer>
-                {({ defaultStyles, palette }) => {
-                    const styles = getStyles(palette);
+            <StyleProvider styleFromInit={styleFromInit}>
+                <StyleConsumer>
+                    {styles => {
+                        const componentStyles = getStyles(styles.palette);
 
-                    // If email sent, show success UI.
-                    if (emailSent === true) {
-                        return (
-                            <div className="container" css={[defaultStyles.container, styleFromInit.container]}>
-                                <div className="row" css={[defaultStyles.row, styleFromInit.row]}>
-                                    <div
-                                        className="primaryText successMessage"
-                                        css={[
-                                            defaultStyles.primaryText,
-                                            styleFromInit.primaryText,
-                                            styles.successMessage,
-                                            styleFromInit.successMessage
-                                        ]}>
-                                        You will receive a password recovery link at your email address in a few
-                                        minutes.{" "}
-                                        <span
-                                            className="link"
-                                            css={[defaultStyles.link, styleFromInit.link]}
-                                            onClick={this.resend}>
-                                            Resend
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
-                        );
-                    }
-
-                    // Otherwise, return Form.
-                    return (
-                        <FormBase
-                            formFields={formFields}
-                            styleFromInit={styleFromInit}
-                            buttonLabel={"Email me"}
-                            onSuccess={this.onSuccess}
-                            callAPI={callAPI}
-                            showLabels={false}
-                            header={
-                                <Fragment>
-                                    <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
-                                        Reset your password
-                                    </div>
-                                    <div
-                                        className="headerSubtitle"
-                                        css={[styles.headerSubTitle, styleFromInit.headerSubtitle]}>
+                        // If email sent, show success UI.
+                        if (emailSent === true) {
+                            return (
+                                <div className="container" css={styles.container}>
+                                    <div className="row" css={styles.row}>
                                         <div
-                                            className="secondaryText"
-                                            css={[defaultStyles.secondaryText, styleFromInit.secondaryText]}>
-                                            We will send you an email to reset your password
+                                            className="primaryText successMessage"
+                                            css={[
+                                                styles.primaryText,
+                                                componentStyles.successMessage,
+                                                styles.successMessage
+                                            ]}>
+                                            You will receive a password recovery link at your email address in a few
+                                            minutes.{" "}
+                                            <span className="link" css={styles.link} onClick={this.resend}>
+                                                Resend
+                                            </span>
                                         </div>
                                     </div>
-                                </Fragment>
-                            }
-                        />
-                    );
-                }}
-            </StyleConsumer>
+                                </div>
+                            );
+                        }
+
+                        // Otherwise, return Form.
+                        return (
+                            <FormBase
+                                formFields={formFields}
+                                buttonLabel={"Email me"}
+                                onSuccess={this.onSuccess}
+                                callAPI={callAPI}
+                                showLabels={false}
+                                header={
+                                    <Fragment>
+                                        <div
+                                            className="headerTitle"
+                                            css={[componentStyles.headerTitle, styles.headerTitle]}>
+                                            Reset your password
+                                        </div>
+                                        <div
+                                            className="headerSubtitle"
+                                            css={[componentStyles.headerSubTitle, styles.headerSubtitle]}>
+                                            <div className="secondaryText" css={styles.secondaryText}>
+                                                We will send you an email to reset your password
+                                            </div>
+                                        </div>
+                                    </Fragment>
+                                }
+                            />
+                        );
+                    }}
+                </StyleConsumer>
+            </StyleProvider>
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/enterEmail.tsx
+++ b/lib/ts/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/enterEmail.tsx
@@ -24,6 +24,7 @@ import { CSSObject } from "@emotion/serialize/types";
 import { jsx } from "@emotion/core";
 import FormBase from "../../../library/FormBase";
 import { Styles } from "../../../../../../types";
+import { StyleConsumer } from "../../../../styles/styleContext";
 
 /*
  * Styles.
@@ -98,60 +99,71 @@ export default class EnterEmailTheme extends PureComponent<EnterEmailThemeProps,
      * Render.
      */
     render(): JSX.Element {
-        const { defaultStyles, palette, callAPI } = this.props;
+        const { callAPI } = this.props;
         const { formFields, emailSent } = this.state;
         const styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
-        const styles = getStyles(palette);
 
-        // If email sent, show success UI.
-        if (emailSent === true) {
-            return (
-                <div className="container" css={[defaultStyles.container, styleFromInit.container]}>
-                    <div className="row" css={[defaultStyles.row, styleFromInit.row]}>
-                        <div
-                            className="primaryText successMessage"
-                            css={[
-                                defaultStyles.primaryText,
-                                styleFromInit.primaryText,
-                                styles.successMessage,
-                                styleFromInit.successMessage
-                            ]}>
-                            You will receive a password recovery link at your email address in a few minutes.{" "}
-                            <span className="link" css={[defaultStyles.link, styleFromInit.link]} onClick={this.resend}>
-                                Resend
-                            </span>
-                        </div>
-                    </div>
-                </div>
-            );
-        }
-
-        // Otherwise, return Form.
         return (
-            <FormBase
-                formFields={formFields}
-                defaultStyles={defaultStyles}
-                styleFromInit={styleFromInit}
-                palette={palette}
-                buttonLabel={"Email me"}
-                onSuccess={this.onSuccess}
-                callAPI={callAPI}
-                showLabels={false}
-                header={
-                    <Fragment>
-                        <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
-                            Reset your password
-                        </div>
-                        <div className="headerSubtitle" css={[styles.headerSubTitle, styleFromInit.headerSubtitle]}>
-                            <div
-                                className="secondaryText"
-                                css={[defaultStyles.secondaryText, styleFromInit.secondaryText]}>
-                                We will send you an email to reset your password
+            <StyleConsumer>
+                {({ defaultStyles, palette }) => {
+                    const styles = getStyles(palette);
+
+                    // If email sent, show success UI.
+                    if (emailSent === true) {
+                        return (
+                            <div className="container" css={[defaultStyles.container, styleFromInit.container]}>
+                                <div className="row" css={[defaultStyles.row, styleFromInit.row]}>
+                                    <div
+                                        className="primaryText successMessage"
+                                        css={[
+                                            defaultStyles.primaryText,
+                                            styleFromInit.primaryText,
+                                            styles.successMessage,
+                                            styleFromInit.successMessage
+                                        ]}>
+                                        You will receive a password recovery link at your email address in a few
+                                        minutes.{" "}
+                                        <span
+                                            className="link"
+                                            css={[defaultStyles.link, styleFromInit.link]}
+                                            onClick={this.resend}>
+                                            Resend
+                                        </span>
+                                    </div>
+                                </div>
                             </div>
-                        </div>
-                    </Fragment>
-                }
-            />
+                        );
+                    }
+
+                    // Otherwise, return Form.
+                    return (
+                        <FormBase
+                            formFields={formFields}
+                            styleFromInit={styleFromInit}
+                            buttonLabel={"Email me"}
+                            onSuccess={this.onSuccess}
+                            callAPI={callAPI}
+                            showLabels={false}
+                            header={
+                                <Fragment>
+                                    <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
+                                        Reset your password
+                                    </div>
+                                    <div
+                                        className="headerSubtitle"
+                                        css={[styles.headerSubTitle, styleFromInit.headerSubtitle]}>
+                                        <div
+                                            className="secondaryText"
+                                            css={[defaultStyles.secondaryText, styleFromInit.secondaryText]}>
+                                            We will send you an email to reset your password
+                                        </div>
+                                    </div>
+                                </Fragment>
+                            }
+                        />
+                    );
+                }}
+            </StyleConsumer>
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/submitNewPassword.tsx
+++ b/lib/ts/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/submitNewPassword.tsx
@@ -27,7 +27,7 @@ import { jsx } from "@emotion/core";
 import FormBase from "../../../library/FormBase";
 import { FormRow, Button } from "../../../library";
 import { Styles } from "../../../../../../types";
-import { StyleConsumer } from "../../../../styles/styleContext";
+import { StyleConsumer, StyleProvider } from "../../../../styles/styleContext";
 
 /*
  * Styles.
@@ -107,71 +107,70 @@ export default class SubmitNewPasswordTheme extends PureComponent<
         const { formFields, hasNewPassword } = this.state;
 
         return (
-            <StyleConsumer>
-                {({ defaultStyles, palette }) => {
-                    const styles = getStyles(palette);
+            <StyleProvider styleFromInit={styleFromInit}>
+                <StyleConsumer>
+                    {styles => {
+                        const componentStyles = getStyles(styles.palette);
 
-                    if (hasNewPassword === true) {
-                        return (
-                            <div className="container" css={[defaultStyles.container, styleFromInit.container]}>
-                                <div className="row" css={[defaultStyles.row, styleFromInit.row]}>
-                                    <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
-                                        Success!
-                                    </div>
-                                    <FormRow style={styleFromInit.formRow} key="form-button">
-                                        <Fragment>
-                                            <div
-                                                className="primaryText successMessage"
-                                                css={[
-                                                    defaultStyles.primaryText,
-                                                    styleFromInit.primaryText,
-                                                    styles.successMessage,
-                                                    styleFromInit.successMessage
-                                                ]}>
-                                                Your password has been updated successfully
-                                            </div>
-                                            <Button
-                                                style={styleFromInit.button}
-                                                disabled={false}
-                                                isLoading={false}
-                                                type="button"
-                                                onClick={onSignInClicked}
-                                                label={"SIGN IN"}
-                                            />
-                                        </Fragment>
-                                    </FormRow>
-                                </div>
-                            </div>
-                        );
-                    }
-                    return (
-                        <FormBase
-                            formFields={formFields}
-                            styleFromInit={styleFromInit}
-                            buttonLabel={"Change password"}
-                            onSuccess={this.onSuccess}
-                            callAPI={callAPI}
-                            showLabels={false}
-                            header={
-                                <Fragment>
-                                    <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
-                                        Change your password
-                                    </div>
-                                    <div
-                                        className="headerSubtitle"
-                                        css={[styles.headerSubTitle, styleFromInit.headerSubtitle]}>
+                        if (hasNewPassword === true) {
+                            return (
+                                <div className="container" css={styles.container}>
+                                    <div className="row" css={styles.row}>
                                         <div
-                                            className="secondaryText"
-                                            css={[defaultStyles.secondaryText, styleFromInit.secondaryText]}>
-                                            Enter a new password below to change your password
+                                            className="headerTitle"
+                                            css={[styles.headerTitle, styleFromInit.headerTitle]}>
+                                            Success!
                                         </div>
+                                        <FormRow key="form-button">
+                                            <Fragment>
+                                                <div
+                                                    className="primaryText successMessage"
+                                                    css={[
+                                                        styles.primaryText,
+                                                        componentStyles.successMessage,
+                                                        styles.successMessage
+                                                    ]}>
+                                                    Your password has been updated successfully
+                                                </div>
+                                                <Button
+                                                    disabled={false}
+                                                    isLoading={false}
+                                                    type="button"
+                                                    onClick={onSignInClicked}
+                                                    label={"SIGN IN"}
+                                                />
+                                            </Fragment>
+                                        </FormRow>
                                     </div>
-                                </Fragment>
-                            }
-                        />
-                    );
-                }}
-            </StyleConsumer>
+                                </div>
+                            );
+                        }
+                        return (
+                            <FormBase
+                                formFields={formFields}
+                                buttonLabel={"Change password"}
+                                onSuccess={this.onSuccess}
+                                callAPI={callAPI}
+                                showLabels={false}
+                                header={
+                                    <Fragment>
+                                        <div
+                                            className="headerTitle"
+                                            css={[componentStyles.headerTitle, styles.headerTitle]}>
+                                            Change your password
+                                        </div>
+                                        <div className="headerSubtitle" css={styles.headerSubTitle}>
+                                            <div className="secondaryText" css={styles.secondaryText}>
+                                                Enter a new password below to change your password
+                                            </div>
+                                        </div>
+                                    </Fragment>
+                                }
+                            />
+                        );
+                    }}
+                </StyleConsumer>
+            </StyleProvider>
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/submitNewPassword.tsx
+++ b/lib/ts/recipe/emailpassword/components/resetPasswordUsingToken/themes/default/submitNewPassword.tsx
@@ -27,6 +27,7 @@ import { jsx } from "@emotion/core";
 import FormBase from "../../../library/FormBase";
 import { FormRow, Button } from "../../../library";
 import { Styles } from "../../../../../../types";
+import { StyleConsumer } from "../../../../styles/styleContext";
 
 /*
  * Styles.
@@ -101,70 +102,76 @@ export default class SubmitNewPasswordTheme extends PureComponent<
      */
 
     render(): JSX.Element {
-        const { defaultStyles, palette, callAPI, onSignInClicked } = this.props;
+        const { callAPI, onSignInClicked } = this.props;
         const styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
         const { formFields, hasNewPassword } = this.state;
-        const styles = getStyles(palette);
 
-        if (hasNewPassword === true) {
-            return (
-                <div className="container" css={[defaultStyles.container, styleFromInit.container]}>
-                    <div className="row" css={[defaultStyles.row, styleFromInit.row]}>
-                        <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
-                            Success!
-                        </div>
-                        <FormRow style={styleFromInit.formRow} key="form-button" defaultStyles={defaultStyles}>
-                            <Fragment>
-                                <div
-                                    className="primaryText successMessage"
-                                    css={[
-                                        defaultStyles.primaryText,
-                                        styleFromInit.primaryText,
-                                        styles.successMessage,
-                                        styleFromInit.successMessage
-                                    ]}>
-                                    Your password has been updated successfully
-                                </div>
-                                <Button
-                                    defaultStyles={defaultStyles}
-                                    style={styleFromInit.button}
-                                    disabled={false}
-                                    isLoading={false}
-                                    type="button"
-                                    onClick={onSignInClicked}
-                                    label={"SIGN IN"}
-                                />
-                            </Fragment>
-                        </FormRow>
-                    </div>
-                </div>
-            );
-        }
         return (
-            <FormBase
-                formFields={formFields}
-                defaultStyles={defaultStyles}
-                styleFromInit={styleFromInit}
-                palette={palette}
-                buttonLabel={"Change password"}
-                onSuccess={this.onSuccess}
-                callAPI={callAPI}
-                showLabels={false}
-                header={
-                    <Fragment>
-                        <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
-                            Change your password
-                        </div>
-                        <div className="headerSubtitle" css={[styles.headerSubTitle, styleFromInit.headerSubtitle]}>
-                            <div
-                                className="secondaryText"
-                                css={[defaultStyles.secondaryText, styleFromInit.secondaryText]}>
-                                Enter a new password below to change your password
+            <StyleConsumer>
+                {({ defaultStyles, palette }) => {
+                    const styles = getStyles(palette);
+
+                    if (hasNewPassword === true) {
+                        return (
+                            <div className="container" css={[defaultStyles.container, styleFromInit.container]}>
+                                <div className="row" css={[defaultStyles.row, styleFromInit.row]}>
+                                    <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
+                                        Success!
+                                    </div>
+                                    <FormRow style={styleFromInit.formRow} key="form-button">
+                                        <Fragment>
+                                            <div
+                                                className="primaryText successMessage"
+                                                css={[
+                                                    defaultStyles.primaryText,
+                                                    styleFromInit.primaryText,
+                                                    styles.successMessage,
+                                                    styleFromInit.successMessage
+                                                ]}>
+                                                Your password has been updated successfully
+                                            </div>
+                                            <Button
+                                                style={styleFromInit.button}
+                                                disabled={false}
+                                                isLoading={false}
+                                                type="button"
+                                                onClick={onSignInClicked}
+                                                label={"SIGN IN"}
+                                            />
+                                        </Fragment>
+                                    </FormRow>
+                                </div>
                             </div>
-                        </div>
-                    </Fragment>
-                }
-            />
+                        );
+                    }
+                    return (
+                        <FormBase
+                            formFields={formFields}
+                            styleFromInit={styleFromInit}
+                            buttonLabel={"Change password"}
+                            onSuccess={this.onSuccess}
+                            callAPI={callAPI}
+                            showLabels={false}
+                            header={
+                                <Fragment>
+                                    <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
+                                        Change your password
+                                    </div>
+                                    <div
+                                        className="headerSubtitle"
+                                        css={[styles.headerSubTitle, styleFromInit.headerSubtitle]}>
+                                        <div
+                                            className="secondaryText"
+                                            css={[defaultStyles.secondaryText, styleFromInit.secondaryText]}>
+                                            Enter a new password below to change your password
+                                        </div>
+                                    </div>
+                                </Fragment>
+                            }
+                        />
+                    );
+                }}
+            </StyleConsumer>
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/components/signInAndUp/SignInAndUp.tsx
+++ b/lib/ts/recipe/emailpassword/components/signInAndUp/SignInAndUp.tsx
@@ -22,8 +22,6 @@ import {
     SignInThemeResponse,
     SignInAndUpProps,
     SignUpThemeResponse,
-    NormalisedDefaultStyles,
-    NormalisedPalette,
     OnHandleSignInAndUpSuccessContext,
     SignInAndUpState,
     SignInAndUpStateStatus,
@@ -38,11 +36,11 @@ import FeatureWrapper from "../../../components/featureWrapper";
 
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
-import { getDefaultStyles } from "../../styles/styles";
 import { redirectToInApp, redirectToWithReload, WithRouter } from "../../../../utils";
 import SuperTokens from "../../../../superTokens";
 import { handleSignInAPI, handleSignUpAPI } from "./api";
 import { SOMETHING_WENT_WRONG_ERROR } from "../../../../constants";
+import { StyleProvider } from "../../styles/styleContext";
 
 /*
  * Component.
@@ -264,20 +262,13 @@ class SignInAndUp extends PureComponent<SignInAndUpProps, SignInAndUpState> {
 
         const signInFeature = this.getRecipeInstanceOrThrow().getConfig().signInAndUpFeature.signInForm;
 
-        const defaultStyles: NormalisedDefaultStyles = getDefaultStyles(
-            this.getRecipeInstanceOrThrow().getConfig().palette
-        );
-        const palette: NormalisedPalette = this.getRecipeInstanceOrThrow().getConfig().palette;
-
         const signInForm = {
             styleFromInit: signInFeature.style,
             formFields: signInFeature.formFields,
             resetPasswordURL: signInFeature.resetPasswordURL,
             callAPI: this.signIn,
             onSuccess: this.onSignInSuccess,
-            forgotPasswordClick: this.onHandleForgotPasswordClicked,
-            defaultStyles,
-            palette
+            forgotPasswordClick: this.onHandleForgotPasswordClicked
         };
 
         const signUpForm = {
@@ -286,9 +277,7 @@ class SignInAndUp extends PureComponent<SignInAndUpProps, SignInAndUpState> {
             privacyPolicyLink: signUpFeature.privacyPolicyLink,
             termsAndConditionsLink: signUpFeature.termsAndConditionsLink,
             onSuccess: this.onSignUpSuccess,
-            callAPI: this.signUp,
-            defaultStyles,
-            palette
+            callAPI: this.signUp
         };
 
         const useShadowDom = this.getRecipeInstanceOrThrow().getConfig().useShadowDom;
@@ -302,20 +291,22 @@ class SignInAndUp extends PureComponent<SignInAndUpProps, SignInAndUpState> {
          * Render.
          */
         return (
-            <FeatureWrapper useShadowDom={useShadowDom} defaultStyles={defaultStyles}>
-                <Fragment>
-                    {/* No custom theme, use default. */}
-                    {this.props.children === undefined && (
-                        <SignInAndUpTheme signInForm={signInForm} signUpForm={signUpForm} />
-                    )}
-                    {/* Otherwise, custom theme is provided, propagate props. */}
-                    {this.props.children &&
-                        React.cloneElement(this.props.children, {
-                            signInForm,
-                            signUpForm
-                        })}
-                </Fragment>
-            </FeatureWrapper>
+            <StyleProvider>
+                <FeatureWrapper useShadowDom={useShadowDom}>
+                    <Fragment>
+                        {/* No custom theme, use default. */}
+                        {this.props.children === undefined && (
+                            <SignInAndUpTheme signInForm={signInForm} signUpForm={signUpForm} />
+                        )}
+                        {/* Otherwise, custom theme is provided, propagate props. */}
+                        {this.props.children &&
+                            React.cloneElement(this.props.children, {
+                                signInForm,
+                                signUpForm
+                            })}
+                    </Fragment>
+                </FeatureWrapper>
+            </StyleProvider>
         );
     };
 }

--- a/lib/ts/recipe/emailpassword/components/signInAndUp/themes/default/SignIn.tsx
+++ b/lib/ts/recipe/emailpassword/components/signInAndUp/themes/default/SignIn.tsx
@@ -26,7 +26,7 @@ import { jsx } from "@emotion/core";
 
 import FormBase from "../../../library/FormBase";
 import { Styles } from "../../../../../../types";
-import { StyleConsumer } from "../../../../styles/styleContext";
+import { StyleConsumer, StyleProvider } from "../../../../styles/styleContext";
 
 /*
  * Styles.
@@ -82,64 +82,59 @@ export default class SignInTheme extends PureComponent<SignInThemeProps, { formF
      */
 
     render(): JSX.Element {
-        const { signUpClicked, forgotPasswordClick, onSuccess, callAPI } = this.props;
-        const styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
+        const { signUpClicked, forgotPasswordClick, styleFromInit, onSuccess, callAPI } = this.props;
         const { formFields } = this.state;
 
         return (
-            <StyleConsumer>
-                {({ palette, defaultStyles }) => {
-                    const styles = getStyles(palette);
-                    return (
-                        <FormBase
-                            formFields={formFields}
-                            styleFromInit={styleFromInit}
-                            buttonLabel={"SIGN IN"}
-                            onSuccess={onSuccess}
-                            callAPI={callAPI}
-                            showLabels={true}
-                            header={
-                                <Fragment>
-                                    <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
-                                        Sign In
-                                    </div>
-                                    <div
-                                        className="headerSubtitle"
-                                        css={[styles.headerSubTitle, styleFromInit.headerSubtitle]}>
+            <StyleProvider styleFromInit={styleFromInit}>
+                <StyleConsumer>
+                    {styles => {
+                        const componentStyle = getStyles(styles.palette as NormalisedPalette);
+                        return (
+                            <FormBase
+                                formFields={formFields}
+                                buttonLabel={"SIGN IN"}
+                                onSuccess={onSuccess}
+                                callAPI={callAPI}
+                                showLabels={true}
+                                header={
+                                    <Fragment>
                                         <div
-                                            className="secondaryText"
-                                            css={[defaultStyles.secondaryText, styleFromInit.secondaryText]}>
-                                            Not registered yet?
-                                            <span
-                                                className="link"
-                                                onClick={signUpClicked}
-                                                css={[defaultStyles.link, styleFromInit.link]}>
-                                                Sign Up
-                                            </span>
+                                            className="headerTitle"
+                                            css={[componentStyle.headerTitle, styles.headerTitle]}>
+                                            Sign In
                                         </div>
+                                        <div
+                                            className="headerSubtitle"
+                                            css={[componentStyle.headerSubTitle, styles.headerSubtitle]}>
+                                            <div className="secondaryText" css={styles.secondaryText}>
+                                                Not registered yet?
+                                                <span className="link" onClick={signUpClicked} css={styles.link}>
+                                                    Sign Up
+                                                </span>
+                                            </div>
+                                        </div>
+                                        <div className="divider" css={styles.divider}></div>
+                                    </Fragment>
+                                }
+                                footer={
+                                    <div
+                                        className="link secondaryText forgotPasswordLink"
+                                        css={[
+                                            styles.link,
+                                            styles.secondaryText,
+                                            componentStyle.forgotPasswordLink,
+                                            styles.forgotPasswordLink
+                                        ]}
+                                        onClick={forgotPasswordClick}>
+                                        Forgot password?
                                     </div>
-                                    <div className="divider" css={[defaultStyles.divider, styleFromInit.divider]}></div>
-                                </Fragment>
-                            }
-                            footer={
-                                <div
-                                    className="link secondaryText forgotPasswordLink"
-                                    css={[
-                                        defaultStyles.link,
-                                        defaultStyles.secondaryText,
-                                        styles.forgotPasswordLink,
-                                        styleFromInit.link,
-                                        styleFromInit.secondaryText,
-                                        styleFromInit.forgotPasswordLink
-                                    ]}
-                                    onClick={forgotPasswordClick}>
-                                    Forgot password?
-                                </div>
-                            }
-                        />
-                    );
-                }}
-            </StyleConsumer>
+                                }
+                            />
+                        );
+                    }}
+                </StyleConsumer>
+            </StyleProvider>
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/components/signInAndUp/themes/default/SignIn.tsx
+++ b/lib/ts/recipe/emailpassword/components/signInAndUp/themes/default/SignIn.tsx
@@ -26,6 +26,7 @@ import { jsx } from "@emotion/core";
 
 import FormBase from "../../../library/FormBase";
 import { Styles } from "../../../../../../types";
+import { StyleConsumer } from "../../../../styles/styleContext";
 
 /*
  * Styles.
@@ -81,58 +82,64 @@ export default class SignInTheme extends PureComponent<SignInThemeProps, { formF
      */
 
     render(): JSX.Element {
-        const { signUpClicked, forgotPasswordClick, defaultStyles, palette, onSuccess, callAPI } = this.props;
+        const { signUpClicked, forgotPasswordClick, onSuccess, callAPI } = this.props;
         const styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
         const { formFields } = this.state;
-        const styles = getStyles(palette);
 
         return (
-            <FormBase
-                formFields={formFields}
-                defaultStyles={defaultStyles}
-                styleFromInit={styleFromInit}
-                palette={palette}
-                buttonLabel={"SIGN IN"}
-                onSuccess={onSuccess}
-                callAPI={callAPI}
-                showLabels={true}
-                header={
-                    <Fragment>
-                        <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
-                            Sign In
-                        </div>
-                        <div className="headerSubtitle" css={[styles.headerSubTitle, styleFromInit.headerSubtitle]}>
-                            <div
-                                className="secondaryText"
-                                css={[defaultStyles.secondaryText, styleFromInit.secondaryText]}>
-                                Not registered yet?
-                                <span
-                                    className="link"
-                                    onClick={signUpClicked}
-                                    css={[defaultStyles.link, styleFromInit.link]}>
-                                    Sign Up
-                                </span>
-                            </div>
-                        </div>
-                        <div className="divider" css={[defaultStyles.divider, styleFromInit.divider]}></div>
-                    </Fragment>
-                }
-                footer={
-                    <div
-                        className="link secondaryText forgotPasswordLink"
-                        css={[
-                            defaultStyles.link,
-                            defaultStyles.secondaryText,
-                            styles.forgotPasswordLink,
-                            styleFromInit.link,
-                            styleFromInit.secondaryText,
-                            styleFromInit.forgotPasswordLink
-                        ]}
-                        onClick={forgotPasswordClick}>
-                        Forgot password?
-                    </div>
-                }
-            />
+            <StyleConsumer>
+                {({ palette, defaultStyles }) => {
+                    const styles = getStyles(palette);
+                    return (
+                        <FormBase
+                            formFields={formFields}
+                            styleFromInit={styleFromInit}
+                            buttonLabel={"SIGN IN"}
+                            onSuccess={onSuccess}
+                            callAPI={callAPI}
+                            showLabels={true}
+                            header={
+                                <Fragment>
+                                    <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
+                                        Sign In
+                                    </div>
+                                    <div
+                                        className="headerSubtitle"
+                                        css={[styles.headerSubTitle, styleFromInit.headerSubtitle]}>
+                                        <div
+                                            className="secondaryText"
+                                            css={[defaultStyles.secondaryText, styleFromInit.secondaryText]}>
+                                            Not registered yet?
+                                            <span
+                                                className="link"
+                                                onClick={signUpClicked}
+                                                css={[defaultStyles.link, styleFromInit.link]}>
+                                                Sign Up
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <div className="divider" css={[defaultStyles.divider, styleFromInit.divider]}></div>
+                                </Fragment>
+                            }
+                            footer={
+                                <div
+                                    className="link secondaryText forgotPasswordLink"
+                                    css={[
+                                        defaultStyles.link,
+                                        defaultStyles.secondaryText,
+                                        styles.forgotPasswordLink,
+                                        styleFromInit.link,
+                                        styleFromInit.secondaryText,
+                                        styleFromInit.forgotPasswordLink
+                                    ]}
+                                    onClick={forgotPasswordClick}>
+                                    Forgot password?
+                                </div>
+                            }
+                        />
+                    );
+                }}
+            </StyleConsumer>
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/components/signInAndUp/themes/default/SignUp.tsx
+++ b/lib/ts/recipe/emailpassword/components/signInAndUp/themes/default/SignUp.tsx
@@ -24,6 +24,7 @@ import { CSSObject } from "@emotion/serialize/types/index";
 import { jsx } from "@emotion/core";
 import { openExternalLink } from "../../../../../../utils";
 import FormBase from "../../../library/FormBase";
+import { StyleConsumer } from "../../../../styles/styleContext";
 
 /*
  * Styles.
@@ -86,76 +87,75 @@ export default class SignUpTheme extends PureComponent<SignUpThemeProps, { formF
      * Render.
      */
     render(): JSX.Element {
-        const {
-            privacyPolicyLink,
-            termsAndConditionsLink,
-            signInClicked,
-            defaultStyles,
-            palette,
-            onSuccess,
-            callAPI
-        } = this.props;
+        const { privacyPolicyLink, termsAndConditionsLink, signInClicked, onSuccess, callAPI } = this.props;
         const { formFields } = this.state;
         const styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
-        const styles = getStyles(palette);
 
         return (
-            <FormBase
-                formFields={formFields}
-                defaultStyles={defaultStyles}
-                styleFromInit={styleFromInit}
-                palette={palette}
-                buttonLabel={"SIGN UP"}
-                onSuccess={onSuccess}
-                callAPI={callAPI}
-                showLabels={true}
-                header={
-                    <Fragment>
-                        <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
-                            Sign Up
-                        </div>
-                        <div className="headerSubtitle" css={[styles.headerSubTitle, styleFromInit.headerSubtitle]}>
-                            <div
-                                className="secondaryText"
-                                css={[defaultStyles.secondaryText, styleFromInit.secondaryText]}>
-                                Already have an account?
-                                <span
-                                    className="link"
-                                    onClick={signInClicked}
-                                    css={[defaultStyles.link, styleFromInit.link]}>
-                                    Sign In
-                                </span>
-                            </div>
-                        </div>
-                        <div className="divider" css={[defaultStyles.divider, styleFromInit.divider]}></div>
-                    </Fragment>
-                }
-                footer={
-                    <div
-                        className="privacyPolicyAndTermsAndConditions secondaryText"
-                        css={[
-                            defaultStyles.secondaryText,
-                            styles.privacyPolicyAndTermsAndConditions,
-                            styleFromInit.secondaryText,
-                            styleFromInit.privacyPolicyAndTermsAndConditions
-                        ]}>
-                        By signin up, you agree to our
-                        <span
-                            className="link"
-                            css={[defaultStyles.link, styleFromInit.link]}
-                            onClick={() => openExternalLink(termsAndConditionsLink)}>
-                            Terms of Service
-                        </span>
-                        and
-                        <span
-                            className="link"
-                            css={[defaultStyles.link, styleFromInit.link]}
-                            onClick={() => openExternalLink(privacyPolicyLink)}>
-                            Privacy Policy
-                        </span>
-                    </div>
-                }
-            />
+            <StyleConsumer>
+                {({ defaultStyles, palette }) => {
+                    const styles = getStyles(palette);
+
+                    return (
+                        <FormBase
+                            formFields={formFields}
+                            styleFromInit={styleFromInit}
+                            buttonLabel={"SIGN UP"}
+                            onSuccess={onSuccess}
+                            callAPI={callAPI}
+                            showLabels={true}
+                            header={
+                                <Fragment>
+                                    <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
+                                        Sign Up
+                                    </div>
+                                    <div
+                                        className="headerSubtitle"
+                                        css={[styles.headerSubTitle, styleFromInit.headerSubtitle]}>
+                                        <div
+                                            className="secondaryText"
+                                            css={[defaultStyles.secondaryText, styleFromInit.secondaryText]}>
+                                            Already have an account?
+                                            <span
+                                                className="link"
+                                                onClick={signInClicked}
+                                                css={[defaultStyles.link, styleFromInit.link]}>
+                                                Sign In
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <div className="divider" css={[defaultStyles.divider, styleFromInit.divider]}></div>
+                                </Fragment>
+                            }
+                            footer={
+                                <div
+                                    className="privacyPolicyAndTermsAndConditions secondaryText"
+                                    css={[
+                                        defaultStyles.secondaryText,
+                                        styles.privacyPolicyAndTermsAndConditions,
+                                        styleFromInit.secondaryText,
+                                        styleFromInit.privacyPolicyAndTermsAndConditions
+                                    ]}>
+                                    By signin up, you agree to our
+                                    <span
+                                        className="link"
+                                        css={[defaultStyles.link, styleFromInit.link]}
+                                        onClick={() => openExternalLink(termsAndConditionsLink)}>
+                                        Terms of Service
+                                    </span>
+                                    and
+                                    <span
+                                        className="link"
+                                        css={[defaultStyles.link, styleFromInit.link]}
+                                        onClick={() => openExternalLink(privacyPolicyLink)}>
+                                        Privacy Policy
+                                    </span>
+                                </div>
+                            }
+                        />
+                    );
+                }}
+            </StyleConsumer>
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/components/signInAndUp/themes/default/SignUp.tsx
+++ b/lib/ts/recipe/emailpassword/components/signInAndUp/themes/default/SignUp.tsx
@@ -24,7 +24,7 @@ import { CSSObject } from "@emotion/serialize/types/index";
 import { jsx } from "@emotion/core";
 import { openExternalLink } from "../../../../../../utils";
 import FormBase from "../../../library/FormBase";
-import { StyleConsumer } from "../../../../styles/styleContext";
+import { StyleConsumer, StyleProvider } from "../../../../styles/styleContext";
 
 /*
  * Styles.
@@ -87,75 +87,78 @@ export default class SignUpTheme extends PureComponent<SignUpThemeProps, { formF
      * Render.
      */
     render(): JSX.Element {
-        const { privacyPolicyLink, termsAndConditionsLink, signInClicked, onSuccess, callAPI } = this.props;
+        const {
+            privacyPolicyLink,
+            termsAndConditionsLink,
+            styleFromInit,
+            signInClicked,
+            onSuccess,
+            callAPI
+        } = this.props;
         const { formFields } = this.state;
-        const styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
-
+        console.log(styleFromInit);
         return (
-            <StyleConsumer>
-                {({ defaultStyles, palette }) => {
-                    const styles = getStyles(palette);
+            <StyleProvider styleFromInit={styleFromInit}>
+                <StyleConsumer>
+                    {styles => {
+                        const componentStyles = getStyles(styles.palette as NormalisedPalette);
 
-                    return (
-                        <FormBase
-                            formFields={formFields}
-                            styleFromInit={styleFromInit}
-                            buttonLabel={"SIGN UP"}
-                            onSuccess={onSuccess}
-                            callAPI={callAPI}
-                            showLabels={true}
-                            header={
-                                <Fragment>
-                                    <div className="headerTitle" css={[styles.headerTitle, styleFromInit.headerTitle]}>
-                                        Sign Up
-                                    </div>
-                                    <div
-                                        className="headerSubtitle"
-                                        css={[styles.headerSubTitle, styleFromInit.headerSubtitle]}>
+                        return (
+                            <FormBase
+                                formFields={formFields}
+                                buttonLabel={"SIGN UP"}
+                                onSuccess={onSuccess}
+                                callAPI={callAPI}
+                                showLabels={true}
+                                header={
+                                    <Fragment>
                                         <div
-                                            className="secondaryText"
-                                            css={[defaultStyles.secondaryText, styleFromInit.secondaryText]}>
-                                            Already have an account?
-                                            <span
-                                                className="link"
-                                                onClick={signInClicked}
-                                                css={[defaultStyles.link, styleFromInit.link]}>
-                                                Sign In
-                                            </span>
+                                            className="headerTitle"
+                                            css={[componentStyles.headerTitle, styles.headerTitle]}>
+                                            Sign Up
                                         </div>
+                                        <div
+                                            className="headerSubtitle"
+                                            css={[componentStyles.headerSubTitle, styles.headerSubtitle]}>
+                                            <div className="secondaryText" css={styles.secondaryText}>
+                                                Already have an account?
+                                                <span className="link" onClick={signInClicked} css={styles.link}>
+                                                    Sign In
+                                                </span>
+                                            </div>
+                                        </div>
+                                        <div className="divider" css={styles.divider}></div>
+                                    </Fragment>
+                                }
+                                footer={
+                                    <div
+                                        className="secondaryText privacyPolicyAndTermsAndConditions"
+                                        css={[
+                                            componentStyles.privacyPolicyAndTermsAndConditions,
+                                            styles.secondaryText,
+                                            styles.privacyPolicyAndTermsAndConditions
+                                        ]}>
+                                        By signin up, you agree to our
+                                        <span
+                                            className="link"
+                                            css={styles.link}
+                                            onClick={() => openExternalLink(termsAndConditionsLink)}>
+                                            Terms of Service
+                                        </span>
+                                        and
+                                        <span
+                                            className="link"
+                                            css={styles.link}
+                                            onClick={() => openExternalLink(privacyPolicyLink)}>
+                                            Privacy Policy
+                                        </span>
                                     </div>
-                                    <div className="divider" css={[defaultStyles.divider, styleFromInit.divider]}></div>
-                                </Fragment>
-                            }
-                            footer={
-                                <div
-                                    className="privacyPolicyAndTermsAndConditions secondaryText"
-                                    css={[
-                                        defaultStyles.secondaryText,
-                                        styles.privacyPolicyAndTermsAndConditions,
-                                        styleFromInit.secondaryText,
-                                        styleFromInit.privacyPolicyAndTermsAndConditions
-                                    ]}>
-                                    By signin up, you agree to our
-                                    <span
-                                        className="link"
-                                        css={[defaultStyles.link, styleFromInit.link]}
-                                        onClick={() => openExternalLink(termsAndConditionsLink)}>
-                                        Terms of Service
-                                    </span>
-                                    and
-                                    <span
-                                        className="link"
-                                        css={[defaultStyles.link, styleFromInit.link]}
-                                        onClick={() => openExternalLink(privacyPolicyLink)}>
-                                        Privacy Policy
-                                    </span>
-                                </div>
-                            }
-                        />
-                    );
-                }}
-            </StyleConsumer>
+                                }
+                            />
+                        );
+                    }}
+                </StyleConsumer>
+            </StyleProvider>
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/styles/styleContext.tsx
+++ b/lib/ts/recipe/emailpassword/styles/styleContext.tsx
@@ -12,42 +12,27 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+import React from "react";
+import EmailPassword from "../emailPassword";
+import { defaultPalette, getDefaultStyles } from "./styles";
 
-/*
- * Imports.
- */
+const StyleContext = React.createContext({
+    palette: defaultPalette,
+    defaultStyles: getDefaultStyles(defaultPalette)
+});
 
-/** @jsx jsx */
-import { jsx } from "@emotion/core";
-import * as React from "react";
-import { CSSObject } from "@emotion/serialize/types/index";
-import { StyleConsumer } from "../../styles/styleContext";
-
-/*
- * Props.
- */
-
-type InputErrorProps = {
-    style: CSSObject;
-    error: string;
-};
-
-/*
- * Component.
- */
-
-export default function InputError({ style, error }: InputErrorProps): JSX.Element {
-    /*
-     * Render.
-     */
+export function StyleProvider({ children }: { children: JSX.Element }): JSX.Element {
+    const palette = EmailPassword.getInstanceOrThrow().getConfig().palette;
 
     return (
-        <StyleConsumer>
-            {({ defaultStyles }) => (
-                <div className="inputErrorMessage" css={[defaultStyles.inputErrorMessage, style]}>
-                    {error}
-                </div>
-            )}
-        </StyleConsumer>
+        <StyleContext.Provider
+            value={{
+                palette,
+                defaultStyles: getDefaultStyles(palette)
+            }}>
+            {children}
+        </StyleContext.Provider>
     );
 }
+
+export const StyleConsumer = StyleContext.Consumer;

--- a/lib/ts/recipe/emailpassword/styles/styles.ts
+++ b/lib/ts/recipe/emailpassword/styles/styles.ts
@@ -122,14 +122,16 @@ export function getDefaultStyles(palette: NormalisedPalette): NormalisedDefaultS
         inputAdornment: {
             float: "right",
             left: "-2%",
-            top: "-33px",
+            top: "-24px",
             position: "relative",
             borderRadius: "12px",
             display: "flex",
-            alignItems: "center"
+            alignItems: "center",
+            height: "0px"
         },
 
         inputErrorMessage: {
+            paddingTop: "10px",
             color: palette.colors.error,
             lineHeight: "24px",
             fontWeight: 400,

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -675,8 +675,6 @@ export type FormBaseProps = {
     callAPI: (
         fields: APIFormField[]
     ) => Promise<SignInThemeResponse | SignUpThemeResponse | SubmitNewPasswordThemeResponse | EnterEmailThemeResponse>;
-
-    styleFromInit?: Styles;
 };
 
 export type SignUpAPI = (requestJson: RequestJson, headers: HeadersInit) => Promise<SignUpAPIResponse>;

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -301,16 +301,6 @@ type ThemeBaseProps = {
     formFields: FormFieldThemeProps[];
 
     /*
-     * Sign up form props.
-     */
-    defaultStyles: NormalisedDefaultStyles;
-
-    /*
-     * Sign up form props.
-     */
-    palette: NormalisedPalette;
-
-    /*
      * Called on successful signin/signup/resetpassword.
      */
     onSuccess?: () => void;
@@ -685,10 +675,6 @@ export type FormBaseProps = {
     callAPI: (
         fields: APIFormField[]
     ) => Promise<SignInThemeResponse | SignUpThemeResponse | SubmitNewPasswordThemeResponse | EnterEmailThemeResponse>;
-
-    defaultStyles: NormalisedDefaultStyles;
-
-    palette: NormalisedPalette;
 
     styleFromInit?: Styles;
 };

--- a/test/react-test-app/public/index.css
+++ b/test/react-test-app/public/index.css
@@ -40,35 +40,35 @@ a {
   margin: 0 auto;
 }
 
-.headings {
+.headingTitle {
   position: relative;
   margin: 90px auto 70px;
   cursor: pointer;
 }
 
-.headings > span {
+.headingTitle > span {
   color: rgba(255, 255, 255, 0.7);
   padding-bottom: 10px;
   border-bottom: solid 2px rgba(17, 97, 237, 0);
   display: inline-block;
 }
 
-.headings > span:first-child {
+.headingTitle > span:first-child {
   margin-left: 20px;
   margin-right: 45px;
 }
 
-.headings > span:hover {
+.headingTitle > span:hover {
   color: rgba(255, 255, 255, 1);
 }
 
-.headings > span.active {
+.headingTitle > span.active {
   color: rgba(255, 255, 255, 1);
   border-bottom: solid 4px #aaf0d1;
   box-shadow: 0 5px 5px -5px #1d2124;
 }
 
-.headings > a span {
+.headingTitle > a span {
   font-size: 1.4rem;
   letter-spacing: 1px;
 }
@@ -233,4 +233,21 @@ footer .fp a:hover {
 
 .terms {
   color: #b7b7b7;
+}
+
+.progress {
+  width: 100%;
+  height: 20px;
+  margin-top: 10px;
+  border-radius: 8px;
+  background-color: #828282
+}
+
+.progress-bar {
+  color: #fff;
+  border-radius: 8px;
+  height: 20px;
+  float: left;
+  text-align: center;
+  justify-content: center;
 }

--- a/test/react-test-app/src/AppWithReactDomRouter.js
+++ b/test/react-test-app/src/AppWithReactDomRouter.js
@@ -84,7 +84,7 @@ function AppWithReactDomRouter() {
 
               />
             </Route>
-            <Route path="/custom">
+            <Route path="/custom-theme">
               <SignInAndUp >
                 <SignInAndUpCustom/>
               </SignInAndUp >

--- a/test/react-test-app/src/themes/signInAndUp.js
+++ b/test/react-test-app/src/themes/signInAndUp.js
@@ -1,5 +1,6 @@
 import React from "react";
 import {useState, useRef} from "react";
+import {StyleConsumer} from "supertokens-auth-react/lib/build/recipe/emailpassword/styles/styleContext"
 
 /*
  * SignInAndUpTheme
@@ -19,39 +20,50 @@ export default function SignInAndUp(props){
      * Render.
      */
      return (
-        <div className="root">
-            <div className="container-shadow"></div>
-            <div className="container">
-                <div className="wrap">
-                    <div className="headings">
-                        <span id="sign-up" className={!isSignIn ? 'active' : ''} onClick={() => setSignIn(false)}>SIGN UP</span>
-                        <span id="sign-in" className={isSignIn ? 'active' : ''} onClick={() => setSignIn(true)}>SIGN IN</span>
+         /*
+          * Use StyleConsumer to access user defined styling.
+          * React does not support media queries as defined by the defaultStyles
+          * as well as mouse event specific css.
+          * For a more complete integration, we encourage you to use emotion.sh to define your styling
+          * if you would like to create a generic SuperTokens theme.
+          */
+         <StyleConsumer>
+             {({defaultStyles, palette}) => (
+                <div className="root" style={defaultStyles.root} >
+                    <div className="container-shadow"></div>
+                    <div className="container">
+                        <div className="wrap" style={defaultStyles.wrap}>
+                            <div className="headingTitle">
+                                <span id="sign-up" style={{color: palette.colors.textPrimary}} className={!isSignIn ? 'active' : ''} onClick={() => setSignIn(false)}>SIGN UP</span>
+                                <span id="sign-in" style={{color: palette.colors.textPrimary}} className={isSignIn ? 'active' : ''} onClick={() => setSignIn(true)}>SIGN IN</span>
+                            </div>
+
+                            {isSignIn && <SignIn {...signInForm} />}
+                            {!isSignIn && <SignUp {...signUpForm}  />}
+                        </div>
                     </div>
 
-                    {isSignIn && <SignIn {...signInForm} />}
-                    {!isSignIn && <SignUp {...signUpForm}  />}
+                    {
+                    /* Because this component is rendered in a Shadow DOM
+                    * https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM
+                    * you must use the <link> html tag to include your styling in encapsulation.
+                    */
+                    }
+                    <link
+                        href="./index.css"
+                        rel="stylesheet"
+                        type="text/css"
+                    />
                 </div>
-            </div>
-
-            {
-            /* Because this component is rendered in a Shadow DOM
-             * https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM
-             * you must use the <link> html tag to include your styling in encapsulation.
-             */
-            }
-            <link
-                href="./index.css"
-                rel="stylesheet"
-                type="text/css"
-            />
-        </div>
+             )}
+         </StyleConsumer>
     )
 }
 
 
 function SignIn (props) {
     const {
-        // styleFromInit,
+        styleFromInit,
         onSuccess,
         resetPasswordURL,
         forgotPasswordClick,
@@ -91,7 +103,7 @@ function SignIn (props) {
         }
 
         // Otherwise, alert the general message error.
-        alert(result.message);
+        alert(`General Error ${result.message}`);
     }
 
     const onResetPassword = async () => {
@@ -104,20 +116,50 @@ function SignIn (props) {
     }
 
     return (
-        <div>
-            <form onSubmit={signIn}>
-                <label>{formFields[0].label}</label>
-                <input ref={emailRef}  type="text" name="email" placeholder={formFields[0].placeholder}/>
-                <label>{formFields[1].label}</label>
-                <input ref={passwordRef} id="password" type="password" name="password"  placeholder={formFields[1].placeholder} />
-                <input type="submit" className="button" name="submit" value="Create account"/>
-            </form>
-    
-            <footer>
-                <div className="hr"></div>
-                <div className="fp"><span className="link" onClick={onResetPassword}>Forgot Password?</span></div>
-            </footer>
-        </div>
+        <StyleConsumer>
+            {({defaultStyles, palette}) => (
+                <div>
+                    <form onSubmit={signIn}>
+                        <label>{formFields[0].label}</label>
+                        <input 
+                            /*
+                             * Allow the user to overwrite default styles for input.
+                             * If you are going to provide a generic SuperTokens theme,
+                             * you should use this pattern everywhere.
+                             */
+                            style={{
+                                ...defaultStyles.input,
+                                color: palette.colors.textPrimary,
+                                ...styleFromInit.input}
+                            }
+                            ref={emailRef}  type="text" name="email" placeholder={formFields[0].placeholder}
+                        />
+                        <label>{formFields[1].label}</label>
+                        <input 
+                            
+                            style={{
+                                ...defaultStyles.input,
+                                color: palette.colors.textPrimary,
+                                ...styleFromInit.input,
+                                }
+                            }
+                            ref={passwordRef} id="password" type="password" name="password"  placeholder={formFields[1].placeholder}
+                        />
+                        <input 
+                            style={{
+                                ...defaultStyles.button,
+                                ...styleFromInit.button}
+                            }
+                            type="submit" name="submit" value="Log In"/>
+                    </form>
+            
+                    <footer>
+                        <div className="hr"></div>
+                        <div className="fp"><span className="link" onClick={onResetPassword}>Forgot Password?</span></div>
+                    </footer>
+                </div>
+            )}
+        </StyleConsumer>
     )
 }
 
@@ -136,13 +178,15 @@ function SignUp (props) {
     /*
     * Inputs ref
     */
+   const [password, setPassword] = useState("");
+   const [email, setEmail] = useState("");
     const emailRef = useRef();
     const passwordRef = useRef();
     
     const signUp = async (e) => {
         e.preventDefault();
-        formFields[0].value = emailRef.current.value;
-        formFields[1].value = passwordRef.current.value;
+        formFields[0].value = email;
+        formFields[1].value = password;
         const result = await callAPI(formFields);
 
         if (result.status === "OK") {
@@ -159,7 +203,7 @@ function SignUp (props) {
         }
 
         // Otherwise, alert the general message error.
-        alert(result.message);
+        alert("General Error", result.message);
     }
 
 
@@ -174,12 +218,103 @@ function SignUp (props) {
                     */
                 }
                 <label>{formFields[0].label}</label>
-                <input ref={emailRef}  type="text" name="email" placeholder={formFields[0].placeholder}/>
+                <input ref={emailRef}  onChange={() => {setEmail(emailRef.current.value)}}  type="text" name="email" placeholder={formFields[0].placeholder}/>
                 <label>{formFields[1].label}</label>
-                <input ref={passwordRef} id="password" type="password" name="password"  placeholder={formFields[1].placeholder} />
+                <input ref={passwordRef} onChange={() => {setPassword(passwordRef.current.value)}} id="password" type="password" name="password"  placeholder={formFields[1].placeholder} />
+
+                {/*
+                 * Adding custom behaviour to your Sign Up widget.
+                */}
+                <PasswordStrengthMeter password={password} />
                 <input type="submit" className="button" name="submit" value="Create account"/>
             </form>
             <div className="terms">By signing up, you agree to our <a target="_blank" rel="noopener noreferrer" href={termsAndConditionsLink}>terms and conditions</a> and <a target="_blank" rel="noopener noreferrer" href={privacyPolicyLink}>privacy policies</a></div>
         </div>
     )
+}
+
+function PasswordStrengthMeter ({password}) {
+    let progressBar;
+    if (password === undefined) {
+        progressBar = <div/>;
+    } else {
+        const passwordStrength = checkPassStrength(password);
+        if (passwordStrength === undefined) {
+            progressBar = <div/>;
+        } else {
+            progressBar = <div class="progress-bar" style={{
+                width: passwordStrength.width,
+                backgroundColor: passwordStrength.backgroundColor
+                }}
+            >
+                {passwordStrength.value}
+            </div>
+        }
+    }
+
+
+    return (
+        <div class="progress">
+            {progressBar}
+        </div>
+    );
+}
+
+
+/*
+* https://stackoverflow.com/questions/948172/password-strength-meter
+*/
+
+function checkPassStrength(pass) {
+    var score = scorePassword(pass);
+    if (score > 80)
+        return {
+            width: "100%",
+            backgroundColor: "green",
+            value:"strong"
+        };
+    if (score > 60)
+        return {
+            width: "60%",
+            backgroundColor: "orange",
+            value: "good"
+        }
+    if (score >= 10) {
+        return {
+            width: "30%",
+            backgroundColor: "red",
+            value: "weak"
+        }
+    }
+
+    return undefined;
+}
+
+function scorePassword(pass) {
+    let score = 0;
+    if (!pass)
+        return score;
+
+    // award every unique letter until 5 repetitions
+    let letters = {};
+    for (var i=0; i<pass.length; i++) {
+        letters[pass[i]] = (letters[pass[i]] || 0) + 1;
+        score += 5.0 / letters[pass[i]];
+    }
+
+    // bonus points for mixing it up
+    var variations = {
+        digits: /\d/.test(pass),
+        lower: /[a-z]/.test(pass),
+        upper: /[A-Z]/.test(pass),
+        nonWords: /\W/.test(pass),
+    }
+
+    var variationCount = 0;
+    for (var check in variations) {
+        variationCount += (variations[check] === true) ? 1 : 0;
+    }
+    score += (variationCount - 1) * 10;
+
+    return parseInt(score);
 }

--- a/test/react-test-app/src/themes/signInAndUp.js
+++ b/test/react-test-app/src/themes/signInAndUp.js
@@ -1,6 +1,6 @@
 import React from "react";
 import {useState, useRef} from "react";
-import {StyleConsumer} from "supertokens-auth-react/lib/build/recipe/emailpassword/styles/styleContext"
+import {StyleConsumer, StyleProvider} from "supertokens-auth-react/lib/build/recipe/emailpassword/styles/styleContext"
 
 /*
  * SignInAndUpTheme
@@ -28,14 +28,14 @@ export default function SignInAndUp(props){
           * if you would like to create a generic SuperTokens theme.
           */
          <StyleConsumer>
-             {({defaultStyles, palette}) => (
-                <div className="root" style={defaultStyles.root} >
+             {styles => (
+                <div className="root" style={styles.root} >
                     <div className="container-shadow"></div>
                     <div className="container">
-                        <div className="wrap" style={defaultStyles.wrap}>
+                        <div className="wrap" style={styles.wrap}>
                             <div className="headingTitle">
-                                <span id="sign-up" style={{color: palette.colors.textPrimary}} className={!isSignIn ? 'active' : ''} onClick={() => setSignIn(false)}>SIGN UP</span>
-                                <span id="sign-in" style={{color: palette.colors.textPrimary}} className={isSignIn ? 'active' : ''} onClick={() => setSignIn(true)}>SIGN IN</span>
+                                <span id="sign-up" style={{color: styles.palette.colors.textPrimary}} className={!isSignIn ? 'active' : ''} onClick={() => setSignIn(false)}>SIGN UP</span>
+                                <span id="sign-in" style={{color: styles.palette.colors.textPrimary}} className={isSignIn ? 'active' : ''} onClick={() => setSignIn(true)}>SIGN IN</span>
                             </div>
 
                             {isSignIn && <SignIn {...signInForm} />}
@@ -116,50 +116,47 @@ function SignIn (props) {
     }
 
     return (
-        <StyleConsumer>
-            {({defaultStyles, palette}) => (
-                <div>
-                    <form onSubmit={signIn}>
-                        <label>{formFields[0].label}</label>
-                        <input 
-                            /*
-                             * Allow the user to overwrite default styles for input.
-                             * If you are going to provide a generic SuperTokens theme,
-                             * you should use this pattern everywhere.
-                             */
-                            style={{
-                                ...defaultStyles.input,
-                                color: palette.colors.textPrimary,
-                                ...styleFromInit.input}
-                            }
-                            ref={emailRef}  type="text" name="email" placeholder={formFields[0].placeholder}
-                        />
-                        <label>{formFields[1].label}</label>
-                        <input 
-                            
-                            style={{
-                                ...defaultStyles.input,
-                                color: palette.colors.textPrimary,
-                                ...styleFromInit.input,
+        <StyleProvider styleFromInit={styleFromInit}>
+            <StyleConsumer>
+                {styles => (
+                    <div>
+                        <form onSubmit={signIn}>
+                            <label>{formFields[0].label}</label>
+                            <input 
+                                /*
+                                * Allow the user to overwrite default styles for input.
+                                * If you are going to provide a generic SuperTokens theme,
+                                * you should use this pattern everywhere.
+                                */
+                                style={{
+                                    color: styles.palette.colors.textPrimary,
+                                    ...styles.input}
                                 }
-                            }
-                            ref={passwordRef} id="password" type="password" name="password"  placeholder={formFields[1].placeholder}
-                        />
-                        <input 
-                            style={{
-                                ...defaultStyles.button,
-                                ...styleFromInit.button}
-                            }
-                            type="submit" name="submit" value="Log In"/>
-                    </form>
-            
-                    <footer>
-                        <div className="hr"></div>
-                        <div className="fp"><span className="link" onClick={onResetPassword}>Forgot Password?</span></div>
-                    </footer>
-                </div>
-            )}
-        </StyleConsumer>
+                                ref={emailRef}  type="text" name="email" placeholder={formFields[0].placeholder}
+                            />
+                            <label>{formFields[1].label}</label>
+                            <input 
+                                
+                                style={{
+                                    color: styles.palette.colors.textPrimary,
+                                    ...styles.input,
+                                    }
+                                }
+                                ref={passwordRef} id="password" type="password" name="password"  placeholder={formFields[1].placeholder}
+                            />
+                            <input 
+                                style={styles.button}
+                                type="submit" name="submit" value="Log In"/>
+                        </form>
+                
+                        <footer>
+                            <div className="hr"></div>
+                            <div className="fp"><span className="link" onClick={onResetPassword}>Forgot Password?</span></div>
+                        </footer>
+                    </div>
+                )}
+            </StyleConsumer>
+        </StyleProvider>
     )
 }
 


### PR DESCRIPTION
# Leverage the CreateContext React API to create a StyleProvider

## What it does

This method helps using styling defined by users from any child components without having to pass down the props to nested components. It reduces the effort of using user defined styles.

## How it works

### Step 1

In `emailpassword/styles/stylesContext.tsx` we create a React context, and export both the provider and the consumer.
We feed the provider with an object containing  the "defaultStyles" and the "palette" as a value.

```tsx
const StyleContext = React.createContext({
    palette: defaultPalette,
    defaultStyles: getDefaultStyles(defaultPalette)
});

export function StyleProvider({ children }: { children: JSX.Element }): JSX.Element {
    const palette = EmailPassword.getInstanceOrThrow().getConfig().palette;

    return (
        <StyleContext.Provider
            value={{
                palette,
                defaultStyles: getDefaultStyles(palette)
            }}>
            {children}
        </StyleContext.Provider>
    );
}
```

### Step 2

In the base components (`SignInAndUp` feature and `ResetPasswordUsingToken` feature), wrap the rendered elements into the `StyleProvider` defined before.

```tsx
render = (): JSX.Element => {
        return (
            <StyleProvider>
                <FeatureWrapper useShadowDom={useShadowDom}>
                    // Component goes here.
                </FeatureWrapper>
            </StyleProvider>
        );
    };
```

### Step 3
In any child components that will need to access the defaultStyles and palette, wrap the rendered elements into the `ThemeConsumer` component that gives "defaultStyles" and "palette" as arguments.
 
Example of the library's `inputError` component:

```tsx
import { StyleConsumer } from "../../styles/styleContext";

export default function InputError({ style, error }: InputErrorProps): JSX.Element {
    return (
        <StyleConsumer>
            {({ defaultStyles }) => (
                <div className="inputErrorMessage" css={[defaultStyles.inputErrorMessage, style]}>
                    {error}
                </div>
            )}
        </StyleConsumer>
    );
}
```

## TODO

 - [ ] Update the docs in Detailed guide to use the StyleConsumer instead of using props in "making your own frontend"
