### PR TITLE
fix width issue when wrapped in display flex container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2020-01-18
+
+### Fixes
+- Fix width when wrapped in flex container
+- Fix right input padding
+
+## [0.4.1] - 2020-01-16
+
+### Fixes
+- Mobile responsiveness
 ## [0.4.0] - 2020-01-07
 
 ### Added

--- a/lib/build/recipe/emailpassword/components/themes/default/styles/styles.js
+++ b/lib/build/recipe/emailpassword/components/themes/default/styles/styles.js
@@ -79,13 +79,13 @@ function getDefaultStyles(palette) {
             margin: "12px auto",
             marginTop: "26px",
             marginBottom: "26px",
-            maxWidth: "420px",
+            width: "420px",
             textAlign: "center",
             borderRadius: "8px",
             boxShadow: "1px 1px 10px rgba(0,0,0,0.16)",
             backgroundColor: palette.colors.background,
             "@media (max-width: 440px)": {
-                maxWidth: "95vw"
+                width: "95vw"
             }
         },
         row: {

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const package_version = "0.4.1";
+export declare const package_version = "0.4.2";
 export declare const supported_fdi: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -19,7 +19,7 @@ exports.supported_fdi = exports.package_version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var package_version = "0.4.1";
+var package_version = "0.4.2";
 exports.package_version = package_version;
 var supported_fdi = ["1.5"];
 exports.supported_fdi = supported_fdi;

--- a/lib/ts/recipe/emailpassword/components/themes/default/styles/styles.ts
+++ b/lib/ts/recipe/emailpassword/components/themes/default/styles/styles.ts
@@ -90,13 +90,13 @@ export function getDefaultStyles(palette: NormalisedPalette): NormalisedDefaultS
             margin: "12px auto",
             marginTop: "26px",
             marginBottom: "26px",
-            maxWidth: "420px",
+            width: "420px",
             textAlign: "center",
             borderRadius: "8px",
             boxShadow: "1px 1px 10px rgba(0,0,0,0.16)",
             backgroundColor: palette.colors.background,
             "@media (max-width: 440px)": {
-                maxWidth: "95vw"
+                width: "95vw"
             }
         },
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,5 +12,5 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.4.1";
+export const package_version = "0.4.2";
 export const supported_fdi = ["1.5"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "supertokens-auth-react",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supertokens-auth-react",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "ReactJS SDK that provides login functionality with SuperTokens.",
   "main": "./index.js",
   "devDependencies": {

--- a/test/react-test-app/src/App.css
+++ b/test/react-test-app/src/App.css
@@ -53,7 +53,6 @@ h1 {
 
 .page {
     flex: 3 0 auto;
-    width: 100vw;
 }
 
 /* Navbar */


### PR DESCRIPTION
Because of the last PR using `maxWidth` to define the container's width (`in 0.4.1`), the form is getting squashed when wrapped in a html tag that uses `display:flex`. 
This fixes to make sure the width is always as expected. This PR keeps the mobile responsiveness introduced in `0.4.1` but also fixes this issue.