### PR TITLE
0.2.style context refactoring

### DIFF
--- a/lib/build/recipe/emailpassword/components/library/FormBase.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/FormBase.d.ts
@@ -1,8 +1,11 @@
-import * as React from "react";
-import { PureComponent } from "react";
+import React, { PureComponent } from "react";
 import { APIFormField } from "../../../../types";
 import { FormBaseProps, FormBaseState, FormBaseStatus, FormFieldState } from "../../types";
 export default class FormBase extends PureComponent<FormBaseProps, FormBaseState> {
+    static contextType: React.Context<{
+        [x: string]: import("@emotion/serialize").CSSObject;
+        palette: import("../themes/default/types").NormalisedPalette;
+    }>;
     constructor(props: FormBaseProps);
     handleInputFocus: (field: APIFormField) => Promise<void>;
     handleInputBlur: (field: APIFormField) => Promise<void>;

--- a/lib/build/recipe/emailpassword/components/library/FormBase.js
+++ b/lib/build/recipe/emailpassword/components/library/FormBase.js
@@ -5,7 +5,9 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-var React = _interopRequireWildcard(require("react"));
+var _react = _interopRequireWildcard(require("react"));
+
+var _styleContext = _interopRequireDefault(require("../styles/styleContext"));
 
 var _ = require(".");
 
@@ -13,7 +15,9 @@ var _core = require("@emotion/core");
 
 var _constants = require("../../constants");
 
-var _styleContext = require("../styles/styleContext");
+function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : { default: obj };
+}
 
 function _getRequireWildcardCache() {
     if (typeof WeakMap !== "function") return null;
@@ -579,6 +583,7 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
             value: function render() {
                 var _this2 = this;
 
+                var styles = this.context;
                 var _this$props = this.props,
                     header = _this$props.header,
                     footer = _this$props.footer,
@@ -587,104 +592,103 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
                     noValidateOnBlur = _this$props.noValidateOnBlur;
                 var formFields = this.state.formFields;
                 var onInputBlur = noValidateOnBlur === true ? undefined : this.handleInputBlur;
-                return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
-                    return (0, _core.jsx)(
+                return (0, _core.jsx)(
+                    "div",
+                    {
+                        className: "container",
+                        css: styles.container
+                    },
+                    (0, _core.jsx)(
                         "div",
                         {
-                            className: "container",
-                            css: styles.container
+                            className: "row",
+                            css: styles.row
                         },
-                        (0, _core.jsx)(
-                            "div",
-                            {
-                                className: "row",
-                                css: styles.row
-                            },
-                            header,
-                            _this2.state.status === "GENERAL_ERROR" &&
-                                (0, _core.jsx)(
-                                    "div",
-                                    {
-                                        className: "generalError",
-                                        css: styles.generalError
-                                    },
-                                    _this2.state.generalError
-                                ),
+                        header,
+                        this.state.status === "GENERAL_ERROR" &&
                             (0, _core.jsx)(
-                                "form",
+                                "div",
                                 {
-                                    autoComplete: "on",
-                                    noValidate: true,
-                                    onSubmit: _this2.onFormSubmit
+                                    className: "generalError",
+                                    css: styles.generalError
                                 },
-                                formFields.map(function(field) {
-                                    var type = "text"; // If email or password, replace field type.
+                                this.state.generalError
+                            ),
+                        (0, _core.jsx)(
+                            "form",
+                            {
+                                autoComplete: "on",
+                                noValidate: true,
+                                onSubmit: this.onFormSubmit
+                            },
+                            formFields.map(function(field) {
+                                var type = "text"; // If email or password, replace field type.
 
-                                    if (_constants.MANDATORY_FORM_FIELDS_ID_ARRAY.includes(field.id)) {
-                                        type = field.id;
-                                    }
+                                if (_constants.MANDATORY_FORM_FIELDS_ID_ARRAY.includes(field.id)) {
+                                    type = field.id;
+                                }
 
-                                    if (field.id === "confirm-password") {
-                                        type = "password";
-                                    }
+                                if (field.id === "confirm-password") {
+                                    type = "password";
+                                }
 
-                                    return (0, _core.jsx)(
-                                        _.FormRow,
-                                        {
-                                            key: field.id,
-                                            hasError: field.error !== undefined
-                                        },
-                                        (0, _core.jsx)(
-                                            React.Fragment,
-                                            null,
-                                            showLabels &&
-                                                (0, _core.jsx)(_.Label, {
-                                                    value: field.label,
-                                                    showIsRequired: field.showIsRequired
-                                                }),
-                                            (0, _core.jsx)(_.Input, {
-                                                type: type,
-                                                name: field.id,
-                                                placeholder: field.placeholder,
-                                                ref: field.ref,
-                                                autoComplete: field.autoComplete,
-                                                onInputFocus: _this2.handleInputFocus,
-                                                onInputBlur: onInputBlur,
-                                                hasError: field.error !== undefined
-                                            }),
-                                            field.error &&
-                                                (0, _core.jsx)(_.InputError, {
-                                                    error: field.error
-                                                })
-                                        )
-                                    );
-                                }),
-                                (0, _core.jsx)(
+                                return (0, _core.jsx)(
                                     _.FormRow,
                                     {
-                                        key: "form-button"
+                                        key: field.id,
+                                        hasError: field.error !== undefined
                                     },
                                     (0, _core.jsx)(
-                                        React.Fragment,
+                                        _react.Fragment,
                                         null,
-                                        (0, _core.jsx)(_.Button, {
-                                            disabled: ["READY", "GENERAL_ERROR"].includes(_this2.state.status) !== true,
-                                            isLoading: _this2.state.status === "LOADING",
-                                            type: "submit",
-                                            label: buttonLabel
+                                        showLabels &&
+                                            (0, _core.jsx)(_.Label, {
+                                                value: field.label,
+                                                showIsRequired: field.showIsRequired
+                                            }),
+                                        (0, _core.jsx)(_.Input, {
+                                            type: type,
+                                            name: field.id,
+                                            placeholder: field.placeholder,
+                                            ref: field.ref,
+                                            autoComplete: field.autoComplete,
+                                            onInputFocus: _this2.handleInputFocus,
+                                            onInputBlur: onInputBlur,
+                                            hasError: field.error !== undefined
                                         }),
-                                        footer
+                                        field.error &&
+                                            (0, _core.jsx)(_.InputError, {
+                                                error: field.error
+                                            })
                                     )
+                                );
+                            }),
+                            (0, _core.jsx)(
+                                _.FormRow,
+                                {
+                                    key: "form-button"
+                                },
+                                (0, _core.jsx)(
+                                    _react.Fragment,
+                                    null,
+                                    (0, _core.jsx)(_.Button, {
+                                        disabled: ["READY", "GENERAL_ERROR"].includes(this.state.status) !== true,
+                                        isLoading: this.state.status === "LOADING",
+                                        type: "submit",
+                                        label: buttonLabel
+                                    }),
+                                    footer
                                 )
                             )
                         )
-                    );
-                });
+                    )
+                );
             }
         }
     ]);
 
     return FormBase;
-})(React.PureComponent);
+})(_react.PureComponent);
 
 exports["default"] = FormBase;
+FormBase.contextType = _styleContext["default"];

--- a/lib/build/recipe/emailpassword/components/library/button.js
+++ b/lib/build/recipe/emailpassword/components/library/button.js
@@ -23,9 +23,13 @@ exports["default"] = Button;
 
 var _core = require("@emotion/core");
 
-var React = _interopRequireWildcard(require("react"));
+var _react = _interopRequireWildcard(require("react"));
 
-var _styleContext = require("../styles/styleContext");
+var _styleContext = _interopRequireDefault(require("../styles/styleContext"));
+
+function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : { default: obj };
+}
 
 function _getRequireWildcardCache() {
     if (typeof WeakMap !== "function") return null;
@@ -97,22 +101,25 @@ function Button(_ref) {
         isLoading = _ref.isLoading,
         onClick = _ref.onClick;
 
+    /*
+     * Render.
+     */
+    var styles = (0, _react.useContext)(_styleContext["default"]);
+
     if (disabled === undefined) {
         disabled = false;
     }
 
-    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
-        return (0, _core.jsx)(
-            "button",
-            {
-                type: type,
-                disabled: disabled,
-                onClick: onClick,
-                css: styles.button,
-                className: "button"
-            },
-            label,
-            isLoading && "..."
-        );
-    });
+    return (0, _core.jsx)(
+        "button",
+        {
+            type: type,
+            disabled: disabled,
+            onClick: onClick,
+            css: styles.button,
+            className: "button"
+        },
+        label,
+        isLoading && "..."
+    );
 }

--- a/lib/build/recipe/emailpassword/components/library/formRow.js
+++ b/lib/build/recipe/emailpassword/components/library/formRow.js
@@ -23,9 +23,13 @@ exports["default"] = FormRow;
 
 var _core = require("@emotion/core");
 
-var React = _interopRequireWildcard(require("react"));
+var _react = _interopRequireWildcard(require("react"));
 
-var _styleContext = require("../styles/styleContext");
+var _styleContext = _interopRequireDefault(require("../styles/styleContext"));
+
+function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : { default: obj };
+}
 
 function _getRequireWildcardCache() {
     if (typeof WeakMap !== "function") return null;
@@ -93,20 +97,23 @@ function _interopRequireWildcard(obj) {
 function FormRow(_ref) {
     var children = _ref.children,
         hasError = _ref.hasError;
+
+    /*
+     * Render.
+     */
+    var styles = (0, _react.useContext)(_styleContext["default"]);
     var errorStyle =
         hasError === true
             ? {
                   paddingBottom: "0px"
               }
             : {};
-    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
-        return (0, _core.jsx)(
-            "div",
-            {
-                className: "formRow",
-                css: [styles.formRow, errorStyle]
-            },
-            children
-        );
-    });
+    return (0, _core.jsx)(
+        "div",
+        {
+            className: "formRow",
+            css: [styles.formRow, errorStyle]
+        },
+        children
+    );
 }

--- a/lib/build/recipe/emailpassword/components/library/input.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/input.d.ts
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { CSSObject } from "@emotion/core";
-import * as React from "react";
+import React from "react";
 import { RefObject } from "react";
 import { APIFormField } from "../../../../types";
 declare type InputProps = {

--- a/lib/build/recipe/emailpassword/components/library/input.js
+++ b/lib/build/recipe/emailpassword/components/library/input.js
@@ -23,9 +23,13 @@ exports["default"] = void 0;
 
 var _core = require("@emotion/core");
 
-var React = _interopRequireWildcard(require("react"));
+var _react = _interopRequireWildcard(require("react"));
 
-var _styleContext = require("../styles/styleContext");
+var _styleContext = _interopRequireDefault(require("../styles/styleContext"));
+
+function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : { default: obj };
+}
 
 function _getRequireWildcardCache() {
     if (typeof WeakMap !== "function") return null;
@@ -123,34 +127,33 @@ function Input(_ref, ref) {
      * Render.
      */
 
-    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
-        var errorStyle = hasError === true ? styles.inputError : undefined;
+    var styles = (0, _react.useContext)(_styleContext["default"]);
+    var errorStyle = hasError === true ? styles.inputError : undefined;
 
-        if (autoComplete === undefined) {
-            autoComplete = "off";
-        }
+    if (autoComplete === undefined) {
+        autoComplete = "off";
+    }
 
-        return (0, _core.jsx)(
-            "div",
-            {
-                className: "inputWrapper",
-                css: [styles.inputWrapper]
-            },
-            (0, _core.jsx)("input", {
-                autoComplete: autoComplete,
-                className: "input inputError",
-                css: [styles.input, errorStyle],
-                onFocus: handleFocus,
-                onBlur: handleBlur,
-                type: type,
-                name: name,
-                placeholder: placeholder,
-                ref: ref
-            })
-        );
-    });
+    return (0, _core.jsx)(
+        "div",
+        {
+            className: "inputWrapper",
+            css: [styles.inputWrapper]
+        },
+        (0, _core.jsx)("input", {
+            autoComplete: autoComplete,
+            className: "input inputError",
+            css: [styles.input, errorStyle],
+            onFocus: handleFocus,
+            onBlur: handleBlur,
+            type: type,
+            name: name,
+            placeholder: placeholder,
+            ref: ref
+        })
+    );
 }
 
-var _default = /*#__PURE__*/ (0, React.forwardRef)(Input);
+var _default = /*#__PURE__*/ (0, _react.forwardRef)(Input);
 
 exports["default"] = _default;

--- a/lib/build/recipe/emailpassword/components/library/inputError.js
+++ b/lib/build/recipe/emailpassword/components/library/inputError.js
@@ -23,9 +23,9 @@ exports["default"] = InputError;
 
 var _core = require("@emotion/core");
 
-var React = _interopRequireWildcard(require("react"));
+var _react = _interopRequireWildcard(require("react"));
 
-var _styleContext = require("../styles/styleContext");
+var _styleContext = _interopRequireDefault(require("../styles/styleContext"));
 
 var _error = _interopRequireDefault(require("../../assets/error"));
 
@@ -102,24 +102,23 @@ function InputError(_ref) {
     /*
      * Render.
      */
-    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
-        return (0, _core.jsx)(
-            "div",
+    var styles = (0, _react.useContext)(_styleContext["default"]);
+    return (0, _core.jsx)(
+        "div",
+        {
+            className: "inputErrorMessage",
+            css: styles.inputErrorMessage
+        },
+        (0, _core.jsx)(
+            "span",
             {
-                className: "inputErrorMessage",
-                css: styles.inputErrorMessage
+                className: "inputErrorSymbol",
+                css: styles.inputErrorSymbol
             },
-            (0, _core.jsx)(
-                "span",
-                {
-                    className: "inputErrorSymbol",
-                    css: styles.inputErrorSymbol
-                },
-                (0, _core.jsx)(_error["default"], {
-                    color: styles.palette.colors.error
-                })
-            ),
-            error
-        );
-    });
+            (0, _core.jsx)(_error["default"], {
+                color: styles.palette.colors.error
+            })
+        ),
+        error
+    );
 }

--- a/lib/build/recipe/emailpassword/components/library/label.js
+++ b/lib/build/recipe/emailpassword/components/library/label.js
@@ -23,9 +23,13 @@ exports["default"] = Label;
 
 var _core = require("@emotion/core");
 
-var React = _interopRequireWildcard(require("react"));
+var _react = _interopRequireWildcard(require("react"));
 
-var _styleContext = require("../styles/styleContext");
+var _styleContext = _interopRequireDefault(require("../styles/styleContext"));
+
+function _interopRequireDefault(obj) {
+    return obj && obj.__esModule ? obj : { default: obj };
+}
 
 function _getRequireWildcardCache() {
     if (typeof WeakMap !== "function") return null;
@@ -97,16 +101,15 @@ function Label(_ref) {
     /*
      * Render.
      */
-    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
-        return (0, _core.jsx)(
-            "div",
-            {
-                className: "label",
-                css: styles.label
-            },
-            value,
-            ":",
-            showIsRequired && " *"
-        );
-    });
+    var styles = (0, _react.useContext)(_styleContext["default"]);
+    return (0, _core.jsx)(
+        "div",
+        {
+            className: "label",
+            css: styles.label
+        },
+        value,
+        ":",
+        showIsRequired && " *"
+    );
 }

--- a/lib/build/recipe/emailpassword/components/styles/styleContext.d.ts
+++ b/lib/build/recipe/emailpassword/components/styles/styleContext.d.ts
@@ -6,6 +6,7 @@ declare type NormalisedStyle = {
     palette: NormalisedPalette;
     [x: string]: CSSObject;
 };
+declare const StyleContext: React.Context<NormalisedStyle>;
 export declare function StyleProvider({ children, styleFromInit, getDefaultStyles, defaultPalette }: {
     children: JSX.Element;
     styleFromInit?: Styles;
@@ -13,4 +14,4 @@ export declare function StyleProvider({ children, styleFromInit, getDefaultStyle
     defaultPalette: NormalisedPalette;
 }): JSX.Element;
 export declare const StyleConsumer: React.ExoticComponent<React.ConsumerProps<NormalisedStyle>>;
-export {};
+export default StyleContext;

--- a/lib/build/recipe/emailpassword/components/styles/styleContext.js
+++ b/lib/build/recipe/emailpassword/components/styles/styleContext.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 exports.StyleProvider = StyleProvider;
-exports.StyleConsumer = void 0;
+exports["default"] = exports.StyleConsumer = void 0;
 
 var _react = _interopRequireDefault(require("react"));
 
@@ -115,3 +115,6 @@ function getMergedPalette(defaultPalette, rawPalette) {
 
     return palette;
 }
+
+var _default = StyleContext;
+exports["default"] = _default;

--- a/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.d.ts
@@ -1,6 +1,12 @@
-import { PureComponent } from "react";
+import React, { PureComponent } from "react";
 import { EnterEmailThemeProps, EnterEmailThemeState } from "../../../../types";
+import { CSSObject } from "@emotion/serialize/types";
+import { NormalisedPalette } from "../types";
 export default class EnterEmailTheme extends PureComponent<EnterEmailThemeProps, EnterEmailThemeState> {
+    static contextType: React.Context<{
+        [x: string]: CSSObject;
+        palette: NormalisedPalette;
+    }>;
     constructor(props: EnterEmailThemeProps);
     onSuccess: () => void;
     resend: () => void;

--- a/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.js
@@ -5,15 +5,13 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-var React = _interopRequireWildcard(require("react"));
+var _react = _interopRequireWildcard(require("react"));
+
+var _styleContext = _interopRequireDefault(require("../../../styles/styleContext"));
 
 var _core = require("@emotion/core");
 
 var _FormBase = _interopRequireDefault(require("../../../library/FormBase"));
-
-var _styleContext = require("../../../styles/styleContext");
-
-var _styles = require("../styles/styles");
 
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
@@ -279,7 +277,7 @@ var EnterEmailTheme = /*#__PURE__*/ (function(_PureComponent) {
                 _objectSpread({}, field),
                 {},
                 {
-                    ref: /*#__PURE__*/ (0, React.createRef)(),
+                    ref: /*#__PURE__*/ (0, _react.createRef)(),
                     validated: false
                 }
             );
@@ -301,103 +299,88 @@ var EnterEmailTheme = /*#__PURE__*/ (function(_PureComponent) {
              * Render.
              */
             value: function render() {
-                var _this2 = this;
-
+                var styles = this.context;
+                var componentStyles = getStyles(styles.palette);
                 var callAPI = this.props.callAPI;
                 var _this$state = this.state,
                     formFields = _this$state.formFields,
-                    emailSent = _this$state.emailSent;
-                var styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
-                return (0, _core.jsx)(
-                    _styleContext.StyleProvider,
-                    {
-                        defaultPalette: _styles.defaultPalette,
-                        styleFromInit: styleFromInit,
-                        getDefaultStyles: _styles.getDefaultStyles
-                    },
-                    (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
-                        var componentStyles = getStyles(styles.palette); // If email sent, show success UI.
+                    emailSent = _this$state.emailSent; // If email sent, show success UI.
 
-                        if (emailSent === true) {
-                            return (0, _core.jsx)(
+                if (emailSent === true) {
+                    return (0, _core.jsx)(
+                        "div",
+                        {
+                            className: "container",
+                            css: styles.container
+                        },
+                        (0, _core.jsx)(
+                            "div",
+                            {
+                                className: "row",
+                                css: styles.row
+                            },
+                            (0, _core.jsx)(
                                 "div",
                                 {
-                                    className: "container",
-                                    css: styles.container
+                                    className: "primaryText successMessage",
+                                    css: [styles.primaryText, componentStyles.successMessage, styles.successMessage]
                                 },
+                                "Please check your email for the password recovery link.",
+                                " ",
                                 (0, _core.jsx)(
-                                    "div",
+                                    "span",
                                     {
-                                        className: "row",
-                                        css: styles.row
+                                        className: "link",
+                                        css: styles.link,
+                                        onClick: this.resend
                                     },
-                                    (0, _core.jsx)(
-                                        "div",
-                                        {
-                                            className: "primaryText successMessage",
-                                            css: [
-                                                styles.primaryText,
-                                                componentStyles.successMessage,
-                                                styles.successMessage
-                                            ]
-                                        },
-                                        "Please check your email for the password recovery link.",
-                                        " ",
-                                        (0, _core.jsx)(
-                                            "span",
-                                            {
-                                                className: "link",
-                                                css: styles.link,
-                                                onClick: _this2.resend
-                                            },
-                                            "Resend"
-                                        )
-                                    )
-                                )
-                            );
-                        } // Otherwise, return Form.
-
-                        return (0, _core.jsx)(_FormBase["default"], {
-                            formFields: formFields,
-                            buttonLabel: "Email me",
-                            onSuccess: _this2.onSuccess,
-                            callAPI: callAPI,
-                            showLabels: false,
-                            header: (0, _core.jsx)(
-                                React.Fragment,
-                                null,
-                                (0, _core.jsx)(
-                                    "div",
-                                    {
-                                        className: "headerTitle",
-                                        css: [componentStyles.headerTitle, styles.headerTitle]
-                                    },
-                                    "Reset your password"
-                                ),
-                                (0, _core.jsx)(
-                                    "div",
-                                    {
-                                        className: "headerSubtitle",
-                                        css: [componentStyles.headerSubTitle, styles.headerSubtitle]
-                                    },
-                                    (0, _core.jsx)(
-                                        "div",
-                                        {
-                                            className: "secondaryText",
-                                            css: styles.secondaryText
-                                        },
-                                        "We will send you an email to reset your password"
-                                    )
+                                    "Resend"
                                 )
                             )
-                        });
-                    })
-                );
+                        )
+                    );
+                } // Otherwise, return Form.
+
+                return (0, _core.jsx)(_FormBase["default"], {
+                    formFields: formFields,
+                    buttonLabel: "Email me",
+                    onSuccess: this.onSuccess,
+                    callAPI: callAPI,
+                    showLabels: false,
+                    header: (0, _core.jsx)(
+                        _react.Fragment,
+                        null,
+                        (0, _core.jsx)(
+                            "div",
+                            {
+                                className: "headerTitle",
+                                css: [componentStyles.headerTitle, styles.headerTitle]
+                            },
+                            "Reset your password"
+                        ),
+                        (0, _core.jsx)(
+                            "div",
+                            {
+                                className: "headerSubtitle",
+                                css: [componentStyles.headerSubTitle, styles.headerSubtitle]
+                            },
+                            (0, _core.jsx)(
+                                "div",
+                                {
+                                    className: "secondaryText",
+                                    css: styles.secondaryText
+                                },
+                                "We will send you an email to reset your password"
+                            )
+                        )
+                    )
+                });
             }
         }
     ]);
 
     return EnterEmailTheme;
-})(React.PureComponent);
+})(_react.PureComponent);
 
 exports["default"] = EnterEmailTheme;
+EnterEmailTheme.contextType = _styleContext["default"];

--- a/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/index.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/index.js
@@ -24,11 +24,15 @@ exports["default"] = void 0;
 
 var React = _interopRequireWildcard(require("react"));
 
+var _styleContext = require("../../../styles/styleContext");
+
 var _ThemeBase = require("../ThemeBase");
 
 var _enterEmail = _interopRequireDefault(require("./enterEmail"));
 
 var _submitNewPassword = _interopRequireDefault(require("./submitNewPassword"));
+
+var _styles = require("../styles/styles");
 
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
@@ -101,10 +105,26 @@ function ResetPasswordUsingTokenTheme(props) {
      */
     // If no token, return SubmitNewPassword.
     if (props.hasToken) {
-        return /*#__PURE__*/ React.createElement(_submitNewPassword["default"], props.submitNewPasswordForm);
+        return /*#__PURE__*/ React.createElement(
+            _styleContext.StyleProvider,
+            {
+                defaultPalette: _styles.defaultPalette,
+                styleFromInit: props.submitNewPasswordForm.styleFromInit,
+                getDefaultStyles: _styles.getDefaultStyles
+            },
+            /*#__PURE__*/ React.createElement(_submitNewPassword["default"], props.submitNewPasswordForm)
+        );
     } // Otherwise, return EnterEmail.
 
-    return /*#__PURE__*/ React.createElement(_enterEmail["default"], props.enterEmailForm);
+    return /*#__PURE__*/ React.createElement(
+        _styleContext.StyleProvider,
+        {
+            defaultPalette: _styles.defaultPalette,
+            styleFromInit: props.enterEmailForm.styleFromInit,
+            getDefaultStyles: _styles.getDefaultStyles
+        },
+        /*#__PURE__*/ React.createElement(_enterEmail["default"], props.enterEmailForm)
+    );
 }
 
 function ResetPasswordUsingTokenThemeWrapper(props) {

--- a/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.d.ts
@@ -1,6 +1,12 @@
-import { PureComponent } from "react";
+import React, { PureComponent } from "react";
+import { CSSObject } from "@emotion/serialize/types";
 import { SubmitNewPasswordThemeProps, SubmitNewPasswordThemeState } from "../../../../types";
+import { NormalisedPalette } from "../types";
 export default class SubmitNewPasswordTheme extends PureComponent<SubmitNewPasswordThemeProps, SubmitNewPasswordThemeState> {
+    static contextType: React.Context<{
+        [x: string]: CSSObject;
+        palette: NormalisedPalette;
+    }>;
     constructor(props: SubmitNewPasswordThemeProps);
     onSuccess: () => void;
     render(): JSX.Element;

--- a/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.js
@@ -5,17 +5,15 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-var React = _interopRequireWildcard(require("react"));
+var _react = _interopRequireWildcard(require("react"));
+
+var _styleContext = _interopRequireDefault(require("../../../styles/styleContext"));
 
 var _core = require("@emotion/core");
 
 var _library = require("../../../library");
 
 var _FormBase = _interopRequireDefault(require("../../../library/FormBase"));
-
-var _styleContext = require("../../../styles/styleContext");
-
-var _styles = require("../styles/styles");
 
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
@@ -273,7 +271,7 @@ var SubmitNewPasswordTheme = /*#__PURE__*/ (function(_PureComponent) {
                 _objectSpread({}, field),
                 {},
                 {
-                    ref: /*#__PURE__*/ (0, React.createRef)(),
+                    ref: /*#__PURE__*/ (0, _react.createRef)(),
                     validated: false
                 }
             );
@@ -292,120 +290,109 @@ var SubmitNewPasswordTheme = /*#__PURE__*/ (function(_PureComponent) {
              * Render.
              */
             value: function render() {
-                var _this2 = this;
-
+                var styles = this.context;
+                var componentStyles = getStyles(styles.palette);
                 var _this$props = this.props,
                     callAPI = _this$props.callAPI,
                     onSignInClicked = _this$props.onSignInClicked;
-                var styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
                 var _this$state = this.state,
                     formFields = _this$state.formFields,
                     hasNewPassword = _this$state.hasNewPassword;
-                return (0, _core.jsx)(
-                    _styleContext.StyleProvider,
-                    {
-                        defaultPalette: _styles.defaultPalette,
-                        styleFromInit: styleFromInit,
-                        getDefaultStyles: _styles.getDefaultStyles
-                    },
-                    (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
-                        var componentStyles = getStyles(styles.palette);
 
-                        if (hasNewPassword === true) {
-                            return (0, _core.jsx)(
+                if (hasNewPassword === true) {
+                    return (0, _core.jsx)(
+                        "div",
+                        {
+                            className: "container",
+                            css: styles.container
+                        },
+                        (0, _core.jsx)(
+                            "div",
+                            {
+                                className: "row",
+                                css: styles.row
+                            },
+                            (0, _core.jsx)(
                                 "div",
                                 {
-                                    className: "container",
-                                    css: styles.container
+                                    className: "headerTitle",
+                                    css: styles.headerTitle
+                                },
+                                "Success!"
+                            ),
+                            (0, _core.jsx)(
+                                _library.FormRow,
+                                {
+                                    key: "form-button"
                                 },
                                 (0, _core.jsx)(
-                                    "div",
-                                    {
-                                        className: "row",
-                                        css: styles.row
-                                    },
+                                    _react.Fragment,
+                                    null,
                                     (0, _core.jsx)(
                                         "div",
                                         {
-                                            className: "headerTitle",
-                                            css: [styles.headerTitle, styleFromInit.headerTitle]
+                                            className: "primaryText successMessage",
+                                            css: [
+                                                styles.primaryText,
+                                                componentStyles.successMessage,
+                                                styles.successMessage
+                                            ]
                                         },
-                                        "Success!"
+                                        "Your password has been updated successfully"
                                     ),
-                                    (0, _core.jsx)(
-                                        _library.FormRow,
-                                        {
-                                            key: "form-button"
-                                        },
-                                        (0, _core.jsx)(
-                                            React.Fragment,
-                                            null,
-                                            (0, _core.jsx)(
-                                                "div",
-                                                {
-                                                    className: "primaryText successMessage",
-                                                    css: [
-                                                        styles.primaryText,
-                                                        componentStyles.successMessage,
-                                                        styles.successMessage
-                                                    ]
-                                                },
-                                                "Your password has been updated successfully"
-                                            ),
-                                            (0, _core.jsx)(_library.Button, {
-                                                disabled: false,
-                                                isLoading: false,
-                                                type: "button",
-                                                onClick: onSignInClicked,
-                                                label: "SIGN IN"
-                                            })
-                                        )
-                                    )
-                                )
-                            );
-                        }
-
-                        return (0, _core.jsx)(_FormBase["default"], {
-                            formFields: formFields,
-                            buttonLabel: "Change password",
-                            onSuccess: _this2.onSuccess,
-                            callAPI: callAPI,
-                            showLabels: false,
-                            header: (0, _core.jsx)(
-                                React.Fragment,
-                                null,
-                                (0, _core.jsx)(
-                                    "div",
-                                    {
-                                        className: "headerTitle",
-                                        css: [componentStyles.headerTitle, styles.headerTitle]
-                                    },
-                                    "Change your password"
-                                ),
-                                (0, _core.jsx)(
-                                    "div",
-                                    {
-                                        className: "headerSubtitle",
-                                        css: styles.headerSubTitle
-                                    },
-                                    (0, _core.jsx)(
-                                        "div",
-                                        {
-                                            className: "secondaryText",
-                                            css: styles.secondaryText
-                                        },
-                                        "Enter a new password below to change your password"
-                                    )
+                                    (0, _core.jsx)(_library.Button, {
+                                        disabled: false,
+                                        isLoading: false,
+                                        type: "button",
+                                        onClick: onSignInClicked,
+                                        label: "SIGN IN"
+                                    })
                                 )
                             )
-                        });
-                    })
-                );
+                        )
+                    );
+                }
+
+                return (0, _core.jsx)(_FormBase["default"], {
+                    formFields: formFields,
+                    buttonLabel: "Change password",
+                    onSuccess: this.onSuccess,
+                    callAPI: callAPI,
+                    showLabels: false,
+                    header: (0, _core.jsx)(
+                        _react.Fragment,
+                        null,
+                        (0, _core.jsx)(
+                            "div",
+                            {
+                                className: "headerTitle",
+                                css: [componentStyles.headerTitle, styles.headerTitle]
+                            },
+                            "Change your password"
+                        ),
+                        (0, _core.jsx)(
+                            "div",
+                            {
+                                className: "headerSubtitle",
+                                css: styles.headerSubTitle
+                            },
+                            (0, _core.jsx)(
+                                "div",
+                                {
+                                    className: "secondaryText",
+                                    css: styles.secondaryText
+                                },
+                                "Enter a new password below to change your password"
+                            )
+                        )
+                    )
+                });
             }
         }
     ]);
 
     return SubmitNewPasswordTheme;
-})(React.PureComponent);
+})(_react.PureComponent);
 
 exports["default"] = SubmitNewPasswordTheme;
+SubmitNewPasswordTheme.contextType = _styleContext["default"];

--- a/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.d.ts
@@ -1,8 +1,14 @@
-import { PureComponent } from "react";
+import React, { PureComponent } from "react";
 import { SignInThemeProps, FormFieldState } from "../../../../types";
+import { CSSObject } from "@emotion/serialize/types";
+import { NormalisedPalette } from "../types";
 export default class SignInTheme extends PureComponent<SignInThemeProps, {
     formFields: FormFieldState[];
 }> {
+    static contextType: React.Context<{
+        [x: string]: CSSObject;
+        palette: NormalisedPalette;
+    }>;
     constructor(props: SignInThemeProps);
     render(): JSX.Element;
 }

--- a/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.js
@@ -5,15 +5,13 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-var React = _interopRequireWildcard(require("react"));
+var _react = _interopRequireWildcard(require("react"));
+
+var _styleContext = _interopRequireDefault(require("../../../styles/styleContext"));
 
 var _core = require("@emotion/core");
 
 var _FormBase = _interopRequireDefault(require("../../../library/FormBase"));
-
-var _styleContext = require("../../../styles/styleContext");
-
-var _styles = require("../styles/styles");
 
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
@@ -250,7 +248,7 @@ var SignInTheme = /*#__PURE__*/ (function(_PureComponent) {
                 _objectSpread({}, field),
                 {},
                 {
-                    ref: /*#__PURE__*/ (0, React.createRef)(),
+                    ref: /*#__PURE__*/ (0, _react.createRef)(),
                     validated: false
                 }
             );
@@ -268,91 +266,82 @@ var SignInTheme = /*#__PURE__*/ (function(_PureComponent) {
         {
             key: "render",
             value: function render() {
+                var styles = this.context;
+                var componentStyle = getStyles(styles.palette);
                 var _this$props = this.props,
                     signUpClicked = _this$props.signUpClicked,
                     forgotPasswordClick = _this$props.forgotPasswordClick,
-                    styleFromInit = _this$props.styleFromInit,
                     onSuccess = _this$props.onSuccess,
                     callAPI = _this$props.callAPI;
                 var formFields = this.state.formFields;
-                return (0, _core.jsx)(
-                    _styleContext.StyleProvider,
-                    {
-                        defaultPalette: _styles.defaultPalette,
-                        styleFromInit: styleFromInit,
-                        getDefaultStyles: _styles.getDefaultStyles
-                    },
-                    (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
-                        var componentStyle = getStyles(styles.palette);
-                        return (0, _core.jsx)(_FormBase["default"], {
-                            formFields: formFields,
-                            buttonLabel: "SIGN IN",
-                            onSuccess: onSuccess,
-                            callAPI: callAPI,
-                            showLabels: true,
-                            noValidateOnBlur: true,
-                            header: (0, _core.jsx)(
-                                React.Fragment,
-                                null,
-                                (0, _core.jsx)(
-                                    "div",
-                                    {
-                                        className: "headerTitle",
-                                        css: [componentStyle.headerTitle, styles.headerTitle]
-                                    },
-                                    "Sign In"
-                                ),
-                                (0, _core.jsx)(
-                                    "div",
-                                    {
-                                        className: "headerSubtitle",
-                                        css: [componentStyle.headerSubTitle, styles.headerSubtitle]
-                                    },
-                                    (0, _core.jsx)(
-                                        "div",
-                                        {
-                                            className: "secondaryText",
-                                            css: styles.secondaryText
-                                        },
-                                        "Not registered yet?",
-                                        (0, _core.jsx)(
-                                            "span",
-                                            {
-                                                className: "link",
-                                                onClick: signUpClicked,
-                                                css: styles.link
-                                            },
-                                            "Sign Up"
-                                        )
-                                    )
-                                ),
-                                (0, _core.jsx)("div", {
-                                    className: "divider",
-                                    css: styles.divider
-                                })
-                            ),
-                            footer: (0, _core.jsx)(
+                return (0, _core.jsx)(_FormBase["default"], {
+                    formFields: formFields,
+                    buttonLabel: "SIGN IN",
+                    onSuccess: onSuccess,
+                    callAPI: callAPI,
+                    showLabels: true,
+                    noValidateOnBlur: true,
+                    header: (0, _core.jsx)(
+                        _react.Fragment,
+                        null,
+                        (0, _core.jsx)(
+                            "div",
+                            {
+                                className: "headerTitle",
+                                css: [componentStyle.headerTitle, styles.headerTitle]
+                            },
+                            "Sign In"
+                        ),
+                        (0, _core.jsx)(
+                            "div",
+                            {
+                                className: "headerSubtitle",
+                                css: [componentStyle.headerSubTitle, styles.headerSubtitle]
+                            },
+                            (0, _core.jsx)(
                                 "div",
                                 {
-                                    className: "link secondaryText forgotPasswordLink",
-                                    css: [
-                                        styles.link,
-                                        styles.secondaryText,
-                                        componentStyle.forgotPasswordLink,
-                                        styles.forgotPasswordLink
-                                    ],
-                                    onClick: forgotPasswordClick
+                                    className: "secondaryText",
+                                    css: styles.secondaryText
                                 },
-                                "Forgot password?"
+                                "Not registered yet?",
+                                (0, _core.jsx)(
+                                    "span",
+                                    {
+                                        className: "link",
+                                        onClick: signUpClicked,
+                                        css: styles.link
+                                    },
+                                    "Sign Up"
+                                )
                             )
-                        });
-                    })
-                );
+                        ),
+                        (0, _core.jsx)("div", {
+                            className: "divider",
+                            css: styles.divider
+                        })
+                    ),
+                    footer: (0, _core.jsx)(
+                        "div",
+                        {
+                            className: "link secondaryText forgotPasswordLink",
+                            css: [
+                                styles.link,
+                                styles.secondaryText,
+                                componentStyle.forgotPasswordLink,
+                                styles.forgotPasswordLink
+                            ],
+                            onClick: forgotPasswordClick
+                        },
+                        "Forgot password?"
+                    )
+                });
             }
         }
     ]);
 
     return SignInTheme;
-})(React.PureComponent);
+})(_react.PureComponent);
 
 exports["default"] = SignInTheme;
+SignInTheme.contextType = _styleContext["default"];

--- a/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.d.ts
@@ -1,8 +1,14 @@
-import { PureComponent } from "react";
+import React, { PureComponent } from "react";
 import { FormFieldState, SignUpThemeProps } from "../../../../types";
+import { CSSObject } from "@emotion/serialize/types";
+import { NormalisedPalette } from "../types";
 export default class SignUpTheme extends PureComponent<SignUpThemeProps, {
     formFields: FormFieldState[];
 }> {
+    static contextType: React.Context<{
+        [x: string]: CSSObject;
+        palette: NormalisedPalette;
+    }>;
     constructor(props: SignUpThemeProps);
     render(): JSX.Element;
 }

--- a/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.js
@@ -5,17 +5,15 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 
-var React = _interopRequireWildcard(require("react"));
+var _react = _interopRequireWildcard(require("react"));
+
+var _styleContext = _interopRequireDefault(require("../../../styles/styleContext"));
 
 var _core = require("@emotion/core");
 
 var _FormBase = _interopRequireDefault(require("../../../library/FormBase"));
 
-var _styleContext = require("../../../styles/styleContext");
-
 var _SignUpFooter = _interopRequireDefault(require("./SignUpFooter"));
-
-var _styles = require("../styles/styles");
 
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
@@ -253,7 +251,7 @@ var SignUpTheme = /*#__PURE__*/ (function(_PureComponent) {
                 _objectSpread({}, field),
                 {},
                 {
-                    ref: /*#__PURE__*/ (0, React.createRef)(),
+                    ref: /*#__PURE__*/ (0, _react.createRef)(),
                     validated: false,
                     showIsRequired: (function() {
                         // If email and password only, do not show required indicator (*).
@@ -286,82 +284,73 @@ var SignUpTheme = /*#__PURE__*/ (function(_PureComponent) {
         {
             key: "render",
             value: function render() {
+                var styles = this.context;
+                var componentStyles = getStyles(styles.palette);
                 var _this$props = this.props,
                     privacyPolicyLink = _this$props.privacyPolicyLink,
                     termsOfServiceLink = _this$props.termsOfServiceLink,
-                    styleFromInit = _this$props.styleFromInit,
                     signInClicked = _this$props.signInClicked,
                     onSuccess = _this$props.onSuccess,
                     callAPI = _this$props.callAPI;
                 var formFields = this.state.formFields;
-                return (0, _core.jsx)(
-                    _styleContext.StyleProvider,
-                    {
-                        defaultPalette: _styles.defaultPalette,
-                        styleFromInit: styleFromInit,
-                        getDefaultStyles: _styles.getDefaultStyles
-                    },
-                    (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
-                        var componentStyles = getStyles(styles.palette);
-                        return (0, _core.jsx)(_FormBase["default"], {
-                            formFields: formFields,
-                            buttonLabel: "SIGN UP",
-                            onSuccess: onSuccess,
-                            callAPI: callAPI,
-                            showLabels: true,
-                            header: (0, _core.jsx)(
-                                React.Fragment,
-                                null,
+                return (0, _core.jsx)(_FormBase["default"], {
+                    formFields: formFields,
+                    buttonLabel: "SIGN UP",
+                    onSuccess: onSuccess,
+                    callAPI: callAPI,
+                    showLabels: true,
+                    header: (0, _core.jsx)(
+                        _react.Fragment,
+                        null,
+                        (0, _core.jsx)(
+                            "div",
+                            {
+                                className: "headerTitle",
+                                css: [componentStyles.headerTitle, styles.headerTitle]
+                            },
+                            "Sign Up"
+                        ),
+                        (0, _core.jsx)(
+                            "div",
+                            {
+                                className: "headerSubtitle",
+                                css: [componentStyles.headerSubTitle, styles.headerSubtitle]
+                            },
+                            (0, _core.jsx)(
+                                "div",
+                                {
+                                    className: "secondaryText",
+                                    css: styles.secondaryText
+                                },
+                                "Already have an account?",
                                 (0, _core.jsx)(
-                                    "div",
+                                    "span",
                                     {
-                                        className: "headerTitle",
-                                        css: [componentStyles.headerTitle, styles.headerTitle]
+                                        className: "link",
+                                        onClick: signInClicked,
+                                        css: styles.link
                                     },
-                                    "Sign Up"
-                                ),
-                                (0, _core.jsx)(
-                                    "div",
-                                    {
-                                        className: "headerSubtitle",
-                                        css: [componentStyles.headerSubTitle, styles.headerSubtitle]
-                                    },
-                                    (0, _core.jsx)(
-                                        "div",
-                                        {
-                                            className: "secondaryText",
-                                            css: styles.secondaryText
-                                        },
-                                        "Already have an account?",
-                                        (0, _core.jsx)(
-                                            "span",
-                                            {
-                                                className: "link",
-                                                onClick: signInClicked,
-                                                css: styles.link
-                                            },
-                                            "Sign In"
-                                        )
-                                    )
-                                ),
-                                (0, _core.jsx)("div", {
-                                    className: "divider",
-                                    css: styles.divider
-                                })
-                            ),
-                            footer: (0, _core.jsx)(_SignUpFooter["default"], {
-                                componentStyles: componentStyles,
-                                privacyPolicyLink: privacyPolicyLink,
-                                termsOfServiceLink: termsOfServiceLink
-                            })
-                        });
+                                    "Sign In"
+                                )
+                            )
+                        ),
+                        (0, _core.jsx)("div", {
+                            className: "divider",
+                            css: styles.divider
+                        })
+                    ),
+                    footer: (0, _core.jsx)(_SignUpFooter["default"], {
+                        componentStyles: componentStyles,
+                        privacyPolicyLink: privacyPolicyLink,
+                        termsOfServiceLink: termsOfServiceLink
                     })
-                );
+                });
             }
         }
     ]);
 
     return SignUpTheme;
-})(React.PureComponent);
+})(_react.PureComponent);
 
 exports["default"] = SignUpTheme;
+SignUpTheme.contextType = _styleContext["default"];

--- a/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignUpFooter.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignUpFooter.js
@@ -1,18 +1,73 @@
 "use strict";
 
+function _typeof(obj) {
+    "@babel/helpers - typeof";
+    if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+        _typeof = function _typeof(obj) {
+            return typeof obj;
+        };
+    } else {
+        _typeof = function _typeof(obj) {
+            return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype
+                ? "symbol"
+                : typeof obj;
+        };
+    }
+    return _typeof(obj);
+}
+
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
 exports["default"] = SignUpFooter;
 
-var _react = _interopRequireDefault(require("react"));
+var _react = _interopRequireWildcard(require("react"));
+
+var _styleContext = _interopRequireDefault(require("../../../styles/styleContext"));
 
 var _core = require("@emotion/core");
 
-var _styleContext = require("../../../styles/styleContext");
-
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
+}
+
+function _getRequireWildcardCache() {
+    if (typeof WeakMap !== "function") return null;
+    var cache = new WeakMap();
+    _getRequireWildcardCache = function _getRequireWildcardCache() {
+        return cache;
+    };
+    return cache;
+}
+
+function _interopRequireWildcard(obj) {
+    if (obj && obj.__esModule) {
+        return obj;
+    }
+    if (obj === null || (_typeof(obj) !== "object" && typeof obj !== "function")) {
+        return { default: obj };
+    }
+    var cache = _getRequireWildcardCache();
+    if (cache && cache.has(obj)) {
+        return cache.get(obj);
+    }
+    var newObj = {};
+    var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor;
+    for (var key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+            var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null;
+            if (desc && (desc.get || desc.set)) {
+                Object.defineProperty(newObj, key, desc);
+            } else {
+                newObj[key] = obj[key];
+            }
+        }
+    }
+    newObj["default"] = obj;
+    if (cache) {
+        cache.set(obj, newObj);
+    }
+    return newObj;
 }
 
 /* Copyright (c) 2020, VRAI Labs and/or its affiliates. All rights reserved.
@@ -39,46 +94,45 @@ function SignUpFooter(_ref) {
     var componentStyles = _ref.componentStyles,
         termsOfServiceLink = _ref.termsOfServiceLink,
         privacyPolicyLink = _ref.privacyPolicyLink;
+    var styles = (0, _react.useContext)(_styleContext["default"]);
 
     if (termsOfServiceLink === undefined && privacyPolicyLink === undefined) {
         return null;
     }
 
-    return (0, _core.jsx)(_styleContext.StyleConsumer, null, function(styles) {
-        return (0, _core.jsx)(
-            "div",
-            {
-                className: "secondaryText privacyPolicyAndTermsAndConditions",
-                css: [
-                    componentStyles.privacyPolicyAndTermsAndConditions,
-                    styles.secondaryText,
-                    styles.privacyPolicyAndTermsAndConditions
-                ]
-            },
-            "By signing up, you agree to our",
-            termsOfServiceLink !== undefined &&
-                (0, _core.jsx)(
-                    "a",
-                    {
-                        className: "link",
-                        css: styles.link,
-                        target: "_blank",
-                        href: termsOfServiceLink
-                    },
-                    "Terms of Service"
-                ),
-            termsOfServiceLink !== undefined && privacyPolicyLink !== undefined && "and",
-            privacyPolicyLink !== undefined &&
-                (0, _core.jsx)(
-                    "a",
-                    {
-                        className: "link",
-                        css: styles.link,
-                        href: privacyPolicyLink,
-                        target: "_blank"
-                    },
-                    "Privacy Policy"
-                )
-        );
-    });
+    return (0, _core.jsx)(
+        "div",
+        {
+            className: "secondaryText privacyPolicyAndTermsAndConditions",
+            css: [
+                componentStyles.privacyPolicyAndTermsAndConditions,
+                styles.secondaryText,
+                styles.privacyPolicyAndTermsAndConditions
+            ]
+        },
+        "By signing up, you agree to our",
+        termsOfServiceLink !== undefined &&
+            (0, _core.jsx)(
+                "a",
+                {
+                    className: "link",
+                    css: styles.link,
+                    target: "_blank",
+                    href: termsOfServiceLink
+                },
+                "Terms of Service"
+            ),
+        termsOfServiceLink !== undefined && privacyPolicyLink !== undefined && "and",
+        privacyPolicyLink !== undefined &&
+            (0, _core.jsx)(
+                "a",
+                {
+                    className: "link",
+                    css: styles.link,
+                    href: privacyPolicyLink,
+                    target: "_blank"
+                },
+                "Privacy Policy"
+            )
+    );
 }

--- a/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/index.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/index.js
@@ -30,6 +30,10 @@ var _SignIn = _interopRequireDefault(require("./SignIn"));
 
 var _ThemeBase = require("../ThemeBase");
 
+var _styleContext = require("../../../styles/styleContext");
+
+var _styles = require("../styles/styles");
+
 function _interopRequireDefault(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
 }
@@ -172,22 +176,38 @@ function SignInAndUpTheme(_ref) {
 
     if (isSignUp) {
         return /*#__PURE__*/ React.createElement(
-            _SignUp["default"],
-            _extends({}, signUpForm, {
-                signInClicked: function signInClicked() {
-                    return setSignUp(false);
-                }
-            })
+            _styleContext.StyleProvider,
+            {
+                defaultPalette: _styles.defaultPalette,
+                styleFromInit: signUpForm.styleFromInit,
+                getDefaultStyles: _styles.getDefaultStyles
+            },
+            /*#__PURE__*/ React.createElement(
+                _SignUp["default"],
+                _extends({}, signUpForm, {
+                    signInClicked: function signInClicked() {
+                        return setSignUp(false);
+                    }
+                })
+            )
         );
     } // Otherwise, return SignIn.
 
     return /*#__PURE__*/ React.createElement(
-        _SignIn["default"],
-        _extends({}, signInForm, {
-            signUpClicked: function signUpClicked() {
-                return setSignUp(true);
-            }
-        })
+        _styleContext.StyleProvider,
+        {
+            defaultPalette: _styles.defaultPalette,
+            styleFromInit: signInForm.styleFromInit,
+            getDefaultStyles: _styles.getDefaultStyles
+        },
+        /*#__PURE__*/ React.createElement(
+            _SignIn["default"],
+            _extends({}, signInForm, {
+                signUpClicked: function signUpClicked() {
+                    return setSignUp(true);
+                }
+            })
+        )
     );
 }
 

--- a/lib/ts/recipe/emailpassword/components/library/FormBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/FormBase.tsx
@@ -16,8 +16,8 @@
 /*
  * Imports.
  */
-import * as React from "react";
-import { FormEvent, Fragment, PureComponent } from "react";
+import React, { FormEvent, Fragment, PureComponent } from "react";
+import StyleContext from "../styles/styleContext";
 import { Button, FormRow, Input, InputError, Label } from ".";
 
 /** @jsx jsx */
@@ -25,13 +25,14 @@ import { jsx } from "@emotion/core";
 import { APIFormField } from "../../../../types";
 import { API_RESPONSE_STATUS, MANDATORY_FORM_FIELDS_ID_ARRAY, MANDATORY_FORM_FIELDS_ID } from "../../constants";
 import { FormBaseProps, FormBaseState, FormBaseStatus, FormFieldState } from "../../types";
-import { StyleConsumer } from "../styles/styleContext";
 
 /*
  * Component.
  */
 
 export default class FormBase extends PureComponent<FormBaseProps, FormBaseState> {
+    static contextType = StyleContext;
+
     /*
      * Constructor.
      */
@@ -208,77 +209,72 @@ export default class FormBase extends PureComponent<FormBaseProps, FormBaseState
      * Render.
      */
     render(): JSX.Element {
+        const styles = this.context;
         const { header, footer, buttonLabel, showLabels, noValidateOnBlur } = this.props;
         const { formFields } = this.state;
         const onInputBlur = noValidateOnBlur === true ? undefined : this.handleInputBlur;
 
         return (
-            <StyleConsumer>
-                {styles => (
-                    <div className="container" css={styles.container}>
-                        <div className="row" css={styles.row}>
-                            {header}
-                            {this.state.status === "GENERAL_ERROR" && (
-                                <div className="generalError" css={styles.generalError}>
-                                    {this.state.generalError}
-                                </div>
-                            )}
+            <div className="container" css={styles.container}>
+                <div className="row" css={styles.row}>
+                    {header}
+                    {this.state.status === "GENERAL_ERROR" && (
+                        <div className="generalError" css={styles.generalError}>
+                            {this.state.generalError}
+                        </div>
+                    )}
 
-                            <form autoComplete="on" noValidate onSubmit={this.onFormSubmit}>
-                                {formFields.map(field => {
-                                    let type = "text";
-                                    // If email or password, replace field type.
-                                    if (
-                                        MANDATORY_FORM_FIELDS_ID_ARRAY.includes(
-                                            (field as { id: MANDATORY_FORM_FIELDS_ID }).id
-                                        )
-                                    ) {
-                                        type = field.id;
-                                    }
-                                    if (field.id === "confirm-password") {
-                                        type = "password";
-                                    }
+                    <form autoComplete="on" noValidate onSubmit={this.onFormSubmit}>
+                        {formFields.map(field => {
+                            let type = "text";
+                            // If email or password, replace field type.
+                            if (
+                                MANDATORY_FORM_FIELDS_ID_ARRAY.includes((field as { id: MANDATORY_FORM_FIELDS_ID }).id)
+                            ) {
+                                type = field.id;
+                            }
+                            if (field.id === "confirm-password") {
+                                type = "password";
+                            }
 
-                                    return (
-                                        <FormRow key={field.id} hasError={field.error !== undefined}>
-                                            <Fragment>
-                                                {showLabels && (
-                                                    <Label value={field.label} showIsRequired={field.showIsRequired} />
-                                                )}
-
-                                                <Input
-                                                    type={type}
-                                                    name={field.id}
-                                                    placeholder={field.placeholder}
-                                                    ref={field.ref}
-                                                    autoComplete={field.autoComplete}
-                                                    onInputFocus={this.handleInputFocus}
-                                                    onInputBlur={onInputBlur}
-                                                    hasError={field.error !== undefined}
-                                                />
-
-                                                {field.error && <InputError error={field.error} />}
-                                            </Fragment>
-                                        </FormRow>
-                                    );
-                                })}
-
-                                <FormRow key="form-button">
+                            return (
+                                <FormRow key={field.id} hasError={field.error !== undefined}>
                                     <Fragment>
-                                        <Button
-                                            disabled={["READY", "GENERAL_ERROR"].includes(this.state.status) !== true}
-                                            isLoading={this.state.status === "LOADING"}
-                                            type="submit"
-                                            label={buttonLabel}
+                                        {showLabels && (
+                                            <Label value={field.label} showIsRequired={field.showIsRequired} />
+                                        )}
+
+                                        <Input
+                                            type={type}
+                                            name={field.id}
+                                            placeholder={field.placeholder}
+                                            ref={field.ref}
+                                            autoComplete={field.autoComplete}
+                                            onInputFocus={this.handleInputFocus}
+                                            onInputBlur={onInputBlur}
+                                            hasError={field.error !== undefined}
                                         />
-                                        {footer}
+
+                                        {field.error && <InputError error={field.error} />}
                                     </Fragment>
                                 </FormRow>
-                            </form>
-                        </div>
-                    </div>
-                )}
-            </StyleConsumer>
+                            );
+                        })}
+
+                        <FormRow key="form-button">
+                            <Fragment>
+                                <Button
+                                    disabled={["READY", "GENERAL_ERROR"].includes(this.state.status) !== true}
+                                    isLoading={this.state.status === "LOADING"}
+                                    type="submit"
+                                    label={buttonLabel}
+                                />
+                                {footer}
+                            </Fragment>
+                        </FormRow>
+                    </form>
+                </div>
+            </div>
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/components/library/button.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/button.tsx
@@ -20,8 +20,8 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
 
-import * as React from "react";
-import { StyleConsumer } from "../styles/styleContext";
+import React, { useContext } from "react";
+import StyleContext from "../styles/styleContext";
 
 /*
  * Props.
@@ -40,19 +40,17 @@ type ButtonProps = {
  */
 
 export default function Button({ type, label, disabled, isLoading, onClick }: ButtonProps): JSX.Element {
+    /*
+     * Render.
+     */
+    const styles = useContext(StyleContext);
     if (disabled === undefined) {
         disabled = false;
     }
     return (
-        <StyleConsumer>
-            {styles => {
-                return (
-                    <button type={type} disabled={disabled} onClick={onClick} css={styles.button} className="button">
-                        {label}
-                        {isLoading && "..."}
-                    </button>
-                );
-            }}
-        </StyleConsumer>
+        <button type={type} disabled={disabled} onClick={onClick} css={styles.button} className="button">
+            {label}
+            {isLoading && "..."}
+        </button>
     );
 }

--- a/lib/ts/recipe/emailpassword/components/library/formRow.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formRow.tsx
@@ -19,8 +19,8 @@
 
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
-import * as React from "react";
-import { StyleConsumer } from "../styles/styleContext";
+import React, { useContext } from "react";
+import StyleContext from "../styles/styleContext";
 
 /*
  * Props.
@@ -36,6 +36,10 @@ type FormRowProps = {
  */
 
 export default function FormRow({ children, hasError }: FormRowProps): JSX.Element {
+    /*
+     * Render.
+     */
+    const styles = useContext(StyleContext);
     const errorStyle =
         hasError === true
             ? {
@@ -43,12 +47,8 @@ export default function FormRow({ children, hasError }: FormRowProps): JSX.Eleme
               }
             : {};
     return (
-        <StyleConsumer>
-            {styles => (
-                <div className="formRow" css={[styles.formRow, errorStyle]}>
-                    {children}
-                </div>
-            )}
-        </StyleConsumer>
+        <div className="formRow" css={[styles.formRow, errorStyle]}>
+            {children}
+        </div>
     );
 }

--- a/lib/ts/recipe/emailpassword/components/library/input.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/input.tsx
@@ -20,10 +20,11 @@
 /** @jsx jsx */
 import { jsx, CSSObject } from "@emotion/core";
 
-import * as React from "react";
+import React, { useContext } from "react";
+import StyleContext from "../styles/styleContext";
+
 import { forwardRef, RefObject } from "react";
 import { APIFormField } from "../../../../types";
-import { StyleConsumer } from "../styles/styleContext";
 
 /*
  * Props.
@@ -75,31 +76,26 @@ function Input(
     /*
      * Render.
      */
-    return (
-        <StyleConsumer>
-            {styles => {
-                const errorStyle: CSSObject | undefined = hasError === true ? styles.inputError : undefined;
-                if (autoComplete === undefined) {
-                    autoComplete = "off";
-                }
+    const styles = useContext(StyleContext);
+    const errorStyle: CSSObject | undefined = hasError === true ? styles.inputError : undefined;
+    if (autoComplete === undefined) {
+        autoComplete = "off";
+    }
 
-                return (
-                    <div className="inputWrapper" css={[styles.inputWrapper]}>
-                        <input
-                            autoComplete={autoComplete}
-                            className="input inputError"
-                            css={[styles.input, errorStyle]}
-                            onFocus={handleFocus}
-                            onBlur={handleBlur}
-                            type={type}
-                            name={name}
-                            placeholder={placeholder}
-                            ref={ref}
-                        />
-                    </div>
-                );
-            }}
-        </StyleConsumer>
+    return (
+        <div className="inputWrapper" css={[styles.inputWrapper]}>
+            <input
+                autoComplete={autoComplete}
+                className="input inputError"
+                css={[styles.input, errorStyle]}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+                type={type}
+                name={name}
+                placeholder={placeholder}
+                ref={ref}
+            />
+        </div>
     );
 }
 

--- a/lib/ts/recipe/emailpassword/components/library/inputError.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/inputError.tsx
@@ -19,8 +19,8 @@
 
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
-import * as React from "react";
-import { StyleConsumer } from "../styles/styleContext";
+import React, { useContext } from "react";
+import StyleContext from "../styles/styleContext";
 import Error from "../../assets/error";
 
 /*
@@ -39,17 +39,13 @@ export default function InputError({ error }: InputErrorProps): JSX.Element {
     /*
      * Render.
      */
-
+    const styles = useContext(StyleContext);
     return (
-        <StyleConsumer>
-            {styles => (
-                <div className="inputErrorMessage" css={styles.inputErrorMessage}>
-                    <span className="inputErrorSymbol" css={styles.inputErrorSymbol}>
-                        <Error color={styles.palette.colors.error} />
-                    </span>
-                    {error}
-                </div>
-            )}
-        </StyleConsumer>
+        <div className="inputErrorMessage" css={styles.inputErrorMessage}>
+            <span className="inputErrorSymbol" css={styles.inputErrorSymbol}>
+                <Error color={styles.palette.colors.error} />
+            </span>
+            {error}
+        </div>
     );
 }

--- a/lib/ts/recipe/emailpassword/components/library/label.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/label.tsx
@@ -20,8 +20,8 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
 
-import * as React from "react";
-import { StyleConsumer } from "../styles/styleContext";
+import React, { useContext } from "react";
+import StyleContext from "../styles/styleContext";
 
 /*
  * Props.
@@ -40,16 +40,12 @@ export default function Label({ value, showIsRequired }: LabelProps): JSX.Elemen
     /*
      * Render.
      */
-
+    const styles = useContext(StyleContext);
     return (
-        <StyleConsumer>
-            {styles => (
-                <div className="label" css={styles.label}>
-                    {value}
-                    {":"}
-                    {showIsRequired && " *"}
-                </div>
-            )}
-        </StyleConsumer>
+        <div className="label" css={styles.label}>
+            {value}
+            {":"}
+            {showIsRequired && " *"}
+        </div>
     );
 }

--- a/lib/ts/recipe/emailpassword/components/styles/styleContext.tsx
+++ b/lib/ts/recipe/emailpassword/components/styles/styleContext.tsx
@@ -80,3 +80,5 @@ function getMergedPalette(defaultPalette: NormalisedPalette, rawPalette: Palette
     }
     return palette;
 }
+
+export default StyleContext;

--- a/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.tsx
@@ -15,8 +15,9 @@
 /*
  * Imports.
  */
-import * as React from "react";
-import { PureComponent, createRef, Fragment } from "react";
+import React, { PureComponent, createRef, Fragment } from "react";
+import StyleContext from "../../../styles/styleContext";
+
 import { EnterEmailThemeProps, EnterEmailThemeState } from "../../../../types";
 import { CSSObject } from "@emotion/serialize/types";
 
@@ -24,9 +25,7 @@ import { CSSObject } from "@emotion/serialize/types";
 import { jsx } from "@emotion/core";
 import FormBase from "../../../library/FormBase";
 import { Styles } from "../../../../../../types";
-import { StyleConsumer, StyleProvider } from "../../../styles/styleContext";
 import { NormalisedPalette } from "../types";
-import { defaultPalette, getDefaultStyles } from "../styles/styles";
 
 /*
  * Styles.
@@ -57,6 +56,8 @@ function getStyles(palette: NormalisedPalette): Styles {
  */
 
 export default class EnterEmailTheme extends PureComponent<EnterEmailThemeProps, EnterEmailThemeState> {
+    static contextType = StyleContext;
+
     /*
      * Constructor.
      */
@@ -101,70 +102,50 @@ export default class EnterEmailTheme extends PureComponent<EnterEmailThemeProps,
      * Render.
      */
     render(): JSX.Element {
+        const styles = this.context;
+        const componentStyles = getStyles(styles.palette);
         const { callAPI } = this.props;
         const { formFields, emailSent } = this.state;
-        const styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
 
+        // If email sent, show success UI.
+        if (emailSent === true) {
+            return (
+                <div className="container" css={styles.container}>
+                    <div className="row" css={styles.row}>
+                        <div
+                            className="primaryText successMessage"
+                            css={[styles.primaryText, componentStyles.successMessage, styles.successMessage]}>
+                            Please check your email for the password recovery link.{" "}
+                            <span className="link" css={styles.link} onClick={this.resend}>
+                                Resend
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            );
+        }
+
+        // Otherwise, return Form.
         return (
-            <StyleProvider
-                defaultPalette={defaultPalette}
-                styleFromInit={styleFromInit}
-                getDefaultStyles={getDefaultStyles}>
-                <StyleConsumer>
-                    {styles => {
-                        const componentStyles = getStyles(styles.palette);
-
-                        // If email sent, show success UI.
-                        if (emailSent === true) {
-                            return (
-                                <div className="container" css={styles.container}>
-                                    <div className="row" css={styles.row}>
-                                        <div
-                                            className="primaryText successMessage"
-                                            css={[
-                                                styles.primaryText,
-                                                componentStyles.successMessage,
-                                                styles.successMessage
-                                            ]}>
-                                            Please check your email for the password recovery link.{" "}
-                                            <span className="link" css={styles.link} onClick={this.resend}>
-                                                Resend
-                                            </span>
-                                        </div>
-                                    </div>
-                                </div>
-                            );
-                        }
-
-                        // Otherwise, return Form.
-                        return (
-                            <FormBase
-                                formFields={formFields}
-                                buttonLabel={"Email me"}
-                                onSuccess={this.onSuccess}
-                                callAPI={callAPI}
-                                showLabels={false}
-                                header={
-                                    <Fragment>
-                                        <div
-                                            className="headerTitle"
-                                            css={[componentStyles.headerTitle, styles.headerTitle]}>
-                                            Reset your password
-                                        </div>
-                                        <div
-                                            className="headerSubtitle"
-                                            css={[componentStyles.headerSubTitle, styles.headerSubtitle]}>
-                                            <div className="secondaryText" css={styles.secondaryText}>
-                                                We will send you an email to reset your password
-                                            </div>
-                                        </div>
-                                    </Fragment>
-                                }
-                            />
-                        );
-                    }}
-                </StyleConsumer>
-            </StyleProvider>
+            <FormBase
+                formFields={formFields}
+                buttonLabel={"Email me"}
+                onSuccess={this.onSuccess}
+                callAPI={callAPI}
+                showLabels={false}
+                header={
+                    <Fragment>
+                        <div className="headerTitle" css={[componentStyles.headerTitle, styles.headerTitle]}>
+                            Reset your password
+                        </div>
+                        <div className="headerSubtitle" css={[componentStyles.headerSubTitle, styles.headerSubtitle]}>
+                            <div className="secondaryText" css={styles.secondaryText}>
+                                We will send you an email to reset your password
+                            </div>
+                        </div>
+                    </Fragment>
+                }
+            />
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/index.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/index.tsx
@@ -17,11 +17,13 @@
  * Imports.
  */
 import * as React from "react";
+import { StyleProvider } from "../../../styles/styleContext";
 import { ResetPasswordUsingTokenThemeProps } from "../../../../types";
 import { ThemeBase } from "../ThemeBase";
 
 import EnterEmail from "./enterEmail";
 import SubmitNewPassword from "./submitNewPassword";
+import { defaultPalette, getDefaultStyles } from "../styles/styles";
 
 /*
  * Component.
@@ -34,11 +36,25 @@ export function ResetPasswordUsingTokenTheme(props: ResetPasswordUsingTokenTheme
 
     // If no token, return SubmitNewPassword.
     if (props.hasToken) {
-        return <SubmitNewPassword {...props.submitNewPasswordForm} />;
+        return (
+            <StyleProvider
+                defaultPalette={defaultPalette}
+                styleFromInit={props.submitNewPasswordForm.styleFromInit}
+                getDefaultStyles={getDefaultStyles}>
+                <SubmitNewPassword {...props.submitNewPasswordForm} />
+            </StyleProvider>
+        );
     }
 
     // Otherwise, return EnterEmail.
-    return <EnterEmail {...props.enterEmailForm} />;
+    return (
+        <StyleProvider
+            defaultPalette={defaultPalette}
+            styleFromInit={props.enterEmailForm.styleFromInit}
+            getDefaultStyles={getDefaultStyles}>
+            <EnterEmail {...props.enterEmailForm} />
+        </StyleProvider>
+    );
 }
 
 function ResetPasswordUsingTokenThemeWrapper(props: ResetPasswordUsingTokenThemeProps): JSX.Element {

--- a/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.tsx
@@ -16,8 +16,8 @@
 /*
  * Imports.
  */
-import * as React from "react";
-import { PureComponent, createRef, Fragment } from "react";
+import React, { PureComponent, createRef, Fragment } from "react";
+import StyleContext from "../../../styles/styleContext";
 
 import { CSSObject } from "@emotion/serialize/types";
 
@@ -27,9 +27,7 @@ import { Styles } from "../../../../../../types";
 import { SubmitNewPasswordThemeProps, SubmitNewPasswordThemeState } from "../../../../types";
 import { FormRow, Button } from "../../../library";
 import FormBase from "../../../library/FormBase";
-import { StyleProvider, StyleConsumer } from "../../../styles/styleContext";
 import { NormalisedPalette } from "../types";
-import { getDefaultStyles, defaultPalette } from "../styles/styles";
 
 /*
  * Styles.
@@ -69,6 +67,8 @@ export default class SubmitNewPasswordTheme extends PureComponent<
     SubmitNewPasswordThemeProps,
     SubmitNewPasswordThemeState
 > {
+    static contextType = StyleContext;
+
     /*
      * Constructor.
      */
@@ -104,78 +104,59 @@ export default class SubmitNewPasswordTheme extends PureComponent<
      */
 
     render(): JSX.Element {
+        const styles = this.context;
+        const componentStyles = getStyles(styles.palette);
         const { callAPI, onSignInClicked } = this.props;
-        const styleFromInit = this.props.styleFromInit !== undefined ? this.props.styleFromInit : {};
         const { formFields, hasNewPassword } = this.state;
 
-        return (
-            <StyleProvider
-                defaultPalette={defaultPalette}
-                styleFromInit={styleFromInit}
-                getDefaultStyles={getDefaultStyles}>
-                <StyleConsumer>
-                    {styles => {
-                        const componentStyles = getStyles(styles.palette);
-
-                        if (hasNewPassword === true) {
-                            return (
-                                <div className="container" css={styles.container}>
-                                    <div className="row" css={styles.row}>
-                                        <div
-                                            className="headerTitle"
-                                            css={[styles.headerTitle, styleFromInit.headerTitle]}>
-                                            Success!
-                                        </div>
-                                        <FormRow key="form-button">
-                                            <Fragment>
-                                                <div
-                                                    className="primaryText successMessage"
-                                                    css={[
-                                                        styles.primaryText,
-                                                        componentStyles.successMessage,
-                                                        styles.successMessage
-                                                    ]}>
-                                                    Your password has been updated successfully
-                                                </div>
-                                                <Button
-                                                    disabled={false}
-                                                    isLoading={false}
-                                                    type="button"
-                                                    onClick={onSignInClicked}
-                                                    label={"SIGN IN"}
-                                                />
-                                            </Fragment>
-                                        </FormRow>
-                                    </div>
+        if (hasNewPassword === true) {
+            return (
+                <div className="container" css={styles.container}>
+                    <div className="row" css={styles.row}>
+                        <div className="headerTitle" css={styles.headerTitle}>
+                            Success!
+                        </div>
+                        <FormRow key="form-button">
+                            <Fragment>
+                                <div
+                                    className="primaryText successMessage"
+                                    css={[styles.primaryText, componentStyles.successMessage, styles.successMessage]}>
+                                    Your password has been updated successfully
                                 </div>
-                            );
-                        }
-                        return (
-                            <FormBase
-                                formFields={formFields}
-                                buttonLabel={"Change password"}
-                                onSuccess={this.onSuccess}
-                                callAPI={callAPI}
-                                showLabels={false}
-                                header={
-                                    <Fragment>
-                                        <div
-                                            className="headerTitle"
-                                            css={[componentStyles.headerTitle, styles.headerTitle]}>
-                                            Change your password
-                                        </div>
-                                        <div className="headerSubtitle" css={styles.headerSubTitle}>
-                                            <div className="secondaryText" css={styles.secondaryText}>
-                                                Enter a new password below to change your password
-                                            </div>
-                                        </div>
-                                    </Fragment>
-                                }
-                            />
-                        );
-                    }}
-                </StyleConsumer>
-            </StyleProvider>
+                                <Button
+                                    disabled={false}
+                                    isLoading={false}
+                                    type="button"
+                                    onClick={onSignInClicked}
+                                    label={"SIGN IN"}
+                                />
+                            </Fragment>
+                        </FormRow>
+                    </div>
+                </div>
+            );
+        }
+
+        return (
+            <FormBase
+                formFields={formFields}
+                buttonLabel={"Change password"}
+                onSuccess={this.onSuccess}
+                callAPI={callAPI}
+                showLabels={false}
+                header={
+                    <Fragment>
+                        <div className="headerTitle" css={[componentStyles.headerTitle, styles.headerTitle]}>
+                            Change your password
+                        </div>
+                        <div className="headerSubtitle" css={styles.headerSubTitle}>
+                            <div className="secondaryText" css={styles.secondaryText}>
+                                Enter a new password below to change your password
+                            </div>
+                        </div>
+                    </Fragment>
+                }
+            />
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.tsx
@@ -16,8 +16,9 @@
 /*
  * Imports.
  */
-import * as React from "react";
-import { PureComponent, createRef, Fragment } from "react";
+import React, { PureComponent, createRef, Fragment } from "react";
+import StyleContext from "../../../styles/styleContext";
+
 import { SignInThemeProps, FormFieldState } from "../../../../types";
 import { CSSObject } from "@emotion/serialize/types";
 
@@ -26,9 +27,7 @@ import { jsx } from "@emotion/core";
 
 import FormBase from "../../../library/FormBase";
 import { Styles } from "../../../../../../types";
-import { StyleConsumer, StyleProvider } from "../../../styles/styleContext";
 import { NormalisedPalette } from "../types";
-import { defaultPalette, getDefaultStyles } from "../styles/styles";
 
 /*
  * Styles.
@@ -60,6 +59,8 @@ function getStyles(palette: NormalisedPalette): Styles {
  */
 
 export default class SignInTheme extends PureComponent<SignInThemeProps, { formFields: FormFieldState[] }> {
+    static contextType = StyleContext;
+
     /*
      * Constructor.
      */
@@ -84,63 +85,50 @@ export default class SignInTheme extends PureComponent<SignInThemeProps, { formF
      */
 
     render(): JSX.Element {
-        const { signUpClicked, forgotPasswordClick, styleFromInit, onSuccess, callAPI } = this.props;
+        const styles = this.context;
+        const componentStyle = getStyles(styles.palette as NormalisedPalette);
+
+        const { signUpClicked, forgotPasswordClick, onSuccess, callAPI } = this.props;
         const { formFields } = this.state;
 
         return (
-            <StyleProvider
-                defaultPalette={defaultPalette}
-                styleFromInit={styleFromInit}
-                getDefaultStyles={getDefaultStyles}>
-                <StyleConsumer>
-                    {styles => {
-                        const componentStyle = getStyles(styles.palette as NormalisedPalette);
-                        return (
-                            <FormBase
-                                formFields={formFields}
-                                buttonLabel={"SIGN IN"}
-                                onSuccess={onSuccess}
-                                callAPI={callAPI}
-                                showLabels={true}
-                                noValidateOnBlur={true}
-                                header={
-                                    <Fragment>
-                                        <div
-                                            className="headerTitle"
-                                            css={[componentStyle.headerTitle, styles.headerTitle]}>
-                                            Sign In
-                                        </div>
-                                        <div
-                                            className="headerSubtitle"
-                                            css={[componentStyle.headerSubTitle, styles.headerSubtitle]}>
-                                            <div className="secondaryText" css={styles.secondaryText}>
-                                                Not registered yet?
-                                                <span className="link" onClick={signUpClicked} css={styles.link}>
-                                                    Sign Up
-                                                </span>
-                                            </div>
-                                        </div>
-                                        <div className="divider" css={styles.divider}></div>
-                                    </Fragment>
-                                }
-                                footer={
-                                    <div
-                                        className="link secondaryText forgotPasswordLink"
-                                        css={[
-                                            styles.link,
-                                            styles.secondaryText,
-                                            componentStyle.forgotPasswordLink,
-                                            styles.forgotPasswordLink
-                                        ]}
-                                        onClick={forgotPasswordClick}>
-                                        Forgot password?
-                                    </div>
-                                }
-                            />
-                        );
-                    }}
-                </StyleConsumer>
-            </StyleProvider>
+            <FormBase
+                formFields={formFields}
+                buttonLabel={"SIGN IN"}
+                onSuccess={onSuccess}
+                callAPI={callAPI}
+                showLabels={true}
+                noValidateOnBlur={true}
+                header={
+                    <Fragment>
+                        <div className="headerTitle" css={[componentStyle.headerTitle, styles.headerTitle]}>
+                            Sign In
+                        </div>
+                        <div className="headerSubtitle" css={[componentStyle.headerSubTitle, styles.headerSubtitle]}>
+                            <div className="secondaryText" css={styles.secondaryText}>
+                                Not registered yet?
+                                <span className="link" onClick={signUpClicked} css={styles.link}>
+                                    Sign Up
+                                </span>
+                            </div>
+                        </div>
+                        <div className="divider" css={styles.divider}></div>
+                    </Fragment>
+                }
+                footer={
+                    <div
+                        className="link secondaryText forgotPasswordLink"
+                        css={[
+                            styles.link,
+                            styles.secondaryText,
+                            componentStyle.forgotPasswordLink,
+                            styles.forgotPasswordLink
+                        ]}
+                        onClick={forgotPasswordClick}>
+                        Forgot password?
+                    </div>
+                }
+            />
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.tsx
@@ -15,18 +15,16 @@
 /*
  * Imports.
  */
-import * as React from "react";
-import { PureComponent, createRef, Fragment } from "react";
+import React, { PureComponent, createRef, Fragment } from "react";
+import StyleContext from "../../../styles/styleContext";
 import { FormFieldState, SignUpThemeProps } from "../../../../types";
 import { CSSObject } from "@emotion/serialize/types";
 
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
 import FormBase from "../../../library/FormBase";
-import { StyleConsumer, StyleProvider } from "../../../styles/styleContext";
 import SignUpFooter from "./SignUpFooter";
 import { NormalisedPalette } from "../types";
-import { defaultPalette, getDefaultStyles } from "../styles/styles";
 
 /*
  * Styles.
@@ -57,6 +55,8 @@ function getStyles(palette: NormalisedPalette): any {
  */
 
 export default class SignUpTheme extends PureComponent<SignUpThemeProps, { formFields: FormFieldState[] }> {
+    static contextType = StyleContext;
+
     /*
      * Constructor.
      */
@@ -95,55 +95,41 @@ export default class SignUpTheme extends PureComponent<SignUpThemeProps, { formF
      * Render.
      */
     render(): JSX.Element {
-        const { privacyPolicyLink, termsOfServiceLink, styleFromInit, signInClicked, onSuccess, callAPI } = this.props;
+        const styles = this.context;
+        const componentStyles = getStyles(styles.palette as NormalisedPalette);
+        const { privacyPolicyLink, termsOfServiceLink, signInClicked, onSuccess, callAPI } = this.props;
         const { formFields } = this.state;
         return (
-            <StyleProvider
-                defaultPalette={defaultPalette}
-                styleFromInit={styleFromInit}
-                getDefaultStyles={getDefaultStyles}>
-                <StyleConsumer>
-                    {styles => {
-                        const componentStyles = getStyles(styles.palette as NormalisedPalette);
-                        return (
-                            <FormBase
-                                formFields={formFields}
-                                buttonLabel={"SIGN UP"}
-                                onSuccess={onSuccess}
-                                callAPI={callAPI}
-                                showLabels={true}
-                                header={
-                                    <Fragment>
-                                        <div
-                                            className="headerTitle"
-                                            css={[componentStyles.headerTitle, styles.headerTitle]}>
-                                            Sign Up
-                                        </div>
-                                        <div
-                                            className="headerSubtitle"
-                                            css={[componentStyles.headerSubTitle, styles.headerSubtitle]}>
-                                            <div className="secondaryText" css={styles.secondaryText}>
-                                                Already have an account?
-                                                <span className="link" onClick={signInClicked} css={styles.link}>
-                                                    Sign In
-                                                </span>
-                                            </div>
-                                        </div>
-                                        <div className="divider" css={styles.divider}></div>
-                                    </Fragment>
-                                }
-                                footer={
-                                    <SignUpFooter
-                                        componentStyles={componentStyles}
-                                        privacyPolicyLink={privacyPolicyLink}
-                                        termsOfServiceLink={termsOfServiceLink}
-                                    />
-                                }
-                            />
-                        );
-                    }}
-                </StyleConsumer>
-            </StyleProvider>
+            <FormBase
+                formFields={formFields}
+                buttonLabel={"SIGN UP"}
+                onSuccess={onSuccess}
+                callAPI={callAPI}
+                showLabels={true}
+                header={
+                    <Fragment>
+                        <div className="headerTitle" css={[componentStyles.headerTitle, styles.headerTitle]}>
+                            Sign Up
+                        </div>
+                        <div className="headerSubtitle" css={[componentStyles.headerSubTitle, styles.headerSubtitle]}>
+                            <div className="secondaryText" css={styles.secondaryText}>
+                                Already have an account?
+                                <span className="link" onClick={signInClicked} css={styles.link}>
+                                    Sign In
+                                </span>
+                            </div>
+                        </div>
+                        <div className="divider" css={styles.divider}></div>
+                    </Fragment>
+                }
+                footer={
+                    <SignUpFooter
+                        componentStyles={componentStyles}
+                        privacyPolicyLink={privacyPolicyLink}
+                        termsOfServiceLink={termsOfServiceLink}
+                    />
+                }
+            />
         );
     }
 }

--- a/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignUpFooter.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignUpFooter.tsx
@@ -17,12 +17,12 @@
  * Imports.
  */
 
-import React from "react";
+import React, { useContext } from "react";
+import StyleContext from "../../../styles/styleContext";
 import { Styles } from "../../../../../../types";
 
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
-import { StyleConsumer } from "../../../styles/styleContext";
 
 export default function SignUpFooter({
     componentStyles,
@@ -33,34 +33,32 @@ export default function SignUpFooter({
     privacyPolicyLink?: string;
     termsOfServiceLink?: string;
 }): JSX.Element | null {
+    const styles = useContext(StyleContext);
+
     if (termsOfServiceLink === undefined && privacyPolicyLink === undefined) {
         return null;
     }
 
     return (
-        <StyleConsumer>
-            {styles => (
-                <div
-                    className="secondaryText privacyPolicyAndTermsAndConditions"
-                    css={[
-                        componentStyles.privacyPolicyAndTermsAndConditions,
-                        styles.secondaryText,
-                        styles.privacyPolicyAndTermsAndConditions
-                    ]}>
-                    By signing up, you agree to our
-                    {termsOfServiceLink !== undefined && (
-                        <a className="link" css={styles.link} target="_blank" href={termsOfServiceLink}>
-                            Terms of Service
-                        </a>
-                    )}
-                    {termsOfServiceLink !== undefined && privacyPolicyLink !== undefined && "and"}
-                    {privacyPolicyLink !== undefined && (
-                        <a className="link" css={styles.link} href={privacyPolicyLink} target="_blank">
-                            Privacy Policy
-                        </a>
-                    )}
-                </div>
+        <div
+            className="secondaryText privacyPolicyAndTermsAndConditions"
+            css={[
+                componentStyles.privacyPolicyAndTermsAndConditions,
+                styles.secondaryText,
+                styles.privacyPolicyAndTermsAndConditions
+            ]}>
+            By signing up, you agree to our
+            {termsOfServiceLink !== undefined && (
+                <a className="link" css={styles.link} target="_blank" href={termsOfServiceLink}>
+                    Terms of Service
+                </a>
             )}
-        </StyleConsumer>
+            {termsOfServiceLink !== undefined && privacyPolicyLink !== undefined && "and"}
+            {privacyPolicyLink !== undefined && (
+                <a className="link" css={styles.link} href={privacyPolicyLink} target="_blank">
+                    Privacy Policy
+                </a>
+            )}
+        </div>
     );
 }

--- a/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/index.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/index.tsx
@@ -23,6 +23,8 @@ import { SignInAndUpThemeProps } from "../../../../types";
 import SignUp from "./SignUp";
 import SignIn from "./SignIn";
 import { ThemeBase } from "../ThemeBase";
+import { StyleProvider } from "../../../styles/styleContext";
+import { defaultPalette, getDefaultStyles } from "../styles/styles";
 
 /*
  * Component.
@@ -41,11 +43,25 @@ export function SignInAndUpTheme({ signInForm, signUpForm, defaultToSignUp }: Si
 
     // If isSignUp, return signUp.
     if (isSignUp) {
-        return <SignUp {...signUpForm} signInClicked={() => setSignUp(false)} />;
+        return (
+            <StyleProvider
+                defaultPalette={defaultPalette}
+                styleFromInit={signUpForm.styleFromInit}
+                getDefaultStyles={getDefaultStyles}>
+                <SignUp {...signUpForm} signInClicked={() => setSignUp(false)} />
+            </StyleProvider>
+        );
     }
 
     // Otherwise, return SignIn.
-    return <SignIn {...signInForm} signUpClicked={() => setSignUp(true)} />;
+    return (
+        <StyleProvider
+            defaultPalette={defaultPalette}
+            styleFromInit={signInForm.styleFromInit}
+            getDefaultStyles={getDefaultStyles}>
+            <SignIn {...signInForm} signUpClicked={() => setSignUp(true)} />
+        </StyleProvider>
+    );
 }
 
 function SignInAndUpThemeWrapper(props: SignInAndUpThemeProps): JSX.Element {


### PR DESCRIPTION
No feature changes, only refactoring to use `useContext` in order to prevent the heavy use of :


```js
  render () {
        return (
                <StyleConsumer>
                    {styles => {
                        const componentStyle = getStyles(styles.palette as NormalisedPalette);
                        return (
                            <FormBase {...}
```

by

```js
  static contextType = StyleContext;
  render () {
        const styles = this.context;
        const componentStyle = getStyles(styles.palette as NormalisedPalette);
        return (<FormBase {...}
```
