### PR TITLE
rename verifyEmailExists, do not pass validateEmail to SignUp + remov…

### DIFF
--- a/lib/build/recipe/emailpassword/components/features/signInAndUp/SignInAndUp.d.ts
+++ b/lib/build/recipe/emailpassword/components/features/signInAndUp/SignInAndUp.d.ts
@@ -1,7 +1,7 @@
 import { PureComponent } from "react";
 import EmailPassword from "../../../emailPassword";
-import { SignInAndUpProps, SignInAndUpState, SignInThemeResponse, SignUpThemeResponse, OnHandleSignInAndUpSuccessContext, SignInAPIResponse, VerifyEmailAPIResponse } from "../../../types";
-import { APIFormField, RequestJson } from "../../../../../types";
+import { SignInAndUpProps, SignInAndUpState, SignInThemeResponse, SignUpThemeResponse, OnHandleSignInAndUpSuccessContext, SignInAPIResponse, VerifyEmailAPIResponse, FormFieldThemeProps } from "../../../types";
+import { APIFormField, NormalisedFormField, RequestJson } from "../../../../../types";
 import Session from "../../../../session/session";
 declare class SignInAndUp extends PureComponent<SignInAndUpProps, SignInAndUpState> {
     constructor(props: SignInAndUpProps);
@@ -19,6 +19,7 @@ declare class SignInAndUp extends PureComponent<SignInAndUpProps, SignInAndUpSta
     onCallSignInAPI: (requestJson: RequestJson, headers: HeadersInit) => Promise<SignInAPIResponse>;
     onCallEmailExistAPI: (value: string, headers: HeadersInit) => Promise<VerifyEmailAPIResponse>;
     validateEmail: (value: string) => Promise<string | undefined>;
+    getSignUpFeatureFormFields(formFields: NormalisedFormField[]): FormFieldThemeProps[];
     componentDidMount: () => Promise<void>;
     render: () => JSX.Element;
 }

--- a/lib/build/recipe/emailpassword/components/features/signInAndUp/SignInAndUp.js
+++ b/lib/build/recipe/emailpassword/components/features/signInAndUp/SignInAndUp.js
@@ -668,20 +668,20 @@ var SignInAndUp = /*#__PURE__*/ (function(_PureComponent) {
                         while (1) {
                             switch ((_context10.prev = _context10.next)) {
                                 case 0:
-                                    if (!(_this.props.verifyEmailExists !== undefined)) {
+                                    if (!(_this.props.onCallEmailExistsAPI !== undefined)) {
                                         _context10.next = 4;
                                         break;
                                     }
 
                                     _context10.next = 3;
-                                    return _this.props.verifyEmailExists(value, headers);
+                                    return _this.props.onCallEmailExistsAPI(value, headers);
 
                                 case 3:
                                     return _context10.abrupt("return", _context10.sent);
 
                                 case 4:
                                     _context10.next = 6;
-                                    return _this.getRecipeInstanceOrThrow().verifyEmailExists(value, headers);
+                                    return _this.getRecipeInstanceOrThrow().emailExistsAPI(value, headers);
 
                                 case 6:
                                     return _context10.abrupt("return", _context10.sent);
@@ -708,7 +708,7 @@ var SignInAndUp = /*#__PURE__*/ (function(_PureComponent) {
                             switch ((_context11.prev = _context11.next)) {
                                 case 0:
                                     _context11.next = 2;
-                                    return (0, _api.handleVerifyEmailAPICall)(
+                                    return (0, _api.handleEmailExistsAPICall)(
                                         value,
                                         _this.getRecipeInstanceOrThrow().getRecipeId(),
                                         _this.onCallEmailExistAPI
@@ -796,12 +796,11 @@ var SignInAndUp = /*#__PURE__*/ (function(_PureComponent) {
             };
             var signUpForm = {
                 styleFromInit: signUpFeature.style,
-                formFields: signUpFeature.formFields,
+                formFields: _this.getSignUpFeatureFormFields(signUpFeature.formFields),
                 privacyPolicyLink: signUpFeature.privacyPolicyLink,
                 termsOfServiceLink: signUpFeature.termsOfServiceLink,
                 onSuccess: _this.onSignUpSuccess,
-                callAPI: _this.signUp,
-                validateEmail: _this.validateEmail
+                callAPI: _this.signUp
             };
 
             var useShadowDom = _this.getRecipeInstanceOrThrow().getConfig().useShadowDom; // Before session is verified, return empty fragment, prevent UI glitch.
@@ -874,6 +873,40 @@ var SignInAndUp = /*#__PURE__*/ (function(_PureComponent) {
                     };
                 });
             }
+        },
+        {
+            key: "getSignUpFeatureFormFields",
+            value: function getSignUpFeatureFormFields(formFields) {
+                var _this2 = this;
+
+                var emailPasswordOnly = formFields.length === 2;
+                return formFields.map(function(field) {
+                    return _objectSpread(
+                        _objectSpread({}, field),
+                        {},
+                        {
+                            showIsRequired: (function() {
+                                // If email and password only, do not show required indicator (*).
+                                if (emailPasswordOnly) {
+                                    return false;
+                                } // Otherwise, show for all non optional fields (including email and password).
+
+                                return field.optional === false;
+                            })(),
+                            validateOnBlurOnly: (function() {
+                                if (field.id === "email") {
+                                    return _this2.validateEmail;
+                                }
+
+                                return undefined;
+                            })()
+                        }
+                    );
+                });
+            }
+            /*
+             * Init.
+             */
         }
     ]);
 

--- a/lib/build/recipe/emailpassword/components/features/signInAndUp/api.d.ts
+++ b/lib/build/recipe/emailpassword/components/features/signInAndUp/api.d.ts
@@ -2,4 +2,4 @@ import { APIFormField } from "../../../../../types";
 import { SignUpAPI, SignUpThemeResponse, SignInAPI, SignInThemeResponse, VerifyEmailAPI } from "../../../types";
 export declare function handleSignUpAPI(formFields: APIFormField[], rid: string, signUpAPI: SignUpAPI): Promise<SignUpThemeResponse>;
 export declare function handleSignInAPI(formFields: APIFormField[], rid: string, signInAPI: SignInAPI): Promise<SignInThemeResponse>;
-export declare function handleVerifyEmailAPICall(value: string, rid: string, verifyEmailAPI: VerifyEmailAPI): Promise<string | undefined>;
+export declare function handleEmailExistsAPICall(value: string, rid: string, onCallEmailExistsAPI: VerifyEmailAPI): Promise<string | undefined>;

--- a/lib/build/recipe/emailpassword/components/features/signInAndUp/api.js
+++ b/lib/build/recipe/emailpassword/components/features/signInAndUp/api.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.handleSignUpAPI = handleSignUpAPI;
 exports.handleSignInAPI = handleSignInAPI;
-exports.handleVerifyEmailAPICall = handleVerifyEmailAPICall;
+exports.handleEmailExistsAPICall = handleEmailExistsAPICall;
 
 var _constants = require("../../../../../constants");
 
@@ -214,13 +214,13 @@ function _handleSignInAPI() {
     return _handleSignInAPI.apply(this, arguments);
 }
 
-function handleVerifyEmailAPICall(_x7, _x8, _x9) {
-    return _handleVerifyEmailAPICall.apply(this, arguments);
+function handleEmailExistsAPICall(_x7, _x8, _x9) {
+    return _handleEmailExistsAPICall.apply(this, arguments);
 }
 
-function _handleVerifyEmailAPICall() {
-    _handleVerifyEmailAPICall = _asyncToGenerator(
-        /*#__PURE__*/ regeneratorRuntime.mark(function _callee3(value, rid, verifyEmailAPI) {
+function _handleEmailExistsAPICall() {
+    _handleEmailExistsAPICall = _asyncToGenerator(
+        /*#__PURE__*/ regeneratorRuntime.mark(function _callee3(value, rid, onCallEmailExistsAPI) {
             var headers, response;
             return regeneratorRuntime.wrap(
                 function _callee3$(_context3) {
@@ -232,7 +232,7 @@ function _handleVerifyEmailAPICall() {
                                     rid: rid
                                 };
                                 _context3.next = 4;
-                                return verifyEmailAPI(value, headers);
+                                return onCallEmailExistsAPI(value, headers);
 
                             case 4:
                                 response = _context3.sent;
@@ -255,7 +255,7 @@ function _handleVerifyEmailAPICall() {
                             case 9:
                                 // Otherwise, something went wrong.
                                 console.error(
-                                    "There was an error handling the output format of onCallSignInAPI props callback. Please refer to https://supertokens.io/docs/auth-react/emailpassword/callbacks//sign-in-up#output-1"
+                                    "There was an error handling the output format of onCallEmailExistsAPI props callback. Please refer to https://supertokens.io/docs/auth-react/emailpassword/callbacks//sign-in-up#output-1"
                                 ); // Fail silently.
 
                                 return _context3.abrupt("return", undefined);
@@ -277,5 +277,5 @@ function _handleVerifyEmailAPICall() {
             );
         })
     );
-    return _handleVerifyEmailAPICall.apply(this, arguments);
+    return _handleEmailExistsAPICall.apply(this, arguments);
 }

--- a/lib/build/recipe/emailpassword/components/library/FormBase.js
+++ b/lib/build/recipe/emailpassword/components/library/FormBase.js
@@ -524,7 +524,15 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
         })();
 
         _this.state = {
-            formFields: props.formFields,
+            formFields: props.formFields.map(function(field) {
+                return _objectSpread(
+                    _objectSpread({}, field),
+                    {},
+                    {
+                        ref: /*#__PURE__*/ (0, _react.createRef)()
+                    }
+                );
+            }),
             status: "IN_PROGRESS"
         };
         return _this;

--- a/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.js
@@ -72,46 +72,6 @@ function _typeof(obj) {
     return _typeof(obj);
 }
 
-function ownKeys(object, enumerableOnly) {
-    var keys = Object.keys(object);
-    if (Object.getOwnPropertySymbols) {
-        var symbols = Object.getOwnPropertySymbols(object);
-        if (enumerableOnly)
-            symbols = symbols.filter(function(sym) {
-                return Object.getOwnPropertyDescriptor(object, sym).enumerable;
-            });
-        keys.push.apply(keys, symbols);
-    }
-    return keys;
-}
-
-function _objectSpread(target) {
-    for (var i = 1; i < arguments.length; i++) {
-        var source = arguments[i] != null ? arguments[i] : {};
-        if (i % 2) {
-            ownKeys(Object(source), true).forEach(function(key) {
-                _defineProperty(target, key, source[key]);
-            });
-        } else if (Object.getOwnPropertyDescriptors) {
-            Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
-        } else {
-            ownKeys(Object(source)).forEach(function(key) {
-                Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
-            });
-        }
-    }
-    return target;
-}
-
-function _defineProperty(obj, key, value) {
-    if (key in obj) {
-        Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true });
-    } else {
-        obj[key] = value;
-    }
-    return obj;
-}
-
 function _classCallCheck(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
         throw new TypeError("Cannot call a class as a function");
@@ -245,14 +205,10 @@ var EnterEmailTheme = /*#__PURE__*/ (function(_PureComponent) {
         _this = _super.call(this, props);
 
         _this.onSuccess = function() {
-            _this.setState(function(oldState) {
-                return _objectSpread(
-                    _objectSpread({}, oldState),
-                    {},
-                    {
-                        emailSent: true
-                    }
-                );
+            _this.setState(function() {
+                return {
+                    emailSent: true
+                };
             });
 
             if (_this.props.onSuccess !== undefined) {
@@ -261,29 +217,15 @@ var EnterEmailTheme = /*#__PURE__*/ (function(_PureComponent) {
         };
 
         _this.resend = function() {
-            _this.setState(function(oldState) {
-                return _objectSpread(
-                    _objectSpread({}, oldState),
-                    {},
-                    {
-                        emailSent: false
-                    }
-                );
+            _this.setState(function() {
+                return {
+                    emailSent: false
+                };
             });
         };
 
-        var formFields = props.formFields.map(function(field) {
-            return _objectSpread(
-                _objectSpread({}, field),
-                {},
-                {
-                    ref: /*#__PURE__*/ (0, _react.createRef)(),
-                    validated: false
-                }
-            );
-        });
         _this.state = {
-            formFields: formFields
+            emailSent: false
         };
         return _this;
     }
@@ -301,10 +243,10 @@ var EnterEmailTheme = /*#__PURE__*/ (function(_PureComponent) {
             value: function render() {
                 var styles = this.context;
                 var componentStyles = getStyles(styles.palette);
-                var callAPI = this.props.callAPI;
-                var _this$state = this.state,
-                    formFields = _this$state.formFields,
-                    emailSent = _this$state.emailSent; // If email sent, show success UI.
+                var _this$props = this.props,
+                    formFields = _this$props.formFields,
+                    callAPI = _this$props.callAPI;
+                var emailSent = this.state.emailSent; // If email sent, show success UI.
 
                 if (emailSent === true) {
                     return (0, _core.jsx)(

--- a/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.js
@@ -74,46 +74,6 @@ function _typeof(obj) {
     return _typeof(obj);
 }
 
-function ownKeys(object, enumerableOnly) {
-    var keys = Object.keys(object);
-    if (Object.getOwnPropertySymbols) {
-        var symbols = Object.getOwnPropertySymbols(object);
-        if (enumerableOnly)
-            symbols = symbols.filter(function(sym) {
-                return Object.getOwnPropertyDescriptor(object, sym).enumerable;
-            });
-        keys.push.apply(keys, symbols);
-    }
-    return keys;
-}
-
-function _objectSpread(target) {
-    for (var i = 1; i < arguments.length; i++) {
-        var source = arguments[i] != null ? arguments[i] : {};
-        if (i % 2) {
-            ownKeys(Object(source), true).forEach(function(key) {
-                _defineProperty(target, key, source[key]);
-            });
-        } else if (Object.getOwnPropertyDescriptors) {
-            Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
-        } else {
-            ownKeys(Object(source)).forEach(function(key) {
-                Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
-            });
-        }
-    }
-    return target;
-}
-
-function _defineProperty(obj, key, value) {
-    if (key in obj) {
-        Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true });
-    } else {
-        obj[key] = value;
-    }
-    return obj;
-}
-
 function _classCallCheck(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
         throw new TypeError("Cannot call a class as a function");
@@ -222,9 +182,6 @@ function getStyles(palette) {
             marginTop: "9px",
             marginBottom: "21px"
         },
-        forgotPasswordLink: {
-            marginTop: "10px"
-        },
         successMessage: {
             marginTop: "15px",
             marginBottom: "15px"
@@ -251,14 +208,10 @@ var SubmitNewPasswordTheme = /*#__PURE__*/ (function(_PureComponent) {
         _this = _super.call(this, props);
 
         _this.onSuccess = function() {
-            _this.setState(function(oldState) {
-                return _objectSpread(
-                    _objectSpread({}, oldState),
-                    {},
-                    {
-                        hasNewPassword: true
-                    }
-                );
+            _this.setState(function() {
+                return {
+                    hasNewPassword: true
+                };
             });
 
             if (_this.props.onSuccess !== undefined) {
@@ -266,18 +219,8 @@ var SubmitNewPasswordTheme = /*#__PURE__*/ (function(_PureComponent) {
             }
         };
 
-        var formFields = props.formFields.map(function(field) {
-            return _objectSpread(
-                _objectSpread({}, field),
-                {},
-                {
-                    ref: /*#__PURE__*/ (0, _react.createRef)(),
-                    validated: false
-                }
-            );
-        });
         _this.state = {
-            formFields: formFields
+            hasNewPassword: false
         };
         return _this;
     }
@@ -294,10 +237,9 @@ var SubmitNewPasswordTheme = /*#__PURE__*/ (function(_PureComponent) {
                 var componentStyles = getStyles(styles.palette);
                 var _this$props = this.props,
                     callAPI = _this$props.callAPI,
+                    formFields = _this$props.formFields,
                     onSignInClicked = _this$props.onSignInClicked;
-                var _this$state = this.state,
-                    formFields = _this$state.formFields,
-                    hasNewPassword = _this$state.hasNewPassword;
+                var hasNewPassword = this.state.hasNewPassword;
 
                 if (hasNewPassword === true) {
                     return (0, _core.jsx)(

--- a/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.d.ts
@@ -1,14 +1,11 @@
 import React, { PureComponent } from "react";
-import { SignInThemeProps, FormFieldState } from "../../../../types";
+import { SignInThemeProps } from "../../../../types";
 import { CSSObject } from "@emotion/serialize/types";
 import { NormalisedPalette } from "../types";
-export default class SignInTheme extends PureComponent<SignInThemeProps, {
-    formFields: FormFieldState[];
-}> {
+export default class SignInTheme extends PureComponent<SignInThemeProps> {
     static contextType: React.Context<{
         [x: string]: CSSObject;
         palette: NormalisedPalette;
     }>;
-    constructor(props: SignInThemeProps);
     render(): JSX.Element;
 }

--- a/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.js
@@ -72,46 +72,6 @@ function _typeof(obj) {
     return _typeof(obj);
 }
 
-function ownKeys(object, enumerableOnly) {
-    var keys = Object.keys(object);
-    if (Object.getOwnPropertySymbols) {
-        var symbols = Object.getOwnPropertySymbols(object);
-        if (enumerableOnly)
-            symbols = symbols.filter(function(sym) {
-                return Object.getOwnPropertyDescriptor(object, sym).enumerable;
-            });
-        keys.push.apply(keys, symbols);
-    }
-    return keys;
-}
-
-function _objectSpread(target) {
-    for (var i = 1; i < arguments.length; i++) {
-        var source = arguments[i] != null ? arguments[i] : {};
-        if (i % 2) {
-            ownKeys(Object(source), true).forEach(function(key) {
-                _defineProperty(target, key, source[key]);
-            });
-        } else if (Object.getOwnPropertyDescriptors) {
-            Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
-        } else {
-            ownKeys(Object(source)).forEach(function(key) {
-                Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
-            });
-        }
-    }
-    return target;
-}
-
-function _defineProperty(obj, key, value) {
-    if (key in obj) {
-        Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true });
-    } else {
-        obj[key] = value;
-    }
-    return obj;
-}
-
 function _classCallCheck(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
         throw new TypeError("Cannot call a class as a function");
@@ -234,37 +194,19 @@ var SignInTheme = /*#__PURE__*/ (function(_PureComponent) {
 
     var _super = _createSuper(SignInTheme);
 
-    /*
-     * Constructor.
-     */
-    function SignInTheme(props) {
-        var _this;
-
+    function SignInTheme() {
         _classCallCheck(this, SignInTheme);
 
-        _this = _super.call(this, props);
-        var formFields = props.formFields.map(function(field) {
-            return _objectSpread(
-                _objectSpread({}, field),
-                {},
-                {
-                    ref: /*#__PURE__*/ (0, _react.createRef)(),
-                    validated: false
-                }
-            );
-        });
-        _this.state = {
-            formFields: formFields
-        };
-        return _this;
+        return _super.apply(this, arguments);
     }
-    /*
-     * Render.
-     */
 
     _createClass(SignInTheme, [
         {
             key: "render",
+
+            /*
+             * Render.
+             */
             value: function render() {
                 var styles = this.context;
                 var componentStyle = getStyles(styles.palette);
@@ -273,7 +215,7 @@ var SignInTheme = /*#__PURE__*/ (function(_PureComponent) {
                     forgotPasswordClick = _this$props.forgotPasswordClick,
                     onSuccess = _this$props.onSuccess,
                     callAPI = _this$props.callAPI;
-                var formFields = this.state.formFields;
+                var formFields = this.props.formFields;
                 return (0, _core.jsx)(_FormBase["default"], {
                     formFields: formFields,
                     buttonLabel: "SIGN IN",

--- a/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.d.ts
@@ -1,14 +1,11 @@
 import React, { PureComponent } from "react";
-import { FormFieldState, SignUpThemeProps } from "../../../../types";
+import { SignUpThemeProps } from "../../../../types";
 import { CSSObject } from "@emotion/serialize/types";
 import { NormalisedPalette } from "../types";
-export default class SignUpTheme extends PureComponent<SignUpThemeProps, {
-    formFields: FormFieldState[];
-}> {
+export default class SignUpTheme extends PureComponent<SignUpThemeProps> {
     static contextType: React.Context<{
         [x: string]: CSSObject;
         palette: NormalisedPalette;
     }>;
-    constructor(props: SignUpThemeProps);
     render(): JSX.Element;
 }

--- a/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.js
@@ -74,46 +74,6 @@ function _typeof(obj) {
     return _typeof(obj);
 }
 
-function ownKeys(object, enumerableOnly) {
-    var keys = Object.keys(object);
-    if (Object.getOwnPropertySymbols) {
-        var symbols = Object.getOwnPropertySymbols(object);
-        if (enumerableOnly)
-            symbols = symbols.filter(function(sym) {
-                return Object.getOwnPropertyDescriptor(object, sym).enumerable;
-            });
-        keys.push.apply(keys, symbols);
-    }
-    return keys;
-}
-
-function _objectSpread(target) {
-    for (var i = 1; i < arguments.length; i++) {
-        var source = arguments[i] != null ? arguments[i] : {};
-        if (i % 2) {
-            ownKeys(Object(source), true).forEach(function(key) {
-                _defineProperty(target, key, source[key]);
-            });
-        } else if (Object.getOwnPropertyDescriptors) {
-            Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
-        } else {
-            ownKeys(Object(source)).forEach(function(key) {
-                Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
-            });
-        }
-    }
-    return target;
-}
-
-function _defineProperty(obj, key, value) {
-    if (key in obj) {
-        Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true });
-    } else {
-        obj[key] = value;
-    }
-    return obj;
-}
-
 function _classCallCheck(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
         throw new TypeError("Cannot call a class as a function");
@@ -236,53 +196,19 @@ var SignUpTheme = /*#__PURE__*/ (function(_PureComponent) {
 
     var _super = _createSuper(SignUpTheme);
 
-    /*
-     * Constructor.
-     */
-    function SignUpTheme(props) {
-        var _this;
-
+    function SignUpTheme() {
         _classCallCheck(this, SignUpTheme);
 
-        _this = _super.call(this, props);
-        var emailPasswordOnly = props.formFields.length === 2;
-        var formFields = props.formFields.map(function(field) {
-            return _objectSpread(
-                _objectSpread({}, field),
-                {},
-                {
-                    ref: /*#__PURE__*/ (0, _react.createRef)(),
-                    validated: false,
-                    showIsRequired: (function() {
-                        // If email and password only, do not show required indicator (*).
-                        if (emailPasswordOnly) {
-                            return false;
-                        } // Otherwise, show for all non optional fields (including email and password).
-
-                        return field.optional === false;
-                    })(),
-                    validateOnBlurOnly: (function() {
-                        if (field.id === "email") {
-                            return props.validateEmail;
-                        }
-
-                        return undefined;
-                    })()
-                }
-            );
-        });
-        _this.state = {
-            formFields: formFields
-        };
-        return _this;
+        return _super.apply(this, arguments);
     }
-    /*
-     * Render.
-     */
 
     _createClass(SignUpTheme, [
         {
             key: "render",
+
+            /*
+             * Render.
+             */
             value: function render() {
                 var styles = this.context;
                 var componentStyles = getStyles(styles.palette);
@@ -292,7 +218,7 @@ var SignUpTheme = /*#__PURE__*/ (function(_PureComponent) {
                     signInClicked = _this$props.signInClicked,
                     onSuccess = _this$props.onSuccess,
                     callAPI = _this$props.callAPI;
-                var formFields = this.state.formFields;
+                var formFields = this.props.formFields;
                 return (0, _core.jsx)(_FormBase["default"], {
                     formFields: formFields,
                     buttonLabel: "SIGN UP",

--- a/lib/build/recipe/emailpassword/emailPassword.d.ts
+++ b/lib/build/recipe/emailpassword/emailPassword.d.ts
@@ -11,7 +11,7 @@ export default class EmailPassword extends RecipeModule {
     getConfig: () => NormalisedEmailPasswordConfig;
     getFeatures: () => Record<string, import("../../types").ReactComponentClass>;
     signUpAPI: (requestJson: RequestJson, headers: HeadersInit) => Promise<import("./types").BaseSignInUpAPIResponse>;
-    verifyEmailExists: (value: string, headers: HeadersInit) => Promise<VerifyEmailAPIResponse>;
+    emailExistsAPI: (value: string, headers: HeadersInit) => Promise<VerifyEmailAPIResponse>;
     signInAPI: (requestJson: RequestJson, headers: HeadersInit) => Promise<SignInAPIResponse>;
     submitNewPasswordAPI: (requestJson: RequestJson, headers: HeadersInit) => Promise<SubmitNewPasswordAPIResponse>;
     enterEmailAPI: (requestJson: RequestJson, headers: HeadersInit) => Promise<import("./types").BaseResetPasswordAPIResponse>;

--- a/lib/build/recipe/emailpassword/emailPassword.js
+++ b/lib/build/recipe/emailpassword/emailPassword.js
@@ -296,7 +296,7 @@ var EmailPassword = /*#__PURE__*/ (function(_RecipeModule) {
             };
         })();
 
-        _this.verifyEmailExists = /*#__PURE__*/ (function() {
+        _this.emailExistsAPI = /*#__PURE__*/ (function() {
             var _ref2 = _asyncToGenerator(
                 /*#__PURE__*/ regeneratorRuntime.mark(function _callee2(value, headers) {
                     return regeneratorRuntime.wrap(function _callee2$(_context2) {

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -82,7 +82,7 @@ export declare type SignInAndUpProps = BaseProps & {
     doesSessionExist?: () => Promise<boolean>;
     onHandleSuccess?: (context: OnHandleSignInAndUpSuccessContext) => Promise<boolean>;
     onCallSignUpAPI?: (requestJson: RequestJson, headers: HeadersInit) => Promise<SignUpAPIResponse>;
-    verifyEmailExists?: (value: string, headers: HeadersInit) => Promise<VerifyEmailAPIResponse>;
+    onCallEmailExistsAPI?: (value: string, headers: HeadersInit) => Promise<VerifyEmailAPIResponse>;
     onCallSignInAPI?: (requestJson: RequestJson, headers: HeadersInit) => Promise<SignInAPIResponse>;
 };
 export declare type ResetPasswordUsingTokenProps = BaseProps & {
@@ -111,7 +111,6 @@ export declare type SignUpThemeProps = ThemeBaseProps & {
     privacyPolicyLink?: string;
     termsOfServiceLink?: string;
     callAPI: (fields: APIFormField[]) => Promise<SignUpThemeResponse>;
-    validateEmail: (value: string) => Promise<string | undefined>;
 };
 export declare type SignInAndUpThemeProps = {
     defaultToSignUp: boolean;
@@ -121,7 +120,14 @@ export declare type SignInAndUpThemeProps = {
 export declare type NormalisedFormFieldWithError = NormalisedFormField & {
     error?: string;
 };
-export declare type FormFieldThemeProps = NormalisedFormFieldWithError;
+export declare type FormFieldThemeProps = NormalisedFormFieldWithError & {
+    showIsRequired?: boolean;
+    validateOnBlurOnly?: (value: string) => Promise<string | undefined>;
+    autoComplete?: string;
+};
+export declare type FormFieldState = FormFieldThemeProps & {
+    ref: RefObject<HTMLInputElement>;
+};
 export declare type FormFieldError = {
     id: string;
     error: string;
@@ -187,19 +193,11 @@ export declare type SubmitNewPasswordThemeProps = ThemeBaseProps & {
     callAPI: (fields: APIFormField[]) => Promise<SubmitNewPasswordThemeResponse>;
     onSignInClicked: () => void;
 };
-export declare type FormFieldState = FormFieldThemeProps & {
-    ref: RefObject<HTMLInputElement>;
-    showIsRequired?: boolean;
-    validateOnBlurOnly?: (value: string) => Promise<string | undefined>;
-    autoComplete?: string;
-};
 export declare type EnterEmailThemeState = {
     emailSent?: boolean;
-    formFields: FormFieldState[];
 };
 export declare type SubmitNewPasswordThemeState = {
     hasNewPassword?: boolean;
-    formFields: FormFieldState[];
 };
 export declare enum SignInAndUpStateStatus {
     LOADING = "LOADING",
@@ -229,7 +227,7 @@ export declare type FormBaseState = {
 export declare type FormBaseProps = {
     header?: JSX.Element;
     footer?: JSX.Element;
-    formFields: FormFieldState[];
+    formFields: FormFieldThemeProps[];
     showLabels: boolean;
     buttonLabel: string;
     noValidateOnBlur?: boolean;

--- a/lib/build/recipe/emailpassword/types.js
+++ b/lib/build/recipe/emailpassword/types.js
@@ -27,10 +27,6 @@ exports.SignInAndUpStateStatus = void 0;
 /*
  * Props Types.
  */
-
-/*
- * State type.
- */
 var SignInAndUpStateStatus;
 exports.SignInAndUpStateStatus = SignInAndUpStateStatus;
 

--- a/lib/ts/recipe/emailpassword/components/features/signInAndUp/api.ts
+++ b/lib/ts/recipe/emailpassword/components/features/signInAndUp/api.ts
@@ -111,16 +111,16 @@ export async function handleSignInAPI(
     }
 }
 
-export async function handleVerifyEmailAPICall(
+export async function handleEmailExistsAPICall(
     value: string,
     rid: string,
-    verifyEmailAPI: VerifyEmailAPI
+    onCallEmailExistsAPI: VerifyEmailAPI
 ): Promise<string | undefined> {
     try {
         const headers: HeadersInit = {
             rid
         };
-        const response = await verifyEmailAPI(value, headers);
+        const response = await onCallEmailExistsAPI(value, headers);
 
         // If email already exists.
         if (response.status === API_RESPONSE_STATUS.OK) {
@@ -135,7 +135,7 @@ export async function handleVerifyEmailAPICall(
 
         // Otherwise, something went wrong.
         console.error(
-            "There was an error handling the output format of onCallSignInAPI props callback. Please refer to https://supertokens.io/docs/auth-react/emailpassword/callbacks//sign-in-up#output-1"
+            "There was an error handling the output format of onCallEmailExistsAPI props callback. Please refer to https://supertokens.io/docs/auth-react/emailpassword/callbacks//sign-in-up#output-1"
         );
         // Fail silently.
         return undefined;

--- a/lib/ts/recipe/emailpassword/components/library/FormBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/FormBase.tsx
@@ -16,7 +16,7 @@
 /*
  * Imports.
  */
-import React, { FormEvent, Fragment, PureComponent } from "react";
+import React, { createRef, FormEvent, Fragment, PureComponent } from "react";
 import StyleContext from "../styles/styleContext";
 import { Button, FormRow, Input, InputError, Label } from ".";
 
@@ -40,7 +40,10 @@ export default class FormBase extends PureComponent<FormBaseProps, FormBaseState
         super(props);
 
         this.state = {
-            formFields: props.formFields,
+            formFields: props.formFields.map(field => ({
+                ...field,
+                ref: createRef<HTMLInputElement>()
+            })),
             status: "IN_PROGRESS"
         };
     }

--- a/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.tsx
@@ -15,7 +15,7 @@
 /*
  * Imports.
  */
-import React, { PureComponent, createRef, Fragment } from "react";
+import React, { PureComponent, Fragment } from "react";
 import StyleContext from "../../../styles/styleContext";
 
 import { EnterEmailThemeProps, EnterEmailThemeState } from "../../../../types";
@@ -57,23 +57,13 @@ function getStyles(palette: NormalisedPalette): Styles {
 
 export default class EnterEmailTheme extends PureComponent<EnterEmailThemeProps, EnterEmailThemeState> {
     static contextType = StyleContext;
-
     /*
      * Constructor.
      */
     constructor(props: EnterEmailThemeProps) {
         super(props);
-
-        const formFields = props.formFields.map(field => {
-            return {
-                ...field,
-                ref: createRef<HTMLInputElement>(),
-                validated: false
-            };
-        });
-
         this.state = {
-            formFields
+            emailSent: false
         };
     }
 
@@ -82,8 +72,7 @@ export default class EnterEmailTheme extends PureComponent<EnterEmailThemeProps,
      */
 
     onSuccess = (): void => {
-        this.setState(oldState => ({
-            ...oldState,
+        this.setState(() => ({
             emailSent: true
         }));
         if (this.props.onSuccess !== undefined) {
@@ -92,8 +81,7 @@ export default class EnterEmailTheme extends PureComponent<EnterEmailThemeProps,
     };
 
     resend = (): void => {
-        this.setState(oldState => ({
-            ...oldState,
+        this.setState(() => ({
             emailSent: false
         }));
     };
@@ -104,8 +92,8 @@ export default class EnterEmailTheme extends PureComponent<EnterEmailThemeProps,
     render(): JSX.Element {
         const styles = this.context;
         const componentStyles = getStyles(styles.palette);
-        const { callAPI } = this.props;
-        const { formFields, emailSent } = this.state;
+        const { formFields, callAPI } = this.props;
+        const { emailSent } = this.state;
 
         // If email sent, show success UI.
         if (emailSent === true) {

--- a/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.tsx
@@ -16,7 +16,7 @@
 /*
  * Imports.
  */
-import React, { PureComponent, createRef, Fragment } from "react";
+import React, { PureComponent, Fragment } from "react";
 import StyleContext from "../../../styles/styleContext";
 
 import { CSSObject } from "@emotion/serialize/types";
@@ -48,10 +48,6 @@ function getStyles(palette: NormalisedPalette): Styles {
             marginBottom: "21px"
         } as CSSObject,
 
-        forgotPasswordLink: {
-            marginTop: "10px"
-        } as CSSObject,
-
         successMessage: {
             marginTop: "15px",
             marginBottom: "15px"
@@ -74,23 +70,13 @@ export default class SubmitNewPasswordTheme extends PureComponent<
      */
     constructor(props: SubmitNewPasswordThemeProps) {
         super(props);
-
-        const formFields = props.formFields.map(field => {
-            return {
-                ...field,
-                ref: createRef<HTMLInputElement>(),
-                validated: false
-            };
-        });
-
         this.state = {
-            formFields
+            hasNewPassword: false
         };
     }
 
     onSuccess = (): void => {
-        this.setState(oldState => ({
-            ...oldState,
+        this.setState(() => ({
             hasNewPassword: true
         }));
 
@@ -106,8 +92,8 @@ export default class SubmitNewPasswordTheme extends PureComponent<
     render(): JSX.Element {
         const styles = this.context;
         const componentStyles = getStyles(styles.palette);
-        const { callAPI, onSignInClicked } = this.props;
-        const { formFields, hasNewPassword } = this.state;
+        const { callAPI, formFields, onSignInClicked } = this.props;
+        const { hasNewPassword } = this.state;
 
         if (hasNewPassword === true) {
             return (

--- a/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.tsx
@@ -16,10 +16,10 @@
 /*
  * Imports.
  */
-import React, { PureComponent, createRef, Fragment } from "react";
+import React, { PureComponent, Fragment } from "react";
 import StyleContext from "../../../styles/styleContext";
 
-import { SignInThemeProps, FormFieldState } from "../../../../types";
+import { SignInThemeProps } from "../../../../types";
 import { CSSObject } from "@emotion/serialize/types";
 
 /** @jsx jsx */
@@ -58,27 +58,8 @@ function getStyles(palette: NormalisedPalette): Styles {
  * Component.
  */
 
-export default class SignInTheme extends PureComponent<SignInThemeProps, { formFields: FormFieldState[] }> {
+export default class SignInTheme extends PureComponent<SignInThemeProps> {
     static contextType = StyleContext;
-
-    /*
-     * Constructor.
-     */
-    constructor(props: SignInThemeProps) {
-        super(props);
-
-        const formFields = props.formFields.map(field => {
-            return {
-                ...field,
-                ref: createRef<HTMLInputElement>(),
-                validated: false
-            };
-        });
-
-        this.state = {
-            formFields
-        };
-    }
 
     /*
      * Render.
@@ -89,7 +70,7 @@ export default class SignInTheme extends PureComponent<SignInThemeProps, { formF
         const componentStyle = getStyles(styles.palette as NormalisedPalette);
 
         const { signUpClicked, forgotPasswordClick, onSuccess, callAPI } = this.props;
-        const { formFields } = this.state;
+        const { formFields } = this.props;
 
         return (
             <FormBase

--- a/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.tsx
@@ -15,9 +15,9 @@
 /*
  * Imports.
  */
-import React, { PureComponent, createRef, Fragment } from "react";
+import React, { PureComponent, Fragment } from "react";
 import StyleContext from "../../../styles/styleContext";
-import { FormFieldState, SignUpThemeProps } from "../../../../types";
+import { SignUpThemeProps } from "../../../../types";
 import { CSSObject } from "@emotion/serialize/types";
 
 /** @jsx jsx */
@@ -54,42 +54,8 @@ function getStyles(palette: NormalisedPalette): any {
  * Component.
  */
 
-export default class SignUpTheme extends PureComponent<SignUpThemeProps, { formFields: FormFieldState[] }> {
+export default class SignUpTheme extends PureComponent<SignUpThemeProps> {
     static contextType = StyleContext;
-
-    /*
-     * Constructor.
-     */
-    constructor(props: SignUpThemeProps) {
-        super(props);
-
-        const emailPasswordOnly = props.formFields.length === 2;
-        const formFields = props.formFields.map(field => {
-            return {
-                ...field,
-                ref: createRef<HTMLInputElement>(),
-                validated: false,
-                showIsRequired: (() => {
-                    // If email and password only, do not show required indicator (*).
-                    if (emailPasswordOnly) {
-                        return false;
-                    }
-                    // Otherwise, show for all non optional fields (including email and password).
-                    return field.optional === false;
-                })(),
-                validateOnBlurOnly: (() => {
-                    if (field.id === "email") {
-                        return props.validateEmail;
-                    }
-                    return undefined;
-                })()
-            };
-        });
-
-        this.state = {
-            formFields
-        };
-    }
 
     /*
      * Render.
@@ -98,7 +64,7 @@ export default class SignUpTheme extends PureComponent<SignUpThemeProps, { formF
         const styles = this.context;
         const componentStyles = getStyles(styles.palette as NormalisedPalette);
         const { privacyPolicyLink, termsOfServiceLink, signInClicked, onSuccess, callAPI } = this.props;
-        const { formFields } = this.state;
+        const { formFields } = this.props;
         return (
             <FormBase
                 formFields={formFields}

--- a/lib/ts/recipe/emailpassword/emailPassword.ts
+++ b/lib/ts/recipe/emailpassword/emailPassword.ts
@@ -114,7 +114,7 @@ export default class EmailPassword extends RecipeModule {
         });
     };
 
-    verifyEmailExists = async (value: string, headers: HeadersInit): Promise<VerifyEmailAPIResponse> => {
+    emailExistsAPI = async (value: string, headers: HeadersInit): Promise<VerifyEmailAPIResponse> => {
         return this.httpRequest.get(
             "/signup/email/exists",
             {

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -282,7 +282,7 @@ export type SignInAndUpProps = BaseProps & {
 
     onCallSignUpAPI?: (requestJson: RequestJson, headers: HeadersInit) => Promise<SignUpAPIResponse>;
 
-    verifyEmailExists?: (value: string, headers: HeadersInit) => Promise<VerifyEmailAPIResponse>;
+    onCallEmailExistsAPI?: (value: string, headers: HeadersInit) => Promise<VerifyEmailAPIResponse>;
 
     onCallSignInAPI?: (requestJson: RequestJson, headers: HeadersInit) => Promise<SignInAPIResponse>;
 };
@@ -360,11 +360,6 @@ export type SignUpThemeProps = ThemeBaseProps & {
      * Call Sign Up API.
      */
     callAPI: (fields: APIFormField[]) => Promise<SignUpThemeResponse>;
-
-    /*
-     * Verify if an email exist.
-     */
-    validateEmail: (value: string) => Promise<string | undefined>;
 };
 
 export type SignInAndUpThemeProps = {
@@ -391,7 +386,29 @@ export type NormalisedFormFieldWithError = NormalisedFormField & {
     error?: string;
 };
 
-export type FormFieldThemeProps = NormalisedFormFieldWithError;
+export type FormFieldThemeProps = NormalisedFormFieldWithError & {
+    /*
+     * Has the value already been submitted to its validator.
+     */
+    showIsRequired?: boolean;
+
+    /*
+     * Validate on blur only.
+     */
+    validateOnBlurOnly?: (value: string) => Promise<string | undefined>;
+
+    /*
+     * Autocomplete
+     */
+    autoComplete?: string;
+};
+
+export type FormFieldState = FormFieldThemeProps & {
+    /*
+     * Has the value already been submitted to its validator.
+     */
+    ref: RefObject<HTMLInputElement>;
+};
 
 export type FormFieldError = {
     /*
@@ -562,42 +579,11 @@ export type SubmitNewPasswordThemeProps = ThemeBaseProps & {
     onSignInClicked: () => void;
 };
 
-/*
- * State type.
- */
-
-export type FormFieldState = FormFieldThemeProps & {
-    /*
-     * Has the value already been submitted to its validator.
-     */
-    ref: RefObject<HTMLInputElement>;
-
-    /*
-     * Has the value already been submitted to its validator.
-     */
-    showIsRequired?: boolean;
-
-    /*
-     * Validate on blur only.
-     */
-    validateOnBlurOnly?: (value: string) => Promise<string | undefined>;
-
-    /*
-     * Autocomplete
-     */
-    autoComplete?: string;
-};
-
 export type EnterEmailThemeState = {
     /*
      * Has the email been sent already.
      */
     emailSent?: boolean;
-
-    /*
-     * Email FormField only.
-     */
-    formFields: FormFieldState[];
 };
 
 export type SubmitNewPasswordThemeState = {
@@ -605,11 +591,6 @@ export type SubmitNewPasswordThemeState = {
      * Has new password been set successfully.
      */
     hasNewPassword?: boolean;
-
-    /*
-     * Password and new password FormFields.
-     */
-    formFields: FormFieldState[];
 };
 
 export enum SignInAndUpStateStatus {
@@ -652,7 +633,7 @@ export type FormBaseProps = {
 
     footer?: JSX.Element;
 
-    formFields: FormFieldState[];
+    formFields: FormFieldThemeProps[];
 
     showLabels: boolean;
 


### PR DESCRIPTION
…e usless states in SignIn/SignUp/EnterEmail/SubmitNewPassword

Follow up on https://github.com/supertokens/supertokens-auth-react/pull/80

# Explanation of how we verify if email exists on blur for sign up only:

- The normalisation of form fields provided by the user in init config is kept unchanged. We can't add the email validation API call here because we do not have access to a potential onCallEmailExistsAPI props provided by the user.

`SignInAndUp.tsx`, (The feature component), which is responsible for:
   -  API calls (built-in or provided by props)
   - Render the themes and give them props (Including formatted formFields).
In `SignInAndUp.tsx`, we add the optional `validateOnBlurOnly` attribute to the `props.signUpForm.formFields`. 

See => https://github.com/supertokens/supertokens-auth-react/pull/81/files#diff-6f8b309acf2aa215826cb1f2ced7a0332da2a044ee71d28fec9f222ca73eb8dcR259

That way we do not have to pass `validateEmail` as a props anymore to `SignUp` which was indeed not optimal.


Then, in FormBase, whenever a field is blurred, https://github.com/supertokens/supertokens-auth-react/blob/0.2/lib/ts/recipe/emailpassword/components/library/FormBase.tsx#L79


The choice of introducing this new optional validateOnBlurOnly field attribute makes is easier to add validation on blur only.
I thought about merging the `verifyEmail` to the validate method directly, but then how do you know the method is called in the context of input blur or if it is called in the context of a signup call?

