### PR TITLE
autocomplete email and password

### DIFF
--- a/lib/build/recipe/emailpassword/components/themes/default/library/FormBase.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/library/FormBase.js
@@ -549,6 +549,7 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
                                                 name: field.id,
                                                 placeholder: field.placeholder,
                                                 ref: field.ref,
+                                                autoComplete: field.autoComplete,
                                                 onChange: _this2.handleInputChange,
                                                 hasError: field.error !== undefined,
                                                 validated: field.validated

--- a/lib/build/recipe/emailpassword/components/themes/default/library/input.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/default/library/input.d.ts
@@ -10,10 +10,11 @@ declare type InputProps = {
     validated: boolean;
     type: string;
     name: string;
+    autoComplete?: string;
     hasError: boolean;
     placeholder: string;
     ref: RefObject<any>;
     onChange?: (field: APIFormField) => void;
 };
-declare const _default: React.ForwardRefExoticComponent<Pick<InputProps, "style" | "name" | "type" | "onChange" | "placeholder" | "hasError" | "validated" | "errorStyle" | "adornmentStyle"> & React.RefAttributes<any>>;
+declare const _default: React.ForwardRefExoticComponent<Pick<InputProps, "style" | "name" | "type" | "onChange" | "placeholder" | "autoComplete" | "hasError" | "validated" | "errorStyle" | "adornmentStyle"> & React.RefAttributes<any>>;
 export default _default;

--- a/lib/build/recipe/emailpassword/components/themes/default/library/input.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/library/input.js
@@ -96,6 +96,7 @@ function Input(_ref, ref) {
     var type = _ref.type,
         name = _ref.name,
         hasError = _ref.hasError,
+        autoComplete = _ref.autoComplete,
         onChange = _ref.onChange,
         placeholder = _ref.placeholder,
         validated = _ref.validated;
@@ -123,6 +124,10 @@ function Input(_ref, ref) {
             adornmentType = hasError ? "error" : "success";
         }
 
+        if (autoComplete === undefined) {
+            autoComplete = "off";
+        }
+
         return (0, _core.jsx)(
             "div",
             {
@@ -130,6 +135,7 @@ function Input(_ref, ref) {
                 css: [styles.inputWrapper]
             },
             (0, _core.jsx)("input", {
+                autoComplete: autoComplete,
                 className: "input inputError",
                 css: [styles.input, errorStyle],
                 onFocus: handleChange,

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -182,6 +182,7 @@ export declare type FormFieldState = FormFieldThemeProps & {
     validated: boolean;
     ref: RefObject<HTMLInputElement>;
     showIsRequired?: boolean;
+    autoComplete?: string;
 };
 export declare type EnterEmailThemeState = {
     emailSent?: boolean;

--- a/lib/build/recipe/emailpassword/utils.js
+++ b/lib/build/recipe/emailpassword/utils.js
@@ -146,6 +146,7 @@ function normaliseSignInAndUpFeature(appInfo, config) {
                     _objectSpread({}, field),
                     {},
                     {
+                        autoComplete: "current-password",
                         validate: _validators.defaultLoginPasswordValidator
                     }
                 )
@@ -239,7 +240,8 @@ function getDefaultEmailFormField() {
         label: "Email",
         placeholder: "Email address",
         validate: _validators.defaultEmailValidator,
-        optional: false
+        optional: false,
+        autoComplete: "email"
     };
 }
 
@@ -249,7 +251,8 @@ function getDefaultPasswordFormField() {
         label: "Password",
         placeholder: "Password",
         validate: _validators.defaultPasswordValidator,
-        optional: false
+        optional: false,
+        autoComplete: "new-password"
     };
 }
 
@@ -280,14 +283,16 @@ function normaliseResetPasswordUsingTokenFeature(
                 label: "New password",
                 placeholder: "New password",
                 validate: signUpPasswordFieldValidate,
-                optional: false
+                optional: false,
+                autoComplete: "new-password"
             },
             {
                 id: "confirm-password",
                 label: "Confirm password",
                 placeholder: "Confirm your password",
                 validate: signUpPasswordFieldValidate,
-                optional: false
+                optional: false,
+                autoComplete: "new-password"
             }
         ]
     };

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -69,6 +69,7 @@ export declare type NormalisedFormField = {
     placeholder: string;
     validate: (value: any) => Promise<string | undefined>;
     optional: boolean;
+    autoComplete?: string;
 };
 export declare type ReactComponentClass = ComponentClass | (<T>(props: T) => JSX.Element);
 export declare type WithRouterType = (Component: ReactComponentClass) => ReactComponentClass;

--- a/lib/ts/recipe/emailpassword/components/themes/default/library/FormBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/library/FormBase.tsx
@@ -194,6 +194,7 @@ export default class FormBase extends PureComponent<FormBaseProps, FormBaseState
                                                     name={field.id}
                                                     placeholder={field.placeholder}
                                                     ref={field.ref}
+                                                    autoComplete={field.autoComplete}
                                                     onChange={this.handleInputChange}
                                                     hasError={field.error !== undefined}
                                                     validated={field.validated}

--- a/lib/ts/recipe/emailpassword/components/themes/default/library/input.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/library/input.tsx
@@ -38,6 +38,7 @@ type InputProps = {
     validated: boolean;
     type: string;
     name: string;
+    autoComplete?: string;
     hasError: boolean;
     placeholder: string;
     ref: RefObject<any>;
@@ -49,7 +50,7 @@ type InputProps = {
  */
 
 function Input(
-    { type, name, hasError, onChange, placeholder, validated }: InputProps,
+    { type, name, hasError, autoComplete, onChange, placeholder, validated }: InputProps,
     ref: RefObject<any>
 ): JSX.Element {
     /*
@@ -78,9 +79,14 @@ function Input(
                     adornmentType = hasError ? "error" : "success";
                 }
 
+                if (autoComplete === undefined) {
+                    autoComplete = "off";
+                }
+
                 return (
                     <div className="inputWrapper" css={[styles.inputWrapper]}>
                         <input
+                            autoComplete={autoComplete}
                             className="input inputError"
                             css={[styles.input, errorStyle]}
                             onFocus={handleChange}

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -553,6 +553,11 @@ export type FormFieldState = FormFieldThemeProps & {
      * Has the value already been submitted to its validator.
      */
     showIsRequired?: boolean;
+
+    /*
+     * Autocomplete
+     */
+    autoComplete?: string;
 };
 
 export type EnterEmailThemeState = {

--- a/lib/ts/recipe/emailpassword/utils.ts
+++ b/lib/ts/recipe/emailpassword/utils.ts
@@ -102,6 +102,7 @@ export function normaliseSignInAndUpFeature(
                     ...signInFieldsAccumulator,
                     {
                         ...field,
+                        autoComplete: "current-password",
                         validate: defaultLoginPasswordValidator
                     }
                 ];
@@ -201,7 +202,8 @@ function getDefaultEmailFormField(): NormalisedFormField {
         label: "Email",
         placeholder: "Email address",
         validate: defaultEmailValidator,
-        optional: false
+        optional: false,
+        autoComplete: "email"
     };
 }
 
@@ -211,7 +213,8 @@ function getDefaultPasswordFormField(): NormalisedFormField {
         label: "Password",
         placeholder: "Password",
         validate: defaultPasswordValidator,
-        optional: false
+        optional: false,
+        autoComplete: "new-password"
     };
 }
 
@@ -244,14 +247,16 @@ export function normaliseResetPasswordUsingTokenFeature(
                 label: "New password",
                 placeholder: "New password",
                 validate: signUpPasswordFieldValidate,
-                optional: false
+                optional: false,
+                autoComplete: "new-password"
             },
             {
                 id: "confirm-password",
                 label: "Confirm password",
                 placeholder: "Confirm your password",
                 validate: signUpPasswordFieldValidate,
-                optional: false
+                optional: false,
+                autoComplete: "new-password"
             }
         ]
     };

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -237,6 +237,11 @@ export type NormalisedFormField = {
      * Whether the field is optional or not.
      */
     optional: boolean;
+
+    /*
+     * Autocomplete input.
+     */
+    autoComplete?: string;
 };
 
 export type ReactComponentClass = ComponentClass | (<T>(props: T) => JSX.Element);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -147,10 +147,13 @@ export async function clearBrowserCookies (page) {
 }
 
 export async function clickForgotPasswordLink (page) {
-        // Click on Forgot Password Link.
-        const forgotPasswordLink = await getForgotPasswordLink(page);
-        await forgotPasswordLink.click();
-        await page.waitForNavigation({ waitUntil: "networkidle0" });
+    // Click on Forgot Password Link.
+    const forgotPasswordLink = await getForgotPasswordLink(page);
+    await Promise.all([
+        page.waitForNavigation(),
+        forgotPasswordLink.click()
+    ]);
+
 }
 
 export async function toggleSignInSignUp(page) {

--- a/test/unit/recipe/emailpassword/emailPassword.test.js
+++ b/test/unit/recipe/emailpassword/emailPassword.test.js
@@ -66,6 +66,7 @@ describe("EmailPassword", function() {
                 getDefaultFormFields()[0],
                 {
                     ...getDefaultFormFields()[1],
+                    autoComplete: "current-password",
                     validate: defaultLoginPasswordValidator
                 }
             ]
@@ -135,6 +136,7 @@ describe("EmailPassword", function() {
                 getDefaultFormFields()[0],
                 {
                     ...getDefaultFormFields()[1],
+                    autoComplete: "current-password",
                     validate: defaultLoginPasswordValidator
                 }
             ]
@@ -142,7 +144,7 @@ describe("EmailPassword", function() {
     });
 
     it("Initializing EmailPassword with custom Email for SignUp", async function() {
-        const companyEmailField = {
+        const customEmailField = {
             id: "email",
             label: "Custom Email Label",
             placeholder: "Your custom email",
@@ -152,7 +154,7 @@ describe("EmailPassword", function() {
         EmailPassword.init({
             signInAndUpFeature: {
                 signUpForm: {
-                    formFields: [companyEmailField]
+                    formFields: [customEmailField]
                 }
             }
         })(SuperTokens.getAppInfo());
@@ -161,7 +163,10 @@ describe("EmailPassword", function() {
             EmailPassword.getInstanceOrThrow()
                 .getConfig().signInAndUpFeature.signUpForm.formFields,
             [
-                companyEmailField,
+                {
+                    ...customEmailField,
+                    autoComplete: "email"
+                },
                 getDefaultFormFields()[1]
             ]
         );
@@ -177,9 +182,13 @@ describe("EmailPassword", function() {
                 .getConfig().signInAndUpFeature.signInForm
                 .formFields,
             [
-                companyEmailField,
+                {
+                    ...customEmailField,
+                    autoComplete: "email"
+                },
                 {
                     ...getDefaultFormFields()[1],
+                    autoComplete: "current-password",
                     validate: defaultLoginPasswordValidator
                 }
             ]
@@ -228,9 +237,13 @@ describe("EmailPassword", function() {
                 .getConfig().signInAndUpFeature.signInForm
                 .formFields,
             [
-                customEmailField,
+                {
+                    ...customEmailField,
+                    autoComplete: "email"
+                },
                 {
                     ...getDefaultFormFields()[1],
+                    autoComplete: "current-password",
                     validate: defaultLoginPasswordValidator
                 }
             ]
@@ -280,6 +293,7 @@ describe("EmailPassword", function() {
                 getDefaultFormFields()[0],
                 {
                     ...getDefaultFormFields()[1],
+                    autoComplete: "current-password",
                     validate: defaultLoginPasswordValidator
                 }
             ]
@@ -287,7 +301,7 @@ describe("EmailPassword", function() {
     });
 
     it("Initializing EmailPassword with custom Email for SignUp", async function() {
-        const companyEmailField = {
+        const customEmailField = {
             id: "email",
             label: "Custom Email Label",
             placeholder: "Your custom email",
@@ -297,7 +311,7 @@ describe("EmailPassword", function() {
         EmailPassword.init({
             signInAndUpFeature: {
                 signUpForm: {
-                    formFields: [companyEmailField]
+                    formFields: [customEmailField]
                 }
             }
         })(SuperTokens.getAppInfo());
@@ -306,7 +320,10 @@ describe("EmailPassword", function() {
             EmailPassword.getInstanceOrThrow()
                 .getConfig().signInAndUpFeature.signUpForm.formFields,
             [
-                companyEmailField,
+                {
+                    ...customEmailField,
+                    autoComplete: "email"
+                },
                 getDefaultFormFields()[1]
             ]
         );
@@ -322,9 +339,13 @@ describe("EmailPassword", function() {
                 .getConfig().signInAndUpFeature.signInForm
                 .formFields,
             [
-                companyEmailField,
+                {
+                    ...customEmailField,
+                    autoComplete: "email"
+                },
                 {
                     ...getDefaultFormFields()[1],
+                    autoComplete: "current-password",
                     validate: defaultLoginPasswordValidator
                 }
             ]
@@ -366,7 +387,10 @@ describe("EmailPassword", function() {
                 .getConfig().signInAndUpFeature.signUpForm.formFields,
             [
                 getDefaultFormFields()[0],
-                customPasswordField
+                {
+                    ...customPasswordField,
+                    autoComplete: "new-password"
+                }
             ]
         );
 
@@ -378,6 +402,7 @@ describe("EmailPassword", function() {
                 getDefaultFormFields()[0],
                 {
                     ...customPasswordField,
+                    autoComplete: "current-password",
                     validate: defaultLoginPasswordValidator
                 }
             ]


### PR DESCRIPTION
Add autocomplete for Chrome/Safari/Opera
They do not all support new password but they support "email" and "current-password"

Firefox does not need any indication. Firefox finds out on its own the correct behaviour!