### PR TITLE
no validateOnBlur method given to themes

### DIFF
--- a/lib/build/recipe/emailpassword/components/features/signInAndUp/SignInAndUp.d.ts
+++ b/lib/build/recipe/emailpassword/components/features/signInAndUp/SignInAndUp.d.ts
@@ -19,7 +19,7 @@ declare class SignInAndUp extends PureComponent<SignInAndUpProps, SignInAndUpSta
     onCallSignInAPI: (requestJson: RequestJson, headers: HeadersInit) => Promise<SignInAPIResponse>;
     onCallEmailExistAPI: (value: string, headers: HeadersInit) => Promise<VerifyEmailAPIResponse>;
     validateEmail: (value: string) => Promise<string | undefined>;
-    getSignUpFeatureFormFields(formFields: NormalisedFormField[]): FormFieldThemeProps[];
+    getThemeSignUpFeatureFormFields(formFields: NormalisedFormField[]): FormFieldThemeProps[];
     componentDidMount: () => Promise<void>;
     render: () => JSX.Element;
 }

--- a/lib/build/recipe/emailpassword/components/features/signInAndUp/SignInAndUp.js
+++ b/lib/build/recipe/emailpassword/components/features/signInAndUp/SignInAndUp.js
@@ -796,7 +796,7 @@ var SignInAndUp = /*#__PURE__*/ (function(_PureComponent) {
             };
             var signUpForm = {
                 styleFromInit: signUpFeature.style,
-                formFields: _this.getSignUpFeatureFormFields(signUpFeature.formFields),
+                formFields: _this.getThemeSignUpFeatureFormFields(signUpFeature.formFields),
                 privacyPolicyLink: signUpFeature.privacyPolicyLink,
                 termsOfServiceLink: signUpFeature.termsOfServiceLink,
                 onSuccess: _this.onSignUpSuccess,
@@ -875,8 +875,8 @@ var SignInAndUp = /*#__PURE__*/ (function(_PureComponent) {
             }
         },
         {
-            key: "getSignUpFeatureFormFields",
-            value: function getSignUpFeatureFormFields(formFields) {
+            key: "getThemeSignUpFeatureFormFields",
+            value: function getThemeSignUpFeatureFormFields(formFields) {
                 var _this2 = this;
 
                 var emailPasswordOnly = formFields.length === 2;
@@ -893,12 +893,59 @@ var SignInAndUp = /*#__PURE__*/ (function(_PureComponent) {
 
                                 return field.optional === false;
                             })(),
-                            validateOnBlurOnly: (function() {
-                                if (field.id === "email") {
-                                    return _this2.validateEmail;
-                                }
+                            validate: (function() {
+                                // If field is not email, return field validate unchanged.
+                                if (field.id !== "email") {
+                                    return field.validate;
+                                } // Otherwise, if email, use syntax validate method and check if email exists.
 
-                                return undefined;
+                                return /*#__PURE__*/ (function() {
+                                    var _ref13 = _asyncToGenerator(
+                                        /*#__PURE__*/ regeneratorRuntime.mark(function _callee13(value) {
+                                            var syntaxError;
+                                            return regeneratorRuntime.wrap(function _callee13$(_context13) {
+                                                while (1) {
+                                                    switch ((_context13.prev = _context13.next)) {
+                                                        case 0:
+                                                            syntaxError = field.validate(value);
+
+                                                            if (!(syntaxError !== undefined)) {
+                                                                _context13.next = 3;
+                                                                break;
+                                                            }
+
+                                                            return _context13.abrupt("return", syntaxError);
+
+                                                        case 3:
+                                                            if (!(typeof value !== "string")) {
+                                                                _context13.next = 5;
+                                                                break;
+                                                            }
+
+                                                            return _context13.abrupt(
+                                                                "return",
+                                                                "Email must be of type string"
+                                                            );
+
+                                                        case 5:
+                                                            return _context13.abrupt(
+                                                                "return",
+                                                                _this2.validateEmail(value)
+                                                            );
+
+                                                        case 6:
+                                                        case "end":
+                                                            return _context13.stop();
+                                                    }
+                                                }
+                                            }, _callee13);
+                                        })
+                                    );
+
+                                    return function(_x11) {
+                                        return _ref13.apply(this, arguments);
+                                    };
+                                })();
                             })()
                         }
                     );

--- a/lib/build/recipe/emailpassword/components/library/FormBase.js
+++ b/lib/build/recipe/emailpassword/components/library/FormBase.js
@@ -336,7 +336,7 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
         _this.handleInputBlur = /*#__PURE__*/ (function() {
             var _ref2 = _asyncToGenerator(
                 /*#__PURE__*/ regeneratorRuntime.mark(function _callee2(field) {
-                    var formFields, i, validateOnBlurOnly, status;
+                    var formFields, i, status;
                     return regeneratorRuntime.wrap(function _callee2$(_context2) {
                         while (1) {
                             switch ((_context2.prev = _context2.next)) {
@@ -346,12 +346,12 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
 
                                 case 2:
                                     if (!(i < formFields.length)) {
-                                        _context2.next = 15;
+                                        _context2.next = 10;
                                         break;
                                     }
 
                                     if (!(field.id === formFields[i].id)) {
-                                        _context2.next = 12;
+                                        _context2.next = 7;
                                         break;
                                     }
 
@@ -360,25 +360,13 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
 
                                 case 6:
                                     formFields[i].error = _context2.sent;
-                                    validateOnBlurOnly = formFields[i].validateOnBlurOnly;
 
-                                    if (!(formFields[i].error === undefined && validateOnBlurOnly !== undefined)) {
-                                        _context2.next = 12;
-                                        break;
-                                    }
-
-                                    _context2.next = 11;
-                                    return validateOnBlurOnly(field.value);
-
-                                case 11:
-                                    formFields[i].error = _context2.sent;
-
-                                case 12:
+                                case 7:
                                     i++;
                                     _context2.next = 2;
                                     break;
 
-                                case 15:
+                                case 10:
                                     status = _this.getNewStatus(formFields, "blur"); // Slightly delay the update to prevent UI glitches.
 
                                     setTimeout(function() {
@@ -395,7 +383,7 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
                                         });
                                     }, 300);
 
-                                case 17:
+                                case 12:
                                 case "end":
                                     return _context2.stop();
                             }
@@ -597,9 +585,9 @@ var FormBase = /*#__PURE__*/ (function(_PureComponent) {
                     footer = _this$props.footer,
                     buttonLabel = _this$props.buttonLabel,
                     showLabels = _this$props.showLabels,
-                    noValidateOnBlur = _this$props.noValidateOnBlur;
+                    validateOnBlur = _this$props.validateOnBlur;
                 var formFields = this.state.formFields;
-                var onInputBlur = noValidateOnBlur === true ? undefined : this.handleInputBlur;
+                var onInputBlur = validateOnBlur === true ? this.handleInputBlur : undefined;
                 return (0, _core.jsx)(
                     "div",
                     {

--- a/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.js
@@ -289,6 +289,7 @@ var EnterEmailTheme = /*#__PURE__*/ (function(_PureComponent) {
                     onSuccess: this.onSuccess,
                     callAPI: callAPI,
                     showLabels: false,
+                    validateOnBlur: true,
                     header: (0, _core.jsx)(
                         _react.Fragment,
                         null,

--- a/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.js
@@ -258,7 +258,7 @@ var SubmitNewPasswordTheme = /*#__PURE__*/ (function(_PureComponent) {
                                 "div",
                                 {
                                     className: "headerTitle",
-                                    css: styles.headerTitle
+                                    css: [componentStyles.headerTitle, styles.headerTitle]
                                 },
                                 "Success!"
                             ),
@@ -299,6 +299,7 @@ var SubmitNewPasswordTheme = /*#__PURE__*/ (function(_PureComponent) {
                     formFields: formFields,
                     buttonLabel: "Change password",
                     onSuccess: this.onSuccess,
+                    validateOnBlur: true,
                     callAPI: callAPI,
                     showLabels: false,
                     header: (0, _core.jsx)(
@@ -316,7 +317,7 @@ var SubmitNewPasswordTheme = /*#__PURE__*/ (function(_PureComponent) {
                             "div",
                             {
                                 className: "headerSubtitle",
-                                css: styles.headerSubTitle
+                                css: [componentStyles.headerSubTitle, styles.headerSubTitle]
                             },
                             (0, _core.jsx)(
                                 "div",

--- a/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.js
@@ -222,7 +222,6 @@ var SignInTheme = /*#__PURE__*/ (function(_PureComponent) {
                     onSuccess: onSuccess,
                     callAPI: callAPI,
                     showLabels: true,
-                    noValidateOnBlur: true,
                     header: (0, _core.jsx)(
                         _react.Fragment,
                         null,

--- a/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.js
@@ -224,6 +224,7 @@ var SignUpTheme = /*#__PURE__*/ (function(_PureComponent) {
                     buttonLabel: "SIGN UP",
                     onSuccess: onSuccess,
                     callAPI: callAPI,
+                    validateOnBlur: true,
                     showLabels: true,
                     header: (0, _core.jsx)(
                         _react.Fragment,

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -122,7 +122,6 @@ export declare type NormalisedFormFieldWithError = NormalisedFormField & {
 };
 export declare type FormFieldThemeProps = NormalisedFormFieldWithError & {
     showIsRequired?: boolean;
-    validateOnBlurOnly?: (value: string) => Promise<string | undefined>;
     autoComplete?: string;
 };
 export declare type FormFieldState = FormFieldThemeProps & {
@@ -230,7 +229,7 @@ export declare type FormBaseProps = {
     formFields: FormFieldThemeProps[];
     showLabels: boolean;
     buttonLabel: string;
-    noValidateOnBlur?: boolean;
+    validateOnBlur?: boolean;
     onSuccess?: () => void;
     callAPI: (fields: APIFormField[]) => Promise<SignInThemeResponse | SignUpThemeResponse | SubmitNewPasswordThemeResponse | EnterEmailThemeResponse>;
 };

--- a/lib/ts/recipe/emailpassword/components/library/FormBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/FormBase.tsx
@@ -80,11 +80,6 @@ export default class FormBase extends PureComponent<FormBaseProps, FormBaseState
             if (field.id === formFields[i].id) {
                 // Validate.
                 formFields[i].error = await formFields[i].validate(field.value);
-                const validateOnBlurOnly = formFields[i].validateOnBlurOnly;
-
-                if (formFields[i].error === undefined && validateOnBlurOnly !== undefined) {
-                    formFields[i].error = await validateOnBlurOnly(field.value);
-                }
             }
         }
         const status = this.getNewStatus(formFields, "blur");
@@ -213,9 +208,9 @@ export default class FormBase extends PureComponent<FormBaseProps, FormBaseState
      */
     render(): JSX.Element {
         const styles = this.context;
-        const { header, footer, buttonLabel, showLabels, noValidateOnBlur } = this.props;
+        const { header, footer, buttonLabel, showLabels, validateOnBlur } = this.props;
         const { formFields } = this.state;
-        const onInputBlur = noValidateOnBlur === true ? undefined : this.handleInputBlur;
+        const onInputBlur = validateOnBlur === true ? this.handleInputBlur : undefined;
 
         return (
             <div className="container" css={styles.container}>

--- a/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/enterEmail.tsx
@@ -121,6 +121,7 @@ export default class EnterEmailTheme extends PureComponent<EnterEmailThemeProps,
                 onSuccess={this.onSuccess}
                 callAPI={callAPI}
                 showLabels={false}
+                validateOnBlur={true}
                 header={
                     <Fragment>
                         <div className="headerTitle" css={[componentStyles.headerTitle, styles.headerTitle]}>

--- a/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/resetPasswordUsingToken/submitNewPassword.tsx
@@ -99,7 +99,7 @@ export default class SubmitNewPasswordTheme extends PureComponent<
             return (
                 <div className="container" css={styles.container}>
                     <div className="row" css={styles.row}>
-                        <div className="headerTitle" css={styles.headerTitle}>
+                        <div className="headerTitle" css={[componentStyles.headerTitle, styles.headerTitle]}>
                             Success!
                         </div>
                         <FormRow key="form-button">
@@ -128,6 +128,7 @@ export default class SubmitNewPasswordTheme extends PureComponent<
                 formFields={formFields}
                 buttonLabel={"Change password"}
                 onSuccess={this.onSuccess}
+                validateOnBlur={true}
                 callAPI={callAPI}
                 showLabels={false}
                 header={
@@ -135,7 +136,7 @@ export default class SubmitNewPasswordTheme extends PureComponent<
                         <div className="headerTitle" css={[componentStyles.headerTitle, styles.headerTitle]}>
                             Change your password
                         </div>
-                        <div className="headerSubtitle" css={styles.headerSubTitle}>
+                        <div className="headerSubtitle" css={[componentStyles.headerSubTitle, styles.headerSubTitle]}>
                             <div className="secondaryText" css={styles.secondaryText}>
                                 Enter a new password below to change your password
                             </div>

--- a/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignIn.tsx
@@ -79,7 +79,6 @@ export default class SignInTheme extends PureComponent<SignInThemeProps> {
                 onSuccess={onSuccess}
                 callAPI={callAPI}
                 showLabels={true}
-                noValidateOnBlur={true}
                 header={
                     <Fragment>
                         <div className="headerTitle" css={[componentStyle.headerTitle, styles.headerTitle]}>

--- a/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/default/signInAndUp/SignUp.tsx
@@ -71,6 +71,7 @@ export default class SignUpTheme extends PureComponent<SignUpThemeProps> {
                 buttonLabel={"SIGN UP"}
                 onSuccess={onSuccess}
                 callAPI={callAPI}
+                validateOnBlur={true}
                 showLabels={true}
                 header={
                     <Fragment>

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -393,11 +393,6 @@ export type FormFieldThemeProps = NormalisedFormFieldWithError & {
     showIsRequired?: boolean;
 
     /*
-     * Validate on blur only.
-     */
-    validateOnBlurOnly?: (value: string) => Promise<string | undefined>;
-
-    /*
      * Autocomplete
      */
     autoComplete?: string;
@@ -639,7 +634,7 @@ export type FormBaseProps = {
 
     buttonLabel: string;
 
-    noValidateOnBlur?: boolean;
+    validateOnBlur?: boolean;
 
     onSuccess?: () => void;
 


### PR DESCRIPTION
- Refactoring to merge user provided form field `validate` method for email with `validateEmail` API Call to verify if an email exists.
That way, the theme can validate on blur using only `field.validate` method.

Changes to what we decided in our call:
 - We keep the validation when SignUp except that **we do not check if email exists when signUp is clicked**

The reasons for this choice are:
     - We still validate the last focused input, so if there is an error here that can be catch by validators, there is no API call.
     - All the default validators are not async, so the time taken by this extra check is negligible.
     - **Most importantly**, if someone implements the a custom theme, they shouldn't have to run the validation themselves if they do not want to validate on blur. This should still be taken care of by the feature.


Validate on blur for:
 - Sign Up
 - Reset password
Do not validate on blur for: 
 - Sign In