### PR TITLE
add right padding to input

### DIFF
--- a/lib/build/recipe/emailpassword/components/themes/default/styles/styles.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/styles/styles.js
@@ -126,6 +126,7 @@ function getDefaultStyles(palette) {
             border: "1px solid #dddddd",
             fontSize: palette.fonts.size[0],
             paddingLeft: "20px",
+            paddingRight: "20px",
             letterSpacing: "1.2px",
             "&:focus": {
                 border: "1px solid ".concat(palette.colors.primary),

--- a/lib/ts/recipe/emailpassword/components/themes/default/styles/styles.ts
+++ b/lib/ts/recipe/emailpassword/components/themes/default/styles/styles.ts
@@ -142,6 +142,7 @@ export function getDefaultStyles(palette: NormalisedPalette): NormalisedDefaultS
             border: "1px solid #dddddd",
             fontSize: palette.fonts.size[0],
             paddingLeft: "20px",
+            paddingRight: "20px",
             letterSpacing: "1.2px",
             "&:focus": {
                 border: `1px solid ${palette.colors.primary}`,


### PR DESCRIPTION
Fix https://github.com/supertokens/supertokens-core/issues/162

![auth-react-inpout-right-padding](https://user-images.githubusercontent.com/5072452/104889175-18a9fc00-596e-11eb-8812-f54b60ee40d0.gif)
