### PR TITLE
always disable shadow DOM for IE

### DIFF
--- a/lib/babel.config.js
+++ b/lib/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-    presets: ['@babel/preset-typescript', '@babel/preset-env', '@babel/preset-react'],
-    plugins: ["transform-class-properties"] 
-}
+    presets: ["@babel/preset-typescript", "@babel/preset-env", "@babel/preset-react"],
+    plugins: ["transform-class-properties"]
+};

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -241,4 +241,9 @@ export declare type SignInAPI = (requestJson: RequestJson, headers: HeadersInit)
 export declare type VerifyEmailAPI = (value: string, headers: HeadersInit) => Promise<VerifyEmailAPIResponse>;
 export declare type EnterEmailAPI = (requestJson: RequestJson, headers: HeadersInit) => Promise<EnterEmailAPIResponse>;
 export declare type SubmitNewPasswordAPI = (requestJson: RequestJson, headers: HeadersInit) => Promise<SubmitNewPasswordAPIResponse>;
+declare global {
+    interface Document {
+        documentMode?: any;
+    }
+}
 export {};

--- a/lib/build/recipe/emailpassword/utils.js
+++ b/lib/build/recipe/emailpassword/utils.js
@@ -144,7 +144,7 @@ function normaliseEmailPasswordConfig(config) {
         config.resetPasswordUsingTokenFeature
     );
     var palette = config.palette !== undefined ? config.palette : {};
-    var useShadowDom = config.useShadowDom !== undefined ? config.useShadowDom : true;
+    var useShadowDom = getShouldUseShadowDom(config.useShadowDom);
     return {
         palette: palette,
         useShadowDom: useShadowDom,
@@ -448,4 +448,19 @@ function getFormattedFormField(field) {
             })()
         }
     );
+}
+
+function getShouldUseShadowDom(useShadowDom) {
+    /*
+     * Detect if browser is IE
+     * In order to disable unsupported shadowDom
+     * https://github.com/supertokens/supertokens-auth-react/issues/99
+     */
+    var isIE = window.document.documentMode !== undefined; // If browser is Internet Explorer, always disable shadow dom.
+
+    if (isIE === true) {
+        return false;
+    } // Otherwise, use provided config or default to true.
+
+    return useShadowDom !== undefined ? useShadowDom : true;
 }

--- a/lib/build/recipe/emailpassword/utils.js
+++ b/lib/build/recipe/emailpassword/utils.js
@@ -14,6 +14,8 @@ exports.getFormattedFormField = getFormattedFormField;
 
 var _normalisedURLPath = _interopRequireDefault(require("../../normalisedURLPath"));
 
+var _utils = require("../../utils");
+
 var _constants = require("./constants");
 
 var _validators = require("./validators");
@@ -456,7 +458,7 @@ function getShouldUseShadowDom(useShadowDom) {
      * In order to disable unsupported shadowDom
      * https://github.com/supertokens/supertokens-auth-react/issues/99
      */
-    var isIE = window.document.documentMode !== undefined; // If browser is Internet Explorer, always disable shadow dom.
+    var isIE = (0, _utils.getWindowOrThrow)().document.documentMode !== undefined; // If browser is Internet Explorer, always disable shadow dom.
 
     if (isIE === true) {
         return false;

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -655,3 +655,12 @@ export type SubmitNewPasswordAPI = (
     requestJson: RequestJson,
     headers: HeadersInit
 ) => Promise<SubmitNewPasswordAPIResponse>;
+
+/*
+ *  Add documentMode to document object in order to use to detect if browser is IE.
+ */
+declare global {
+    interface Document {
+        documentMode?: any;
+    }
+}

--- a/lib/ts/recipe/emailpassword/utils.ts
+++ b/lib/ts/recipe/emailpassword/utils.ts
@@ -64,7 +64,7 @@ export function normaliseEmailPasswordConfig(config: EmailPasswordConfig): Norma
 
     const palette = config.palette !== undefined ? config.palette : {};
 
-    const useShadowDom = config.useShadowDom !== undefined ? config.useShadowDom : true;
+    const useShadowDom = getShouldUseShadowDom(config.useShadowDom);
 
     return {
         palette,
@@ -353,4 +353,20 @@ export function getFormattedFormField(field: NormalisedFormField): NormalisedFor
             return await field.validate(value);
         }
     };
+}
+
+function getShouldUseShadowDom(useShadowDom?: boolean): boolean {
+    /*
+     * Detect if browser is IE
+     * In order to disable unsupported shadowDom
+     * https://github.com/supertokens/supertokens-auth-react/issues/99
+     */
+    const isIE = window.document.documentMode !== undefined;
+    // If browser is Internet Explorer, always disable shadow dom.
+    if (isIE === true) {
+        return false;
+    }
+
+    // Otherwise, use provided config or default to true.
+    return useShadowDom !== undefined ? useShadowDom : true;
 }

--- a/lib/ts/recipe/emailpassword/utils.ts
+++ b/lib/ts/recipe/emailpassword/utils.ts
@@ -15,6 +15,7 @@
 
 import NormalisedURLPath from "../../normalisedURLPath";
 import { FormField, FormFieldBaseConfig, NormalisedAppInfo, NormalisedFormField } from "../../types";
+import { getWindowOrThrow } from "../../utils";
 import { DEFAULT_RESET_PASSWORD_PATH, MANDATORY_FORM_FIELDS_ID, MANDATORY_FORM_FIELDS_ID_ARRAY } from "./constants";
 import {
     EmailPasswordConfig,
@@ -361,7 +362,7 @@ function getShouldUseShadowDom(useShadowDom?: boolean): boolean {
      * In order to disable unsupported shadowDom
      * https://github.com/supertokens/supertokens-auth-react/issues/99
      */
-    const isIE = window.document.documentMode !== undefined;
+    const isIE = getWindowOrThrow().document.documentMode !== undefined;
     // If browser is Internet Explorer, always disable shadow dom.
     if (isIE === true) {
         return false;


### PR DESCRIPTION
# Disable shadow DOM for IE.

I've tested that it does not impact any other browser than IE.
I've tested that the code used to detect IE works properly (using https://www.browserling.com/).

I haven't successfully tested that the library works on IE11 since my test app does not work in IE11 (even without Supertokens). IE does not really work with react (see https://github.com/supertokens/supertokens-auth-react/issues/99).