### PR TITLE
auth recipe module

### DIFF
--- a/examples/for-tests/src/themes/signInAndUp.js
+++ b/examples/for-tests/src/themes/signInAndUp.js
@@ -16,7 +16,7 @@ export default function SignInAndUp(props){
      */
     const [isSignIn, setSignIn] = useState(false);
 
-    const palette = EmailPassword.getInstanceOrThrow().getConfig().palette;
+    const palette = EmailPassword.getInstanceOrThrow().config.palette;
     /*
      * Render.
      */
@@ -111,7 +111,7 @@ function SignIn (props) {
      * Render.
      */
 
-    const palette = EmailPassword.getInstanceOrThrow().getConfig().palette;
+    const palette = EmailPassword.getInstanceOrThrow().config.palette;
     return (
         <div>
             <form onSubmit={signIn}>

--- a/lib/build/httpRequest.js
+++ b/lib/build/httpRequest.js
@@ -268,7 +268,7 @@ var HttpRequest = /** @class */ (function() {
                                         headers: __assign({}, headers, {
                                             "fdi-version": version_1.supported_fdi.join(","),
                                             "Content-Type": "application/json",
-                                            rid: this.recipe.getRecipeId()
+                                            rid: this.recipe.recipeId
                                         })
                                     })
                                 })
@@ -305,8 +305,8 @@ var HttpRequest = /** @class */ (function() {
             var path = new normalisedURLPath_1.default(pathStr);
             var fullUrl =
                 "" +
-                _this.recipe.getAppInfo().apiDomain.getAsStringDangerous() +
-                _this.recipe.getAppInfo().apiBasePath.getAsStringDangerous() +
+                _this.recipe.appInfo.apiDomain.getAsStringDangerous() +
+                _this.recipe.appInfo.apiBasePath.getAsStringDangerous() +
                 path.getAsStringDangerous();
             if (queryParams === undefined) {
                 return fullUrl;

--- a/lib/build/recipe/authRecipeModule.d.ts
+++ b/lib/build/recipe/authRecipeModule.d.ts
@@ -1,0 +1,12 @@
+import { AuthRecipeModuleConfig, NormalisedAuthRecipeConfig, NormalisedAuthRecipeConfigHooks, NormalisedRecipeModuleHooks, SuccessAPIResponse } from "../types";
+import RecipeModule from "./recipeModule";
+import { History } from "history";
+export default abstract class AuthRecipeModule extends RecipeModule {
+    config: NormalisedAuthRecipeConfig;
+    hooks: NormalisedAuthRecipeConfigHooks & NormalisedRecipeModuleHooks;
+    constructor(config: AuthRecipeModuleConfig<unknown, unknown, unknown>);
+    redirect: (context: unknown, history?: History<unknown> | undefined, queryParams?: Record<string, string> | undefined) => Promise<void>;
+    getRedirectUrl: (context: any) => Promise<string>;
+    abstract getDefaultRedirectionURL(context: unknown): Promise<string>;
+    abstract signOut(): Promise<SuccessAPIResponse>;
+}

--- a/lib/build/recipe/authRecipeModule.js
+++ b/lib/build/recipe/authRecipeModule.js
@@ -1,0 +1,261 @@
+"use strict";
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+var __extends =
+    (this && this.__extends) ||
+    (function() {
+        var extendStatics = function(d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function(d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function(d, b) {
+                    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function(d, b) {
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function() {
+        __assign =
+            Object.assign ||
+            function(t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function(thisArg, _arguments, P, generator) {
+        return new (P || (P = Promise))(function(resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done
+                    ? resolve(result.value)
+                    : new P(function(resolve) {
+                          resolve(result.value);
+                      }).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function(thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function() {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: []
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function() {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function(v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function(mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+var utils_1 = require("../utils");
+var recipeModule_1 = __importDefault(require("./recipeModule"));
+var normalisedURLDomain_1 = __importDefault(require("../normalisedURLDomain"));
+/*
+ * Class.
+ */
+var AuthRecipeModule = /** @class */ (function(_super) {
+    __extends(AuthRecipeModule, _super);
+    /*
+     * Constructor.
+     */
+    function AuthRecipeModule(config) {
+        var _this = _super.call(this, config) || this;
+        _this.redirect = function(context, history, queryParams) {
+            return __awaiter(_this, void 0, void 0, function() {
+                var redirectUrl, origin_1;
+                return __generator(this, function(_a) {
+                    switch (_a.label) {
+                        case 0:
+                            return [4 /*yield*/, this.getRedirectUrl(context)];
+                        case 1:
+                            redirectUrl = _a.sent();
+                            redirectUrl = utils_1.appendQueryParamsToURL(redirectUrl, queryParams);
+                            try {
+                                new URL(redirectUrl); // If full URL, no error thrown, skip in app redirection.
+                            } catch (e) {
+                                origin_1 = new normalisedURLDomain_1.default(
+                                    utils_1.getWindowOrThrow().location.origin
+                                ).getAsStringDangerous();
+                                if (origin_1 !== this.appInfo.websiteDomain.getAsStringDangerous()) {
+                                    redirectUrl = "" + this.appInfo.websiteDomain.getAsStringDangerous() + redirectUrl;
+                                    utils_1.getWindowOrThrow().location.href = redirectUrl;
+                                    return [2 /*return*/];
+                                }
+                                // If history was provided, use to redirect without reloading.
+                                if (history !== undefined) {
+                                    history.push(redirectUrl);
+                                    return [2 /*return*/];
+                                }
+                            }
+                            // Otherwise, redirect in app.
+                            utils_1.getWindowOrThrow().location.href = redirectUrl;
+                            return [2 /*return*/];
+                    }
+                });
+            });
+        };
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+        _this.getRedirectUrl = function(context) {
+            return __awaiter(_this, void 0, void 0, function() {
+                var redirectUrl;
+                return __generator(this, function(_a) {
+                    switch (_a.label) {
+                        case 0:
+                            return [4 /*yield*/, this.hooks.getRedirectionURL(context)];
+                        case 1:
+                            redirectUrl = _a.sent();
+                            if (redirectUrl !== undefined) {
+                                return [2 /*return*/, redirectUrl];
+                            }
+                            return [4 /*yield*/, this.getDefaultRedirectionURL(context)];
+                        case 2:
+                            // Otherwise, use default.
+                            return [2 /*return*/, _a.sent()];
+                    }
+                });
+            });
+        };
+        _this.config = __assign({}, _this.config, utils_1.normaliseAuthRecipeModuleConfig(config));
+        _this.hooks = __assign({}, _this.hooks, utils_1.normalisedAuthRecipeConfigHooks(config));
+        return _this;
+    }
+    return AuthRecipeModule;
+})(recipeModule_1.default);
+exports.default = AuthRecipeModule;

--- a/lib/build/recipe/emailpassword/components/emailPasswordAuth.js
+++ b/lib/build/recipe/emailpassword/components/emailPasswordAuth.js
@@ -252,7 +252,7 @@ var EmailPasswordAuth = /** @class */ (function(_super) {
                             status: "READY"
                         });
                         // If email verification mode is off or optional, return.
-                        if (this.getRecipeInstanceOrThrow().getConfig().emailVerificationFeature.mode !== "REQUIRED") {
+                        if (this.getRecipeInstanceOrThrow().config.emailVerificationFeature.mode !== "REQUIRED") {
                             return [2 /*return*/];
                         }
                         return [4 /*yield*/, this.isEmailVerifiedAPI()];

--- a/lib/build/recipe/emailpassword/components/features/emailVerification/api.js
+++ b/lib/build/recipe/emailpassword/components/features/emailVerification/api.js
@@ -154,7 +154,7 @@ function verifyEmailAPI(recipe, token) {
                 case 0:
                     return [
                         4 /*yield*/,
-                        recipe.getHttp().post(
+                        recipe.httpRequest.post(
                             "/user/email/verify",
                             {
                                 body: JSON.stringify({
@@ -197,7 +197,7 @@ function sendVerifyEmailAPI(recipe) {
         return __generator(this, function(_a) {
             switch (_a.label) {
                 case 0:
-                    return [4 /*yield*/, recipe.getHttp().post("/user/email/verify/token", {}, "SEND_VERIFY_EMAIL")];
+                    return [4 /*yield*/, recipe.httpRequest.post("/user/email/verify/token", {}, "SEND_VERIFY_EMAIL")];
                 case 1:
                     response = _a.sent();
                     // If email already verified.
@@ -230,7 +230,7 @@ function isEmailVerifiedAPI(recipe) {
         return __generator(this, function(_a) {
             switch (_a.label) {
                 case 0:
-                    return [4 /*yield*/, recipe.getHttp().get("/user/email/verify", {}, "IS_EMAIL_VERIFIED")];
+                    return [4 /*yield*/, recipe.httpRequest.get("/user/email/verify", {}, "IS_EMAIL_VERIFIED")];
                 case 1:
                     response = _a.sent();
                     return [2 /*return*/, response.isVerified];

--- a/lib/build/recipe/emailpassword/components/features/emailVerification/emailVerification.js
+++ b/lib/build/recipe/emailpassword/components/features/emailVerification/emailVerification.js
@@ -286,7 +286,7 @@ var EmailVerification = /** @class */ (function(_super) {
             });
         };
         _this.render = function() {
-            var sendVerifyEmailScreenFeature = _this.getRecipeInstanceOrThrow().getConfig().emailVerificationFeature
+            var sendVerifyEmailScreenFeature = _this.getRecipeInstanceOrThrow().config.emailVerificationFeature
                 .sendVerifyEmailScreen;
             var sendVerifyEmailScreen = {
                 styleFromInit: sendVerifyEmailScreenFeature.style,
@@ -312,8 +312,8 @@ var EmailVerification = /** @class */ (function(_super) {
                     return _this.getRecipeInstanceOrThrow().redirect({ action: "SUCCESS" }, _this.props.history);
                 }
             };
-            var verifyEmailLinkClickedScreenFeature = _this.getRecipeInstanceOrThrow().getConfig()
-                .emailVerificationFeature.verifyEmailLinkClickedScreen;
+            var verifyEmailLinkClickedScreenFeature = _this.getRecipeInstanceOrThrow().config.emailVerificationFeature
+                .verifyEmailLinkClickedScreen;
             var verifyEmailLinkClickedScreen = {
                 styleFromInit: verifyEmailLinkClickedScreenFeature.style,
                 onTokenInvalidRedirect: _this.onTokenInvalidRedirect,
@@ -341,7 +341,7 @@ var EmailVerification = /** @class */ (function(_super) {
                     });
                 }
             };
-            var useShadowDom = _this.getRecipeInstanceOrThrow().getConfig().useShadowDom;
+            var useShadowDom = _this.getRecipeInstanceOrThrow().config.useShadowDom;
             var hasToken = _this.state.token.length !== 0;
             /*
              * Render.
@@ -383,7 +383,7 @@ var EmailVerification = /** @class */ (function(_super) {
             return __generator(this, function(_a) {
                 switch (_a.label) {
                     case 0:
-                        if (!(this.getRecipeInstanceOrThrow().getConfig().emailVerificationFeature.mode !== "REQUIRED"))
+                        if (!(this.getRecipeInstanceOrThrow().config.emailVerificationFeature.mode !== "REQUIRED"))
                             return [3 /*break*/, 2];
                         return [
                             4 /*yield*/,

--- a/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/api.js
+++ b/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/api.js
@@ -154,7 +154,7 @@ function handleSubmitNewPasswordAPI(formFields, recipe, token) {
                 case 0:
                     return [
                         4 /*yield*/,
-                        recipe.getHttp().post(
+                        recipe.httpRequest.post(
                             "/user/password/reset",
                             {
                                 body: JSON.stringify({ formFields: formFields, token: token })
@@ -207,7 +207,7 @@ function enterEmailAPI(formFields, recipe) {
                 case 0:
                     return [
                         4 /*yield*/,
-                        recipe.getHttp().post(
+                        recipe.httpRequest.post(
                             "/user/password/reset/token",
                             {
                                 body: JSON.stringify({ formFields: formFields })

--- a/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/resetPasswordUsingToken.js
+++ b/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/resetPasswordUsingToken.js
@@ -223,7 +223,7 @@ var ResetPasswordUsingToken = /** @class */ (function(_super) {
                                 4 /*yield*/,
                                 utils_1.validateForm(
                                     formFields,
-                                    this.getRecipeInstanceOrThrow().getConfig().resetPasswordUsingTokenFeature
+                                    this.getRecipeInstanceOrThrow().config.resetPasswordUsingTokenFeature
                                         .submitNewPasswordForm.formFields
                                 )
                             ];
@@ -279,8 +279,8 @@ var ResetPasswordUsingToken = /** @class */ (function(_super) {
                                 4 /*yield*/,
                                 utils_1.validateForm(
                                     formFields,
-                                    this.getRecipeInstanceOrThrow().getConfig().resetPasswordUsingTokenFeature
-                                        .enterEmailForm.formFields
+                                    this.getRecipeInstanceOrThrow().config.resetPasswordUsingTokenFeature.enterEmailForm
+                                        .formFields
                                 )
                             ];
                         case 1:
@@ -303,10 +303,10 @@ var ResetPasswordUsingToken = /** @class */ (function(_super) {
             });
         };
         _this.render = function() {
-            var enterEmailFormFeature = _this.getRecipeInstanceOrThrow().getConfig().resetPasswordUsingTokenFeature
+            var enterEmailFormFeature = _this.getRecipeInstanceOrThrow().config.resetPasswordUsingTokenFeature
                 .enterEmailForm;
-            var submitNewPasswordFormFeature = _this.getRecipeInstanceOrThrow().getConfig()
-                .resetPasswordUsingTokenFeature.submitNewPasswordForm;
+            var submitNewPasswordFormFeature = _this.getRecipeInstanceOrThrow().config.resetPasswordUsingTokenFeature
+                .submitNewPasswordForm;
             var submitNewPasswordForm = {
                 styleFromInit: submitNewPasswordFormFeature.style,
                 formFields: submitNewPasswordFormFeature.formFields,
@@ -330,7 +330,7 @@ var ResetPasswordUsingToken = /** @class */ (function(_super) {
                 },
                 enterEmailAPI: _this.enterEmail
             };
-            var useShadowDom = _this.getRecipeInstanceOrThrow().getConfig().useShadowDom;
+            var useShadowDom = _this.getRecipeInstanceOrThrow().config.useShadowDom;
             var hasToken = _this.state.token.length !== 0;
             /*
              * Render.

--- a/lib/build/recipe/emailpassword/components/features/signInAndUp/api.js
+++ b/lib/build/recipe/emailpassword/components/features/signInAndUp/api.js
@@ -157,7 +157,7 @@ function signUpAPI(formFields, recipe) {
                 case 0:
                     return [
                         4 /*yield*/,
-                        recipe.getHttp().post(
+                        recipe.httpRequest.post(
                             "/signup",
                             {
                                 body: JSON.stringify({ formFields: formFields })
@@ -201,7 +201,7 @@ function signInAPI(formFields, recipe) {
                 case 0:
                     return [
                         4 /*yield*/,
-                        recipe.getHttp().post(
+                        recipe.httpRequest.post(
                             "/signin",
                             {
                                 body: JSON.stringify({ formFields: formFields })
@@ -255,7 +255,9 @@ function emailExistsAPI(email, recipe) {
                 case 0:
                     return [
                         4 /*yield*/,
-                        recipe.getHttp().get("/signup/email/exists", {}, "EMAIL_EXISTS", { email: email })
+                        recipe.httpRequest.get("/signup/email/exists", {}, "EMAIL_EXISTS", {
+                            email: email
+                        })
                     ];
                 case 1:
                     response = _a.sent();

--- a/lib/build/recipe/emailpassword/components/features/signInAndUp/signInAndUp.js
+++ b/lib/build/recipe/emailpassword/components/features/signInAndUp/signInAndUp.js
@@ -237,7 +237,7 @@ var SignInAndUp = /** @class */ (function(_super) {
                                 4 /*yield*/,
                                 utils_1.validateForm(
                                     formFields,
-                                    this.getRecipeInstanceOrThrow().getConfig().signInAndUpFeature.signInForm.formFields
+                                    this.getRecipeInstanceOrThrow().config.signInAndUpFeature.signInForm.formFields
                                 )
                             ];
                         case 1:
@@ -299,7 +299,7 @@ var SignInAndUp = /** @class */ (function(_super) {
                                 4 /*yield*/,
                                 utils_1.validateForm(
                                     formFields,
-                                    this.getRecipeInstanceOrThrow().getConfig().signInAndUpFeature.signUpForm.formFields
+                                    this.getRecipeInstanceOrThrow().config.signInAndUpFeature.signUpForm.formFields
                                 )
                             ];
                         case 1:
@@ -339,9 +339,7 @@ var SignInAndUp = /** @class */ (function(_super) {
                             context = {
                                 action: "VERIFY_EMAIL"
                             };
-                            if (
-                                this.getRecipeInstanceOrThrow().getConfig().emailVerificationFeature.mode !== "REQUIRED"
-                            ) {
+                            if (this.getRecipeInstanceOrThrow().config.emailVerificationFeature.mode !== "REQUIRED") {
                                 // Or if sign up and email verification mode is not required, redirect to success screen.
                                 context = {
                                     redirectToPath: utils_1.getRedirectToPathFromURL(),
@@ -388,7 +386,7 @@ var SignInAndUp = /** @class */ (function(_super) {
             });
         };
         _this.render = function() {
-            var signInAndUpFeature = _this.getRecipeInstanceOrThrow().getConfig().signInAndUpFeature;
+            var signInAndUpFeature = _this.getRecipeInstanceOrThrow().config.signInAndUpFeature;
             var signUpFeature = signInAndUpFeature.signUpForm;
             var signInFeature = signInAndUpFeature.signInForm;
             var signInForm = {
@@ -409,7 +407,7 @@ var SignInAndUp = /** @class */ (function(_super) {
                 onSuccess: _this.onSignUpSuccess,
                 signUpAPI: _this.signUp
             };
-            var useShadowDom = _this.getRecipeInstanceOrThrow().getConfig().useShadowDom;
+            var useShadowDom = _this.getRecipeInstanceOrThrow().config.useShadowDom;
             // Before session is verified, return empty fragment, prevent UI glitch.
             if (_this.state.status === "LOADING") {
                 return react_1.jsx(react_2.Fragment, null);

--- a/lib/build/recipe/emailpassword/components/features/signOut/api.js
+++ b/lib/build/recipe/emailpassword/components/features/signOut/api.js
@@ -164,8 +164,8 @@ function signOut(recipe) {
                     sessionExpiredStatusCode = fetch_1.default.sessionExpiredStatusCode;
                     return [
                         4 /*yield*/,
-                        recipe.getHttp().fetch(
-                            recipe.getHttp().getFullUrl("/signout"),
+                        recipe.httpRequest.fetch(
+                            recipe.httpRequest.getFullUrl("/signout"),
                             {
                                 method: "POST"
                             },

--- a/lib/build/recipe/emailpassword/components/styles/styleContext.js
+++ b/lib/build/recipe/emailpassword/components/styles/styleContext.js
@@ -34,7 +34,7 @@ function StyleProvider(_a) {
         styleFromInit = _a.styleFromInit,
         getDefaultStyles = _a.getDefaultStyles,
         defaultPalette = _a.defaultPalette;
-    var rawPalette = emailPassword_1.default.getInstanceOrThrow().getConfig().palette;
+    var rawPalette = emailPassword_1.default.getInstanceOrThrow().config.palette;
     var palette = getMergedPalette(defaultPalette, rawPalette);
     var styles = __assign({ palette: palette }, getDefaultStyles(palette));
     if (styleFromInit !== undefined) {

--- a/lib/build/recipe/emailpassword/emailPassword.d.ts
+++ b/lib/build/recipe/emailpassword/emailPassword.d.ts
@@ -1,20 +1,18 @@
-import RecipeModule from "../recipeModule";
-import { CreateRecipeFunction } from "../../types";
+import AuthRecipeModule from "../authRecipeModule";
+import { CreateRecipeFunction, NormalisedAuthRecipeConfig } from "../../types";
 import { EmailPasswordConfig, EmailPasswordGetRedirectionURLContext, EmailPasswordUserInput, NormalisedEmailPasswordConfig, SignOutAPIResponse } from "./types";
 import Session from "../session/session";
-export default class EmailPassword extends RecipeModule {
+export default class EmailPassword extends AuthRecipeModule {
     static instance?: EmailPassword;
     static RECIPE_ID: string;
-    private config;
+    config: NormalisedEmailPasswordConfig & NormalisedAuthRecipeConfig;
     constructor(config: EmailPasswordConfig);
     getConfig: () => NormalisedEmailPasswordConfig;
     getFeatures: () => Record<string, import("../../types").ReactComponentClass>;
     getDefaultRedirectionURL: (context: EmailPasswordGetRedirectionURLContext) => Promise<string>;
     getSessionRecipe: () => Session | undefined;
     doesSessionExist: () => boolean;
-    signOut: () => Promise<{
-        status: "OK";
-    }>;
+    signOut: () => Promise<SignOutAPIResponse>;
     isEmailVerified(): Promise<boolean>;
     static init(config?: EmailPasswordUserInput): CreateRecipeFunction;
     static signOut(): Promise<SignOutAPIResponse>;

--- a/lib/build/recipe/emailpassword/emailPassword.js
+++ b/lib/build/recipe/emailpassword/emailPassword.js
@@ -187,7 +187,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 /*
  * Imports.
  */
-var recipeModule_1 = __importDefault(require("../recipeModule"));
+var authRecipeModule_1 = __importDefault(require("../authRecipeModule"));
 var utils_1 = require("../../utils");
 var utils_2 = require("./utils");
 var _1 = require(".");
@@ -216,26 +216,22 @@ var EmailPassword = /** @class */ (function(_super) {
         _this.getFeatures = function() {
             var features = {};
             if (_this.config.signInAndUpFeature.disableDefaultImplementation !== true) {
-                var normalisedFullPath = _this
-                    .getAppInfo()
-                    .websiteBasePath.appendPath(new normalisedURLPath_1.default("/"));
+                var normalisedFullPath = _this.appInfo.websiteBasePath.appendPath(new normalisedURLPath_1.default("/"));
                 features[normalisedFullPath.getAsStringDangerous()] = _1.SignInAndUp;
             }
             if (_this.config.resetPasswordUsingTokenFeature.disableDefaultImplementation !== true) {
-                var normalisedFullPath = _this
-                    .getAppInfo()
-                    .websiteBasePath.appendPath(
-                        new normalisedURLPath_1.default(constants_1.DEFAULT_RESET_PASSWORD_PATH)
-                    );
+                var normalisedFullPath = _this.appInfo.websiteBasePath.appendPath(
+                    new normalisedURLPath_1.default(constants_1.DEFAULT_RESET_PASSWORD_PATH)
+                );
                 features[normalisedFullPath.getAsStringDangerous()] = _1.ResetPasswordUsingToken;
             }
             if (
                 _this.config.emailVerificationFeature.disableDefaultImplementation !== true &&
                 _this.config.emailVerificationFeature.mode !== "OFF"
             ) {
-                var normalisedFullPath = _this
-                    .getAppInfo()
-                    .websiteBasePath.appendPath(new normalisedURLPath_1.default(constants_1.DEFAULT_VERIFY_EMAIL_PATH));
+                var normalisedFullPath = _this.appInfo.websiteBasePath.appendPath(
+                    new normalisedURLPath_1.default(constants_1.DEFAULT_VERIFY_EMAIL_PATH)
+                );
                 features[normalisedFullPath.getAsStringDangerous()] = _1.EmailVerification;
             }
             return features;
@@ -248,17 +244,15 @@ var EmailPassword = /** @class */ (function(_super) {
                         case "SIGN_IN_AND_UP":
                             return [
                                 2 /*return*/,
-                                this.getAppInfo().websiteBasePath.getAsStringDangerous() + "?rid=" + this.getRecipeId()
+                                this.appInfo.websiteBasePath.getAsStringDangerous() + "?rid=" + this.recipeId
                             ];
                         case "VERIFY_EMAIL": {
                             verifyEmailPath = new normalisedURLPath_1.default(constants_1.DEFAULT_VERIFY_EMAIL_PATH);
                             return [
                                 2 /*return*/,
-                                this.getAppInfo()
-                                    .websiteBasePath.appendPath(verifyEmailPath)
-                                    .getAsStringDangerous() +
+                                this.appInfo.websiteBasePath.appendPath(verifyEmailPath).getAsStringDangerous() +
                                     "?rid=" +
-                                    this.getRecipeId()
+                                    this.recipeId
                             ];
                         }
                         case "RESET_PASSWORD": {
@@ -267,11 +261,9 @@ var EmailPassword = /** @class */ (function(_super) {
                             );
                             return [
                                 2 /*return*/,
-                                this.getAppInfo()
-                                    .websiteBasePath.appendPath(resetPasswordPath)
-                                    .getAsStringDangerous() +
+                                this.appInfo.websiteBasePath.appendPath(resetPasswordPath).getAsStringDangerous() +
                                     "?rid=" +
-                                    this.getRecipeId()
+                                    this.recipeId
                             ];
                         }
                         case "SUCCESS":
@@ -304,7 +296,7 @@ var EmailPassword = /** @class */ (function(_super) {
                 });
             });
         };
-        _this.config = utils_2.normaliseEmailPasswordConfig(config);
+        _this.config = __assign({}, _this.config, utils_2.normaliseEmailPasswordConfig(config));
         return _this;
     }
     /*
@@ -373,5 +365,5 @@ var EmailPassword = /** @class */ (function(_super) {
     };
     EmailPassword.RECIPE_ID = "emailpassword";
     return EmailPassword;
-})(recipeModule_1.default);
+})(authRecipeModule_1.default);
 exports.default = EmailPassword;

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -15,10 +15,8 @@ export declare type EmailPasswordUserInput = EmailPasswordHooks & {
     resetPasswordUsingTokenFeature?: ResetPasswordUsingTokenUserInput;
     emailVerificationFeature?: EmailVerificationUserInput;
 };
-export declare type EmailPasswordConfig = RecipeModuleConfig & EmailPasswordUserInput;
+export declare type EmailPasswordConfig = EmailPasswordUserInput & RecipeModuleConfig<EmailPasswordPreAPIHookContext, EmailPasswordOnHandleEventContext>;
 export declare type NormalisedEmailPasswordConfig = {
-    palette: PaletteUserInput;
-    useShadowDom: boolean;
     signInAndUpFeature: NormalisedSignInAndUpFeatureConfig;
     resetPasswordUsingTokenFeature: NormalisedResetPasswordUsingTokenFeatureConfig;
     emailVerificationFeature: NormalisedEmailVerificationFeatureConfig;
@@ -132,18 +130,19 @@ export declare type FormFieldError = {
     id: string;
     error: string;
 };
-declare type SuccessAPIResponse = {
+export declare type SignOutAPIResponse = {
     status: "OK";
 };
-export declare type SignOutAPIResponse = SuccessAPIResponse;
-export declare type EmailExistsAPIResponse = SuccessAPIResponse & {
+export declare type EmailExistsAPIResponse = {
+    status: "OK";
     exists: boolean;
 };
-export declare type IsEmailVerifiedAPIResponse = SuccessAPIResponse & {
+export declare type IsEmailVerifiedAPIResponse = {
+    status: "OK";
     isVerified: boolean;
 };
-export declare type VerifyEmailAPIResponse = SuccessAPIResponse | {
-    status: "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
+export declare type VerifyEmailAPIResponse = {
+    status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
 };
 export declare type FormFieldAPIResponse = {
     status: "FIELD_ERROR";

--- a/lib/build/recipe/emailpassword/utils.js
+++ b/lib/build/recipe/emailpassword/utils.js
@@ -162,7 +162,6 @@ var __importDefault =
     };
 Object.defineProperty(exports, "__esModule", { value: true });
 var normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
-var utils_1 = require("../../utils");
 var constants_1 = require("./constants");
 var validators_1 = require("./validators");
 function normaliseEmailPasswordConfig(config) {
@@ -179,11 +178,7 @@ function normaliseEmailPasswordConfig(config) {
         config.resetPasswordUsingTokenFeature
     );
     var emailVerificationFeature = normaliseEmailVerificationFeature(config.emailVerificationFeature);
-    var palette = config.palette !== undefined ? config.palette : {};
-    var useShadowDom = getShouldUseShadowDom(config.useShadowDom);
     return {
-        palette: palette,
-        useShadowDom: useShadowDom,
         signInAndUpFeature: signInAndUpFeature,
         resetPasswordUsingTokenFeature: resetPasswordUsingTokenFeature,
         emailVerificationFeature: emailVerificationFeature
@@ -448,17 +443,3 @@ function getFormattedFormField(field) {
     });
 }
 exports.getFormattedFormField = getFormattedFormField;
-function getShouldUseShadowDom(useShadowDom) {
-    /*
-     * Detect if browser is IE
-     * In order to disable unsupported shadowDom
-     * https://github.com/supertokens/supertokens-auth-react/issues/99
-     */
-    var isIE = utils_1.getWindowOrThrow().document.documentMode !== undefined;
-    // If browser is Internet Explorer, always disable shadow dom.
-    if (isIE === true) {
-        return false;
-    }
-    // Otherwise, use provided config or default to true.
-    return useShadowDom !== undefined ? useShadowDom : true;
-}

--- a/lib/build/recipe/recipeModule.d.ts
+++ b/lib/build/recipe/recipeModule.d.ts
@@ -1,17 +1,10 @@
 import HttpRequest from "../httpRequest";
 import { RouteToFeatureComponentMap, RecipeModuleConfig, NormalisedAppInfo, NormalisedRecipeModuleHooks } from "../types";
-import { History } from "history";
 export default abstract class RecipeModule {
-    private recipeId;
-    private appInfo;
-    private httpRequest;
+    recipeId: string;
+    appInfo: NormalisedAppInfo;
+    httpRequest: HttpRequest;
     hooks: NormalisedRecipeModuleHooks;
-    constructor(config: RecipeModuleConfig);
-    getRecipeId: () => string;
-    getAppInfo: () => NormalisedAppInfo;
-    getHttp: () => HttpRequest;
-    redirect: (context: unknown, history?: History<unknown> | undefined, queryParams?: Record<string, string> | undefined) => Promise<void>;
-    getRedirectUrl: (context: any) => Promise<string>;
+    constructor(config: RecipeModuleConfig<unknown, unknown>);
     abstract getFeatures(): RouteToFeatureComponentMap;
-    protected getDefaultRedirectionURL(context: unknown): Promise<string>;
 }

--- a/lib/build/recipe/recipeModule.js
+++ b/lib/build/recipe/recipeModule.js
@@ -13,134 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var __awaiter =
-    (this && this.__awaiter) ||
-    function(thisArg, _arguments, P, generator) {
-        return new (P || (P = Promise))(function(resolve, reject) {
-            function fulfilled(value) {
-                try {
-                    step(generator.next(value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function rejected(value) {
-                try {
-                    step(generator["throw"](value));
-                } catch (e) {
-                    reject(e);
-                }
-            }
-            function step(result) {
-                result.done
-                    ? resolve(result.value)
-                    : new P(function(resolve) {
-                          resolve(result.value);
-                      }).then(fulfilled, rejected);
-            }
-            step((generator = generator.apply(thisArg, _arguments || [])).next());
-        });
-    };
-var __generator =
-    (this && this.__generator) ||
-    function(thisArg, body) {
-        var _ = {
-                label: 0,
-                sent: function() {
-                    if (t[0] & 1) throw t[1];
-                    return t[1];
-                },
-                trys: [],
-                ops: []
-            },
-            f,
-            y,
-            t,
-            g;
-        return (
-            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
-            typeof Symbol === "function" &&
-                (g[Symbol.iterator] = function() {
-                    return this;
-                }),
-            g
-        );
-        function verb(n) {
-            return function(v) {
-                return step([n, v]);
-            };
-        }
-        function step(op) {
-            if (f) throw new TypeError("Generator is already executing.");
-            while (_)
-                try {
-                    if (
-                        ((f = 1),
-                        y &&
-                            (t =
-                                op[0] & 2
-                                    ? y["return"]
-                                    : op[0]
-                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
-                                    : y.next) &&
-                            !(t = t.call(y, op[1])).done)
-                    )
-                        return t;
-                    if (((y = 0), t)) op = [op[0] & 2, t.value];
-                    switch (op[0]) {
-                        case 0:
-                        case 1:
-                            t = op;
-                            break;
-                        case 4:
-                            _.label++;
-                            return { value: op[1], done: false };
-                        case 5:
-                            _.label++;
-                            y = op[1];
-                            op = [0];
-                            continue;
-                        case 7:
-                            op = _.ops.pop();
-                            _.trys.pop();
-                            continue;
-                        default:
-                            if (
-                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
-                                (op[0] === 6 || op[0] === 2)
-                            ) {
-                                _ = 0;
-                                continue;
-                            }
-                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
-                                _.label = op[1];
-                                break;
-                            }
-                            if (op[0] === 6 && _.label < t[1]) {
-                                _.label = t[1];
-                                t = op;
-                                break;
-                            }
-                            if (t && _.label < t[2]) {
-                                _.label = t[2];
-                                _.ops.push(op);
-                                break;
-                            }
-                            if (t[2]) _.ops.pop();
-                            _.trys.pop();
-                            continue;
-                    }
-                    op = body.call(thisArg, _);
-                } catch (e) {
-                    op = [6, e];
-                    y = 0;
-                } finally {
-                    f = t = 0;
-                }
-            if (op[0] & 5) throw op[1];
-            return { value: op[0] ? op[1] : void 0, done: true };
-        }
-    };
 var __importDefault =
     (this && this.__importDefault) ||
     function(mod) {
@@ -152,7 +24,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
  */
 var httpRequest_1 = __importDefault(require("../httpRequest"));
 var utils_1 = require("../utils");
-var normalisedURLDomain_1 = __importDefault(require("../normalisedURLDomain"));
 /*
  * Class.
  */
@@ -161,86 +32,11 @@ var RecipeModule = /** @class */ (function() {
      * Constructor.
      */
     function RecipeModule(config) {
-        var _this = this;
-        /*
-         * Instance Methods.
-         */
-        this.getRecipeId = function() {
-            return _this.recipeId;
-        };
-        this.getAppInfo = function() {
-            return _this.appInfo;
-        };
-        this.getHttp = function() {
-            return _this.httpRequest;
-        };
-        this.redirect = function(context, history, queryParams) {
-            return __awaiter(_this, void 0, void 0, function() {
-                var redirectUrl, origin_1;
-                return __generator(this, function(_a) {
-                    switch (_a.label) {
-                        case 0:
-                            return [4 /*yield*/, this.getRedirectUrl(context)];
-                        case 1:
-                            redirectUrl = _a.sent();
-                            redirectUrl = utils_1.appendQueryParamsToURL(redirectUrl, queryParams);
-                            try {
-                                new URL(redirectUrl); // If full URL, no error thrown, skip in app redirection.
-                            } catch (e) {
-                                origin_1 = new normalisedURLDomain_1.default(
-                                    utils_1.getWindowOrThrow().location.origin
-                                ).getAsStringDangerous();
-                                if (origin_1 !== this.appInfo.websiteDomain.getAsStringDangerous()) {
-                                    redirectUrl = "" + this.appInfo.websiteDomain.getAsStringDangerous() + redirectUrl;
-                                    utils_1.getWindowOrThrow().location.href = redirectUrl;
-                                    return [2 /*return*/];
-                                }
-                                if (history !== undefined) {
-                                    history.push(redirectUrl);
-                                    return [2 /*return*/];
-                                }
-                            }
-                            // Otherwise, redirect in app.
-                            utils_1.getWindowOrThrow().location.href = redirectUrl;
-                            return [2 /*return*/];
-                    }
-                });
-            });
-        };
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-        this.getRedirectUrl = function(context) {
-            return __awaiter(_this, void 0, void 0, function() {
-                var redirectUrl;
-                return __generator(this, function(_a) {
-                    switch (_a.label) {
-                        case 0:
-                            return [4 /*yield*/, this.hooks.getRedirectionURL(context)];
-                        case 1:
-                            redirectUrl = _a.sent();
-                            if (redirectUrl !== undefined) {
-                                return [2 /*return*/, redirectUrl];
-                            }
-                            return [4 /*yield*/, this.getDefaultRedirectionURL(context)];
-                        case 2:
-                            // Otherwise, use default.
-                            return [2 /*return*/, _a.sent()];
-                    }
-                });
-            });
-        };
         this.recipeId = config.recipeId;
         this.appInfo = config.appInfo;
         this.httpRequest = new httpRequest_1.default(this);
         this.hooks = utils_1.normalisedRecipeModuleHooks(config);
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    RecipeModule.prototype.getDefaultRedirectionURL = function(context) {
-        return __awaiter(this, void 0, void 0, function() {
-            return __generator(this, function(_a) {
-                throw new Error("Recipe must overwrite getDefaultRedirectionURL");
-            });
-        });
-    };
     return RecipeModule;
 })();
 exports.default = RecipeModule;

--- a/lib/build/recipe/session/session.js
+++ b/lib/build/recipe/session/session.js
@@ -241,7 +241,7 @@ var Session = /** @class */ (function(_super) {
         }
         supertokens_website_1.default.init({
             sessionScope: config.sessionScope,
-            refreshAPICustomHeaders: __assign({ rid: _this.getRecipeId() }, usersHeaders),
+            refreshAPICustomHeaders: __assign({ rid: _this.recipeId }, usersHeaders),
             autoAddCredentials: config.autoAddCredentials,
             sessionExpiredStatusCode: config.sessionExpiredStatusCode,
             apiDomain: config.appInfo.apiDomain.getAsStringDangerous(),

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -5,4 +5,4 @@ export declare type SessionUserInput = {
     sessionExpiredStatusCode?: number;
     autoAddCredentials?: boolean;
 };
-export declare type SessionConfig = RecipeModuleConfig & SessionUserInput;
+export declare type SessionConfig = RecipeModuleConfig<unknown, unknown> & SessionUserInput;

--- a/lib/build/superTokens.js
+++ b/lib/build/superTokens.js
@@ -81,7 +81,7 @@ var SuperTokens = /** @class */ (function() {
                         pathsToComponentWithRecipeIdMap[featurePath] = [];
                     }
                     pathsToComponentWithRecipeIdMap[featurePath].push({
-                        rid: recipe.getRecipeId(),
+                        rid: recipe.recipeId,
                         component: features[featurePath]
                     });
                 }
@@ -111,7 +111,7 @@ var SuperTokens = /** @class */ (function() {
         };
         this.getDefaultSessionRecipe = function() {
             return _this.getRecipeList().find(function(recipe) {
-                return recipe.getRecipeId() === session_1.default.RECIPE_ID;
+                return recipe.recipeId === session_1.default.RECIPE_ID;
             });
         };
         this.appInfo = utils_1.normaliseInputAppInfoOrThrowError(config.appInfo);

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -22,7 +22,7 @@ export declare type NormalisedAppInfo = {
     apiBasePath: NormalisedURLPath;
     websiteBasePath: NormalisedURLPath;
 };
-export declare type RecipeModuleConfig = RecipeModuleHooks & {
+export declare type RecipeModuleConfig<S, R> = RecipeModuleHooks<S, R> & {
     recipeId: string;
     /**
      *
@@ -30,15 +30,26 @@ export declare type RecipeModuleConfig = RecipeModuleHooks & {
      */
     appInfo: NormalisedAppInfo;
 };
-export declare type RecipeModuleHooks = {
-    preAPIHook?: (context: unknown) => Promise<RequestInit>;
-    getRedirectionURL?: (context: unknown) => Promise<string | undefined>;
-    onHandleEvent?: (context: unknown) => void;
+export declare type RecipeModuleHooks<S, R> = {
+    preAPIHook?: (context: S) => Promise<RequestInit>;
+    onHandleEvent?: (context: R) => void;
 };
 export declare type NormalisedRecipeModuleHooks = {
     preAPIHook: (context: unknown) => Promise<RequestInit>;
-    getRedirectionURL: (context: unknown) => Promise<string | undefined>;
     onHandleEvent: (context: unknown) => void;
+};
+export declare type NormalisedAuthRecipeConfigHooks = {
+    getRedirectionURL: (context: unknown) => Promise<string | undefined>;
+};
+export declare type AuthRecipeModuleConfig<T, S, R> = AuthRecipeModuleUserInput<T, S, R> & RecipeModuleConfig<S, R>;
+export declare type AuthRecipeModuleUserInput<T, S, R> = RecipeModuleHooks<S, R> & {
+    useShadowDom?: boolean;
+    palette?: Record<string, string>;
+    getRedirectionURL?: (context: T) => Promise<string | undefined>;
+};
+export declare type NormalisedAuthRecipeConfig = {
+    useShadowDom: boolean;
+    palette: Record<string, string>;
 };
 export declare type RouteToFeatureComponentMap = Record<string, ReactComponentClass>;
 export declare type ComponentWithRecipeId = {
@@ -46,12 +57,6 @@ export declare type ComponentWithRecipeId = {
     component: ReactComponentClass;
 };
 export declare type PathToComponentWithRecipeIdMap = Record<string, ComponentWithRecipeId[]>;
-export declare type FeatureBaseConfig = {
-    style?: Styles;
-};
-export declare type NormalisedBaseConfig = {
-    style: Styles;
-};
 export declare type FormFieldBaseConfig = {
     id: string;
     label: string;
@@ -76,3 +81,12 @@ export declare type NormalisedFormField = {
 export declare type ReactComponentClass = ComponentClass | (<T>(props: T) => JSX.Element);
 export declare type WithRouterType = (Component: ReactComponentClass) => ReactComponentClass;
 export declare type Styles = Record<string, CSSObject>;
+export declare type FeatureBaseConfig = {
+    style?: Styles;
+};
+export declare type NormalisedBaseConfig = {
+    style: Styles;
+};
+export declare type SuccessAPIResponse = {
+    status: "OK";
+};

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -1,7 +1,9 @@
 import NormalisedURLPath from "./normalisedURLPath";
 import { FormFieldError } from "./recipe/emailpassword/types";
-import { APIFormField, AppInfoUserInput, NormalisedAppInfo, NormalisedFormField, NormalisedRecipeModuleHooks, RecipeModuleHooks } from "./types";
-export declare function normalisedRecipeModuleHooks(config: RecipeModuleHooks): NormalisedRecipeModuleHooks;
+import { APIFormField, AppInfoUserInput, AuthRecipeModuleConfig, AuthRecipeModuleUserInput, NormalisedAppInfo, NormalisedAuthRecipeConfig, NormalisedAuthRecipeConfigHooks, NormalisedFormField, NormalisedRecipeModuleHooks, RecipeModuleHooks } from "./types";
+export declare function normalisedRecipeModuleHooks(config: RecipeModuleHooks<unknown, unknown>): NormalisedRecipeModuleHooks;
+export declare function normalisedAuthRecipeConfigHooks(config: AuthRecipeModuleUserInput<unknown, unknown, unknown>): NormalisedAuthRecipeConfigHooks;
+export declare function normaliseAuthRecipeModuleConfig(config: AuthRecipeModuleConfig<unknown, unknown, unknown>): NormalisedAuthRecipeConfig;
 export declare function getRecipeIdFromSearch(search: string): string | null;
 export declare function getQueryParams(param: string): string | null;
 export declare function getRedirectToPathFromURL(): string | undefined;
@@ -11,3 +13,4 @@ export declare function validateForm(inputs: APIFormField[], configFormFields: N
 export declare function getCurrentNormalisedUrlPath(): NormalisedURLPath;
 export declare function appendQueryParamsToURL(stringUrl: string, queryParams?: Record<string, string>): string;
 export declare function getWindowOrThrow(): any;
+export declare function getShouldUseShadowDom(useShadowDom?: boolean): boolean;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -156,7 +156,6 @@ var normalisedURLPath_1 = __importDefault(require("./normalisedURLPath"));
 function normalisedRecipeModuleHooks(config) {
     var _this = this;
     var preAPIHook = config.preAPIHook,
-        getRedirectionURL = config.getRedirectionURL,
         onHandleEvent = config.onHandleEvent;
     if (preAPIHook === undefined) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -168,6 +167,22 @@ function normalisedRecipeModuleHooks(config) {
             });
         };
     }
+    if (onHandleEvent === undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+        onHandleEvent = function(context) {};
+    }
+    return {
+        preAPIHook: preAPIHook,
+        onHandleEvent: onHandleEvent
+    };
+}
+exports.normalisedRecipeModuleHooks = normalisedRecipeModuleHooks;
+/*
+ * NormalisedRecipeModuleHooks
+ */
+function normalisedAuthRecipeConfigHooks(config) {
+    var _this = this;
+    var getRedirectionURL = config.getRedirectionURL;
     if (getRedirectionURL === undefined) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         getRedirectionURL = function(context) {
@@ -178,17 +193,23 @@ function normalisedRecipeModuleHooks(config) {
             });
         };
     }
-    if (onHandleEvent === undefined) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-        onHandleEvent = function(context) {};
-    }
     return {
-        preAPIHook: preAPIHook,
-        getRedirectionURL: getRedirectionURL,
-        onHandleEvent: onHandleEvent
+        getRedirectionURL: getRedirectionURL
     };
 }
-exports.normalisedRecipeModuleHooks = normalisedRecipeModuleHooks;
+exports.normalisedAuthRecipeConfigHooks = normalisedAuthRecipeConfigHooks;
+/*
+ * normaliseAuthRecipeModule
+ */
+function normaliseAuthRecipeModuleConfig(config) {
+    var useShadowDom = config.useShadowDom === undefined ? true : config.useShadowDom;
+    var palette = config.palette === undefined ? {} : config.palette;
+    return {
+        useShadowDom: getShouldUseShadowDom(useShadowDom),
+        palette: palette
+    };
+}
+exports.normaliseAuthRecipeModuleConfig = normaliseAuthRecipeModuleConfig;
 /*
  * getRecipeIdFromPath
  * Input:
@@ -354,3 +375,18 @@ function getWindowOrThrow() {
     return window;
 }
 exports.getWindowOrThrow = getWindowOrThrow;
+function getShouldUseShadowDom(useShadowDom) {
+    /*
+     * Detect if browser is IE
+     * In order to disable unsupported shadowDom
+     * https://github.com/supertokens/supertokens-auth-react/issues/99
+     */
+    var isIE = getWindowOrThrow().document.documentMode !== undefined;
+    // If browser is Internet Explorer, always disable shadow dom.
+    if (isIE === true) {
+        return false;
+    }
+    // Otherwise, use provided config or default to true.
+    return useShadowDom !== undefined ? useShadowDom : true;
+}
+exports.getShouldUseShadowDom = getShouldUseShadowDom;

--- a/lib/ts/httpRequest.ts
+++ b/lib/ts/httpRequest.ts
@@ -98,7 +98,7 @@ export default class HttpRequest {
                     ...headers,
                     "fdi-version": supported_fdi.join(","),
                     "Content-Type": "application/json",
-                    rid: this.recipe.getRecipeId()
+                    rid: this.recipe.recipeId
                 }
             }
         });
@@ -117,11 +117,7 @@ export default class HttpRequest {
 
     getFullUrl = (pathStr: string, queryParams?: Record<string, string>): string => {
         const path = new NormalisedURLPath(pathStr);
-        const fullUrl = `${this.recipe
-            .getAppInfo()
-            .apiDomain.getAsStringDangerous()}${this.recipe
-            .getAppInfo()
-            .apiBasePath.getAsStringDangerous()}${path.getAsStringDangerous()}`;
+        const fullUrl = `${this.recipe.appInfo.apiDomain.getAsStringDangerous()}${this.recipe.appInfo.apiBasePath.getAsStringDangerous()}${path.getAsStringDangerous()}`;
 
         if (queryParams === undefined) {
             return fullUrl;

--- a/lib/ts/recipe/authRecipeModule.ts
+++ b/lib/ts/recipe/authRecipeModule.ts
@@ -1,0 +1,105 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Imports.
+ */
+import {
+    AuthRecipeModuleConfig,
+    NormalisedAuthRecipeConfig,
+    NormalisedAuthRecipeConfigHooks,
+    NormalisedRecipeModuleHooks,
+    SuccessAPIResponse
+} from "../types";
+import {
+    appendQueryParamsToURL,
+    getWindowOrThrow,
+    normaliseAuthRecipeModuleConfig,
+    normalisedAuthRecipeConfigHooks
+} from "../utils";
+import RecipeModule from "./recipeModule";
+import { History, LocationState } from "history";
+import NormalisedURLDomain from "../normalisedURLDomain";
+
+/*
+ * Class.
+ */
+export default abstract class AuthRecipeModule extends RecipeModule {
+    /*
+     * Instance attributes.
+     */
+
+    config: NormalisedAuthRecipeConfig;
+    hooks: NormalisedAuthRecipeConfigHooks & NormalisedRecipeModuleHooks;
+
+    /*
+     * Constructor.
+     */
+    constructor(config: AuthRecipeModuleConfig<unknown, unknown, unknown>) {
+        super(config);
+        this.config = {
+            ...this.config,
+            ...normaliseAuthRecipeModuleConfig(config)
+        };
+        this.hooks = {
+            ...this.hooks,
+            ...normalisedAuthRecipeConfigHooks(config)
+        };
+    }
+
+    redirect = async (
+        context: unknown,
+        history?: History<LocationState>,
+        queryParams?: Record<string, string>
+    ): Promise<void> => {
+        let redirectUrl = await this.getRedirectUrl(context);
+        redirectUrl = appendQueryParamsToURL(redirectUrl, queryParams);
+
+        try {
+            new URL(redirectUrl); // If full URL, no error thrown, skip in app redirection.
+        } catch (e) {
+            // For multi tenancy, If mismatch between websiteDomain and current location, prepand URL relative path with websiteDomain.
+            const origin = new NormalisedURLDomain(getWindowOrThrow().location.origin).getAsStringDangerous();
+            if (origin !== this.appInfo.websiteDomain.getAsStringDangerous()) {
+                redirectUrl = `${this.appInfo.websiteDomain.getAsStringDangerous()}${redirectUrl}`;
+                getWindowOrThrow().location.href = redirectUrl;
+                return;
+            }
+
+            // If history was provided, use to redirect without reloading.
+            if (history !== undefined) {
+                history.push(redirectUrl);
+                return;
+            }
+        }
+        // Otherwise, redirect in app.
+        getWindowOrThrow().location.href = redirectUrl;
+    };
+
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    getRedirectUrl = async (context: any): Promise<string> => {
+        // If getRedirectionURL provided by user.
+        const redirectUrl = await this.hooks.getRedirectionURL(context);
+        if (redirectUrl !== undefined) {
+            return redirectUrl;
+        }
+
+        // Otherwise, use default.
+        return await this.getDefaultRedirectionURL(context);
+    };
+
+    abstract getDefaultRedirectionURL(context: unknown): Promise<string>;
+    abstract signOut(): Promise<SuccessAPIResponse>;
+}

--- a/lib/ts/recipe/emailpassword/components/emailPasswordAuth.tsx
+++ b/lib/ts/recipe/emailpassword/components/emailPasswordAuth.tsx
@@ -76,7 +76,7 @@ class EmailPasswordAuth extends PureComponent<FeatureBaseProps, EmailPasswordAut
         });
 
         // If email verification mode is off or optional, return.
-        if (this.getRecipeInstanceOrThrow().getConfig().emailVerificationFeature.mode !== "REQUIRED") {
+        if (this.getRecipeInstanceOrThrow().config.emailVerificationFeature.mode !== "REQUIRED") {
             return;
         }
 

--- a/lib/ts/recipe/emailpassword/components/features/emailVerification/api.ts
+++ b/lib/ts/recipe/emailpassword/components/features/emailVerification/api.ts
@@ -28,7 +28,7 @@ import {
  */
 
 export async function verifyEmailAPI(recipe: RecipeModule, token: string): Promise<VerifyEmailThemeResponse> {
-    const response: VerifyEmailAPIResponse = await recipe.getHttp().post(
+    const response: VerifyEmailAPIResponse = await recipe.httpRequest.post(
         "/user/email/verify",
         {
             body: JSON.stringify({
@@ -57,9 +57,11 @@ export async function verifyEmailAPI(recipe: RecipeModule, token: string): Promi
 }
 
 export async function sendVerifyEmailAPI(recipe: RecipeModule): Promise<SendVerifyEmailThemeResponse> {
-    const response: SendVerifyEmailAPIResponse = await recipe
-        .getHttp()
-        .post("/user/email/verify/token", {}, "SEND_VERIFY_EMAIL");
+    const response: SendVerifyEmailAPIResponse = await recipe.httpRequest.post(
+        "/user/email/verify/token",
+        {},
+        "SEND_VERIFY_EMAIL"
+    );
 
     // If email already verified.
     if (response.status === "EMAIL_ALREADY_VERIFIED_ERROR") {
@@ -79,8 +81,10 @@ export async function sendVerifyEmailAPI(recipe: RecipeModule): Promise<SendVeri
 }
 
 export async function isEmailVerifiedAPI(recipe: RecipeModule): Promise<boolean> {
-    const response: IsEmailVerifiedAPIResponse = await recipe
-        .getHttp()
-        .get("/user/email/verify", {}, "IS_EMAIL_VERIFIED");
+    const response: IsEmailVerifiedAPIResponse = await recipe.httpRequest.get(
+        "/user/email/verify",
+        {},
+        "IS_EMAIL_VERIFIED"
+    );
     return response.isVerified;
 }

--- a/lib/ts/recipe/emailpassword/components/features/emailVerification/emailVerification.tsx
+++ b/lib/ts/recipe/emailpassword/components/features/emailVerification/emailVerification.tsx
@@ -89,7 +89,7 @@ class EmailVerification extends PureComponent<FeatureBaseProps, { token: string 
 
     async componentDidMount(): Promise<void> {
         // In case Email Verification Mode is not required, redirect to success URL.
-        if (this.getRecipeInstanceOrThrow().getConfig().emailVerificationFeature.mode !== "REQUIRED") {
+        if (this.getRecipeInstanceOrThrow().config.emailVerificationFeature.mode !== "REQUIRED") {
             return await this.getRecipeInstanceOrThrow().redirect({ action: "SUCCESS" }, this.props.history);
         }
 
@@ -112,7 +112,7 @@ class EmailVerification extends PureComponent<FeatureBaseProps, { token: string 
     }
 
     render = (): JSX.Element => {
-        const sendVerifyEmailScreenFeature = this.getRecipeInstanceOrThrow().getConfig().emailVerificationFeature
+        const sendVerifyEmailScreenFeature = this.getRecipeInstanceOrThrow().config.emailVerificationFeature
             .sendVerifyEmailScreen;
 
         const sendVerifyEmailScreen: SendVerifyEmailThemeProps = {
@@ -127,7 +127,7 @@ class EmailVerification extends PureComponent<FeatureBaseProps, { token: string 
                 this.getRecipeInstanceOrThrow().redirect({ action: "SUCCESS" }, this.props.history)
         };
 
-        const verifyEmailLinkClickedScreenFeature = this.getRecipeInstanceOrThrow().getConfig().emailVerificationFeature
+        const verifyEmailLinkClickedScreenFeature = this.getRecipeInstanceOrThrow().config.emailVerificationFeature
             .verifyEmailLinkClickedScreen;
 
         const verifyEmailLinkClickedScreen: VerifyEmailLinkClickedThemeProps = {
@@ -142,7 +142,7 @@ class EmailVerification extends PureComponent<FeatureBaseProps, { token: string 
             verifyEmailAPI: async () => await verifyEmailAPI(this.getRecipeInstanceOrThrow(), this.state.token)
         };
 
-        const useShadowDom = this.getRecipeInstanceOrThrow().getConfig().useShadowDom;
+        const useShadowDom = this.getRecipeInstanceOrThrow().config.useShadowDom;
 
         const hasToken = this.state.token.length !== 0;
 

--- a/lib/ts/recipe/emailpassword/components/features/resetPasswordUsingToken/api.ts
+++ b/lib/ts/recipe/emailpassword/components/features/resetPasswordUsingToken/api.ts
@@ -27,7 +27,7 @@ export async function handleSubmitNewPasswordAPI(
     recipe: RecipeModule,
     token: string
 ): Promise<FormBaseAPIResponse> {
-    const response: SubmitNewPasswordAPIResponse = await recipe.getHttp().post(
+    const response: SubmitNewPasswordAPIResponse = await recipe.httpRequest.post(
         "/user/password/reset",
         {
             body: JSON.stringify({ formFields, token })
@@ -62,7 +62,7 @@ export async function handleSubmitNewPasswordAPI(
 }
 
 export async function enterEmailAPI(formFields: APIFormField[], recipe: RecipeModule): Promise<FormBaseAPIResponse> {
-    const response: EnterEmailAPIResponse = await recipe.getHttp().post(
+    const response: EnterEmailAPIResponse = await recipe.httpRequest.post(
         "/user/password/reset/token",
         {
             body: JSON.stringify({ formFields })

--- a/lib/ts/recipe/emailpassword/components/features/resetPasswordUsingToken/resetPasswordUsingToken.tsx
+++ b/lib/ts/recipe/emailpassword/components/features/resetPasswordUsingToken/resetPasswordUsingToken.tsx
@@ -68,7 +68,7 @@ class ResetPasswordUsingToken extends PureComponent<FeatureBaseProps, { token: s
         // Front end validation.
         const validationErrors = await validateForm(
             formFields,
-            this.getRecipeInstanceOrThrow().getConfig().resetPasswordUsingTokenFeature.submitNewPasswordForm.formFields
+            this.getRecipeInstanceOrThrow().config.resetPasswordUsingTokenFeature.submitNewPasswordForm.formFields
         );
 
         // If errors, return.
@@ -100,7 +100,7 @@ class ResetPasswordUsingToken extends PureComponent<FeatureBaseProps, { token: s
         // Front end validation.
         const validationErrors = await validateForm(
             formFields,
-            this.getRecipeInstanceOrThrow().getConfig().resetPasswordUsingTokenFeature.enterEmailForm.formFields
+            this.getRecipeInstanceOrThrow().config.resetPasswordUsingTokenFeature.enterEmailForm.formFields
         );
 
         // If errors, return.
@@ -115,10 +115,10 @@ class ResetPasswordUsingToken extends PureComponent<FeatureBaseProps, { token: s
     };
 
     render = (): JSX.Element => {
-        const enterEmailFormFeature = this.getRecipeInstanceOrThrow().getConfig().resetPasswordUsingTokenFeature
+        const enterEmailFormFeature = this.getRecipeInstanceOrThrow().config.resetPasswordUsingTokenFeature
             .enterEmailForm;
 
-        const submitNewPasswordFormFeature = this.getRecipeInstanceOrThrow().getConfig().resetPasswordUsingTokenFeature
+        const submitNewPasswordFormFeature = this.getRecipeInstanceOrThrow().config.resetPasswordUsingTokenFeature
             .submitNewPasswordForm;
 
         const submitNewPasswordForm: SubmitNewPasswordThemeProps = {
@@ -145,7 +145,7 @@ class ResetPasswordUsingToken extends PureComponent<FeatureBaseProps, { token: s
             },
             enterEmailAPI: this.enterEmail
         };
-        const useShadowDom = this.getRecipeInstanceOrThrow().getConfig().useShadowDom;
+        const useShadowDom = this.getRecipeInstanceOrThrow().config.useShadowDom;
 
         const hasToken = this.state.token.length !== 0;
 

--- a/lib/ts/recipe/emailpassword/components/features/signInAndUp/api.ts
+++ b/lib/ts/recipe/emailpassword/components/features/signInAndUp/api.ts
@@ -26,7 +26,7 @@ import { EmailExistsAPIResponse, FormBaseAPIResponse, SignInAPIResponse, SignUpA
  */
 
 export async function signUpAPI(formFields: APIFormField[], recipe: RecipeModule): Promise<FormBaseAPIResponse> {
-    const response: SignUpAPIResponse = await recipe.getHttp().post(
+    const response: SignUpAPIResponse = await recipe.httpRequest.post(
         "/signup",
         {
             body: JSON.stringify({ formFields })
@@ -54,7 +54,7 @@ export async function signUpAPI(formFields: APIFormField[], recipe: RecipeModule
 }
 
 export async function signInAPI(formFields: APIFormField[], recipe: RecipeModule): Promise<FormBaseAPIResponse> {
-    const response: SignInAPIResponse = await recipe.getHttp().post(
+    const response: SignInAPIResponse = await recipe.httpRequest.post(
         "/signin",
         {
             body: JSON.stringify({ formFields })
@@ -90,9 +90,9 @@ export async function signInAPI(formFields: APIFormField[], recipe: RecipeModule
 }
 
 export async function emailExistsAPI(email: string, recipe: RecipeModule): Promise<string | undefined> {
-    const response: EmailExistsAPIResponse = await recipe
-        .getHttp()
-        .get("/signup/email/exists", {}, "EMAIL_EXISTS", { email });
+    const response: EmailExistsAPIResponse = await recipe.httpRequest.get("/signup/email/exists", {}, "EMAIL_EXISTS", {
+        email
+    });
 
     // If email already exists.
     if (response.status === "OK") {

--- a/lib/ts/recipe/emailpassword/components/features/signInAndUp/signInAndUp.tsx
+++ b/lib/ts/recipe/emailpassword/components/features/signInAndUp/signInAndUp.tsx
@@ -68,7 +68,7 @@ class SignInAndUp extends PureComponent<FeatureBaseProps, SignInAndUpState> {
         // Front end validation.
         const validationErrors = await validateForm(
             formFields,
-            this.getRecipeInstanceOrThrow().getConfig().signInAndUpFeature.signInForm.formFields
+            this.getRecipeInstanceOrThrow().config.signInAndUpFeature.signInForm.formFields
         );
         // If errors, return.
         if (validationErrors.length > 0) {
@@ -108,7 +108,7 @@ class SignInAndUp extends PureComponent<FeatureBaseProps, SignInAndUpState> {
         // Front end validation.
         const validationErrors = await validateForm(
             formFields,
-            this.getRecipeInstanceOrThrow().getConfig().signInAndUpFeature.signUpForm.formFields
+            this.getRecipeInstanceOrThrow().config.signInAndUpFeature.signUpForm.formFields
         );
 
         // If errors, return.
@@ -160,7 +160,7 @@ class SignInAndUp extends PureComponent<FeatureBaseProps, SignInAndUpState> {
         let context: EmailPasswordGetRedirectionURLContext = {
             action: "VERIFY_EMAIL"
         };
-        if (this.getRecipeInstanceOrThrow().getConfig().emailVerificationFeature.mode !== "REQUIRED") {
+        if (this.getRecipeInstanceOrThrow().config.emailVerificationFeature.mode !== "REQUIRED") {
             // Or if sign up and email verification mode is not required, redirect to success screen.
             context = {
                 redirectToPath: getRedirectToPathFromURL(),
@@ -236,7 +236,7 @@ class SignInAndUp extends PureComponent<FeatureBaseProps, SignInAndUpState> {
     };
 
     render = (): JSX.Element => {
-        const signInAndUpFeature = this.getRecipeInstanceOrThrow().getConfig().signInAndUpFeature;
+        const signInAndUpFeature = this.getRecipeInstanceOrThrow().config.signInAndUpFeature;
         const signUpFeature = signInAndUpFeature.signUpForm;
         const signInFeature = signInAndUpFeature.signInForm;
 
@@ -259,7 +259,7 @@ class SignInAndUp extends PureComponent<FeatureBaseProps, SignInAndUpState> {
             signUpAPI: this.signUp
         };
 
-        const useShadowDom = this.getRecipeInstanceOrThrow().getConfig().useShadowDom;
+        const useShadowDom = this.getRecipeInstanceOrThrow().config.useShadowDom;
 
         // Before session is verified, return empty fragment, prevent UI glitch.
         if (this.state.status === "LOADING") {

--- a/lib/ts/recipe/emailpassword/components/features/signOut/api.ts
+++ b/lib/ts/recipe/emailpassword/components/features/signOut/api.ts
@@ -28,8 +28,8 @@ import { SignOutAPIResponse } from "../../../types";
 export async function signOut(recipe: RecipeModule): Promise<SignOutAPIResponse> {
     const sessionExpiredStatusCode = sessionSdk.sessionExpiredStatusCode;
 
-    const result = await recipe.getHttp().fetch(
-        recipe.getHttp().getFullUrl("/signout"),
+    const result = await recipe.httpRequest.fetch(
+        recipe.httpRequest.getFullUrl("/signout"),
         {
             method: "POST"
         },

--- a/lib/ts/recipe/emailpassword/components/styles/styleContext.tsx
+++ b/lib/ts/recipe/emailpassword/components/styles/styleContext.tsx
@@ -44,7 +44,7 @@ export function StyleProvider({
     getDefaultStyles: (palette: NormalisedPalette) => NormalisedDefaultStyles;
     defaultPalette: NormalisedPalette;
 }): JSX.Element {
-    const rawPalette = EmailPassword.getInstanceOrThrow().getConfig().palette;
+    const rawPalette = EmailPassword.getInstanceOrThrow().config.palette;
     const palette = getMergedPalette(defaultPalette, rawPalette);
 
     const styles: NormalisedStyle = {

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -71,24 +71,15 @@ export type EmailPasswordUserInput = EmailPasswordHooks & {
     resetPasswordUsingTokenFeature?: ResetPasswordUsingTokenUserInput;
 
     /*
-     * Email Verification feature.
+     * Email Verification configs.
      */
     emailVerificationFeature?: EmailVerificationUserInput;
 };
 
-export type EmailPasswordConfig = RecipeModuleConfig & EmailPasswordUserInput;
+export type EmailPasswordConfig = EmailPasswordUserInput &
+    RecipeModuleConfig<EmailPasswordPreAPIHookContext, EmailPasswordOnHandleEventContext>;
 
 export type NormalisedEmailPasswordConfig = {
-    /*
-     * Styling palette.
-     */
-    palette: PaletteUserInput;
-
-    /*
-     * Use shadow Dom root.
-     */
-    useShadowDom: boolean;
-
     /*
      * Sign In and Sign Up feature.
      */
@@ -446,37 +437,43 @@ export type FormFieldError = {
     error: string;
 };
 
-type SuccessAPIResponse = {
+export type SignOutAPIResponse = {
     /*
      * Success.
      */
     status: "OK";
 };
 
-export type SignOutAPIResponse = SuccessAPIResponse;
+export type EmailExistsAPIResponse = {
+    /*
+     * Success.
+     */
+    status: "OK";
 
-export type EmailExistsAPIResponse = SuccessAPIResponse & {
     /*
      * Is email already registered
      */
     exists: boolean;
 };
 
-export type IsEmailVerifiedAPIResponse = SuccessAPIResponse & {
+export type IsEmailVerifiedAPIResponse = {
+    /*
+     * Success.
+     */
+    status: "OK";
+
     /*
      * Is email verified
      */
     isVerified: boolean;
 };
 
-export type VerifyEmailAPIResponse =
-    | SuccessAPIResponse
-    | {
-          /*
-           * Email verification invalid token error.
-           */
-          status: "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
-      };
+export type VerifyEmailAPIResponse = {
+    /*
+     * Email verification status.
+     */
+    status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
+};
 
 export type FormFieldAPIResponse = {
     /*

--- a/lib/ts/recipe/emailpassword/utils.ts
+++ b/lib/ts/recipe/emailpassword/utils.ts
@@ -21,7 +21,6 @@ import {
     NormalisedBaseConfig,
     NormalisedFormField
 } from "../../types";
-import { getWindowOrThrow } from "../../utils";
 import { DEFAULT_RESET_PASSWORD_PATH, MANDATORY_FORM_FIELDS_ID_ARRAY } from "./constants";
 import {
     EmailPasswordConfig,
@@ -75,13 +74,7 @@ export function normaliseEmailPasswordConfig(config: EmailPasswordConfig): Norma
         config.emailVerificationFeature
     );
 
-    const palette = config.palette !== undefined ? config.palette : {};
-
-    const useShadowDom = getShouldUseShadowDom(config.useShadowDom);
-
     return {
-        palette,
-        useShadowDom,
         signInAndUpFeature,
         resetPasswordUsingTokenFeature,
         emailVerificationFeature
@@ -398,20 +391,4 @@ export function getFormattedFormField(field: NormalisedFormField): NormalisedFor
             return await field.validate(value);
         }
     };
-}
-
-function getShouldUseShadowDom(useShadowDom?: boolean): boolean {
-    /*
-     * Detect if browser is IE
-     * In order to disable unsupported shadowDom
-     * https://github.com/supertokens/supertokens-auth-react/issues/99
-     */
-    const isIE = getWindowOrThrow().document.documentMode !== undefined;
-    // If browser is Internet Explorer, always disable shadow dom.
-    if (isIE === true) {
-        return false;
-    }
-
-    // Otherwise, use provided config or default to true.
-    return useShadowDom !== undefined ? useShadowDom : true;
 }

--- a/lib/ts/recipe/recipeModule.ts
+++ b/lib/ts/recipe/recipeModule.ts
@@ -23,9 +23,7 @@ import {
     NormalisedAppInfo,
     NormalisedRecipeModuleHooks
 } from "../types";
-import { appendQueryParamsToURL, getWindowOrThrow, normalisedRecipeModuleHooks } from "../utils";
-import { History, LocationState } from "history";
-import NormalisedURLDomain from "../normalisedURLDomain";
+import { normalisedRecipeModuleHooks } from "../utils";
 
 /*
  * Class.
@@ -35,82 +33,20 @@ export default abstract class RecipeModule {
      * Instance attributes.
      */
 
-    private recipeId: string;
-    private appInfo: NormalisedAppInfo;
-    private httpRequest: HttpRequest;
+    recipeId: string;
+    appInfo: NormalisedAppInfo;
+    httpRequest: HttpRequest;
     hooks: NormalisedRecipeModuleHooks;
 
     /*
      * Constructor.
      */
-    constructor(config: RecipeModuleConfig) {
+    constructor(config: RecipeModuleConfig<unknown, unknown>) {
         this.recipeId = config.recipeId;
         this.appInfo = config.appInfo;
         this.httpRequest = new HttpRequest(this);
         this.hooks = normalisedRecipeModuleHooks(config);
     }
 
-    /*
-     * Instance Methods.
-     */
-    getRecipeId = (): string => {
-        return this.recipeId;
-    };
-
-    getAppInfo = (): NormalisedAppInfo => {
-        return this.appInfo;
-    };
-
-    getHttp = (): HttpRequest => {
-        return this.httpRequest;
-    };
-
-    redirect = async (
-        context: unknown,
-        history?: History<LocationState>,
-        queryParams?: Record<string, string>
-    ): Promise<void> => {
-        let redirectUrl = await this.getRedirectUrl(context);
-        redirectUrl = appendQueryParamsToURL(redirectUrl, queryParams);
-
-        try {
-            new URL(redirectUrl); // If full URL, no error thrown, skip in app redirection.
-        } catch (e) {
-            // If history was provided, use to redirect without reloading.
-
-            // For multi tenancy, If mismatch between websiteDomain and current location, prepand URL relative path with websiteDomain.
-            const origin = new NormalisedURLDomain(getWindowOrThrow().location.origin).getAsStringDangerous();
-            if (origin !== this.appInfo.websiteDomain.getAsStringDangerous()) {
-                redirectUrl = `${this.appInfo.websiteDomain.getAsStringDangerous()}${redirectUrl}`;
-                getWindowOrThrow().location.href = redirectUrl;
-                return;
-            }
-
-            if (history !== undefined) {
-                history.push(redirectUrl);
-                return;
-            }
-        }
-        // Otherwise, redirect in app.
-        getWindowOrThrow().location.href = redirectUrl;
-    };
-
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    getRedirectUrl = async (context: any): Promise<string> => {
-        // If getRedirectionURL provided by user.
-        const redirectUrl = await this.hooks.getRedirectionURL(context);
-        if (redirectUrl !== undefined) {
-            return redirectUrl;
-        }
-
-        // Otherwise, use default.
-        return await this.getDefaultRedirectionURL(context);
-    };
-
     abstract getFeatures(): RouteToFeatureComponentMap;
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    protected async getDefaultRedirectionURL(context: unknown): Promise<string> {
-        throw new Error("Recipe must overwrite getDefaultRedirectionURL");
-    }
 }

--- a/lib/ts/recipe/session/session.ts
+++ b/lib/ts/recipe/session/session.ts
@@ -44,7 +44,7 @@ export default class Session extends RecipeModule {
         sessionSdk.init({
             sessionScope: config.sessionScope,
             refreshAPICustomHeaders: {
-                rid: this.getRecipeId(),
+                rid: this.recipeId,
                 ...usersHeaders
             },
             autoAddCredentials: config.autoAddCredentials,

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -42,4 +42,4 @@ export type SessionUserInput = {
     autoAddCredentials?: boolean;
 };
 
-export type SessionConfig = RecipeModuleConfig & SessionUserInput;
+export type SessionConfig = RecipeModuleConfig<unknown, unknown> & SessionUserInput;

--- a/lib/ts/superTokens.tsx
+++ b/lib/ts/superTokens.tsx
@@ -147,7 +147,7 @@ export default class SuperTokens {
                 }
 
                 pathsToComponentWithRecipeIdMap[featurePath].push({
-                    rid: recipe.getRecipeId(),
+                    rid: recipe.recipeId,
                     component: features[featurePath]
                 });
             }
@@ -186,7 +186,7 @@ export default class SuperTokens {
 
     getDefaultSessionRecipe = (): Session | undefined => {
         return this.getRecipeList().find(recipe => {
-            return recipe.getRecipeId() === Session.RECIPE_ID;
+            return recipe.recipeId === Session.RECIPE_ID;
         }) as Session;
     };
 

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -94,7 +94,7 @@ export type NormalisedAppInfo = {
     websiteBasePath: NormalisedURLPath;
 };
 
-export type RecipeModuleConfig = RecipeModuleHooks & {
+export type RecipeModuleConfig<S, R> = RecipeModuleHooks<S, R> & {
     /*
      * Unique Identifier of a module.
      */
@@ -107,21 +107,16 @@ export type RecipeModuleConfig = RecipeModuleHooks & {
     appInfo: NormalisedAppInfo;
 };
 
-export type RecipeModuleHooks = {
+export type RecipeModuleHooks<S, R> = {
     /*
      * Optional pre API Hook.
      */
-    preAPIHook?: (context: unknown) => Promise<RequestInit>;
-
-    /*
-     * Optional method used for redirections.
-     */
-    getRedirectionURL?: (context: unknown) => Promise<string | undefined>;
+    preAPIHook?: (context: S) => Promise<RequestInit>;
 
     /*
      * Optional method used for handling event success.
      */
-    onHandleEvent?: (context: unknown) => void;
+    onHandleEvent?: (context: R) => void;
 };
 
 export type NormalisedRecipeModuleHooks = {
@@ -131,15 +126,49 @@ export type NormalisedRecipeModuleHooks = {
     preAPIHook: (context: unknown) => Promise<RequestInit>;
 
     /*
-     * Method used for redirections.
-     */
-    getRedirectionURL: (context: unknown) => Promise<string | undefined>;
-
-    /*
      * Method used for handling event success.
      */
     onHandleEvent: (context: unknown) => void;
 };
+
+export type NormalisedAuthRecipeConfigHooks = {
+    /*
+     * Method used for redirections.
+     */
+    getRedirectionURL: (context: unknown) => Promise<string | undefined>;
+};
+
+export type AuthRecipeModuleConfig<T, S, R> = AuthRecipeModuleUserInput<T, S, R> & RecipeModuleConfig<S, R>;
+
+export type AuthRecipeModuleUserInput<T, S, R> = RecipeModuleHooks<S, R> & {
+    /*
+     * Use shadow Dom root.
+     */
+    useShadowDom?: boolean;
+
+    /*
+     * Styling palette.
+     */
+    palette?: Record<string, string>;
+
+    /*
+     * Optional method used for redirections.
+     */
+    getRedirectionURL?: (context: T) => Promise<string | undefined>;
+};
+
+export type NormalisedAuthRecipeConfig = {
+    /*
+     * Use shadow Dom root.
+     */
+    useShadowDom: boolean;
+
+    /*
+     * Styling palette.
+     */
+    palette: Record<string, string>;
+};
+
 /*
  * Routing manipulation types.
  */
@@ -158,24 +187,6 @@ export type ComponentWithRecipeId = {
 };
 
 export type PathToComponentWithRecipeIdMap = Record<string, ComponentWithRecipeId[]>;
-
-/*
- * Features Config Types.
- */
-
-export type FeatureBaseConfig = {
-    /*
-     * Additional styles to override themes.
-     */
-    style?: Styles;
-};
-
-export type NormalisedBaseConfig = {
-    /*
-     * Additional styles to override themes.
-     */
-    style: Styles;
-};
 
 export type FormFieldBaseConfig = {
     /*
@@ -254,3 +265,28 @@ export type ReactComponentClass = ComponentClass | (<T>(props: T) => JSX.Element
 export type WithRouterType = (Component: ReactComponentClass) => ReactComponentClass;
 
 export type Styles = Record<string, CSSObject>;
+
+/*
+ * Features Config Types.
+ */
+
+export type FeatureBaseConfig = {
+    /*
+     * Additional styles to override themes.
+     */
+    style?: Styles;
+};
+
+export type NormalisedBaseConfig = {
+    /*
+     * Additional styles to override themes.
+     */
+    style: Styles;
+};
+
+export type SuccessAPIResponse = {
+    /*
+     * Success.
+     */
+    status: "OK";
+};

--- a/test/unit/recipe/emailpassword/emailPassword.test.js
+++ b/test/unit/recipe/emailpassword/emailPassword.test.js
@@ -57,7 +57,7 @@ describe("EmailPassword", function() {
         EmailPassword.init()(SuperTokens.getAppInfo());
 
         await assertFormFieldsEqual(
-            EmailPassword.getInstanceOrThrow().getConfig().signInAndUpFeature.signUpForm.formFields,
+            EmailPassword.getInstanceOrThrow().config.signInAndUpFeature.signUpForm.formFields,
             getDefaultFormFields().map(getFormattedFormField),
             [
                 ["", "john", "john.doe@gmail.com"],
@@ -66,7 +66,7 @@ describe("EmailPassword", function() {
         );
 
         await assertFormFieldsEqual(
-            EmailPassword.getInstanceOrThrow().getConfig().signInAndUpFeature.signInForm.formFields,
+            EmailPassword.getInstanceOrThrow().config.signInAndUpFeature.signInForm.formFields,
             [
                 getDefaultFormFields()[0],
                 {
@@ -83,7 +83,7 @@ describe("EmailPassword", function() {
         assert(EmailPassword.getInstanceOrThrow().getFeatures()["/auth"] !== undefined);
         assert(EmailPassword.getInstanceOrThrow().getFeatures()["/auth/reset-password"] !== undefined);
         assert(EmailPassword.getInstanceOrThrow().getFeatures()["/auth/verify-email"] === undefined);
-        assert.deepStrictEqual(EmailPassword.getInstanceOrThrow().getRecipeId(), "emailpassword");
+        assert.deepStrictEqual(EmailPassword.getInstanceOrThrow().recipeId, "emailpassword");
     });
 
     it("Initializing EmailPassword and disable default implementation but Email verification required", async function() {
@@ -108,7 +108,7 @@ describe("EmailPassword", function() {
         assert(EmailPassword.getInstanceOrThrow().getFeatures()["/auth"] === undefined);
         assert(EmailPassword.getInstanceOrThrow().getFeatures()["/auth/reset-password"] === undefined);
         assert(EmailPassword.getInstanceOrThrow().getFeatures()["/auth/verify-email"] !== undefined);
-        assert.deepStrictEqual(EmailPassword.getInstanceOrThrow().getConfig().emailVerificationFeature.mode, "REQUIRED");
+        assert.deepStrictEqual(EmailPassword.getInstanceOrThrow().config.emailVerificationFeature.mode, "REQUIRED");
     });
 
     it("Initializing EmailPassword with optional custom Fields for SignUp", async function() {
@@ -128,7 +128,7 @@ describe("EmailPassword", function() {
         // Default Sign Up fields + Custom fields.
         await assertFormFieldsEqual(
             EmailPassword.getInstanceOrThrow()
-                .getConfig().signInAndUpFeature.signUpForm.formFields,
+                .config.signInAndUpFeature.signUpForm.formFields,
             [
                 getDefaultFormFields()[0],
                 getDefaultFormFields()[1],
@@ -147,7 +147,7 @@ describe("EmailPassword", function() {
         // Sign In fields unchanged.
 
         await assertFormFieldsEqual(
-            EmailPassword.getInstanceOrThrow().getConfig().signInAndUpFeature.signInForm.formFields,
+            EmailPassword.getInstanceOrThrow().config.signInAndUpFeature.signInForm.formFields,
             [
                 getDefaultFormFields()[0],
                 {
@@ -181,7 +181,7 @@ describe("EmailPassword", function() {
         // Default Sign Up fields + Custom fields.
         await assertFormFieldsEqual(
             EmailPassword.getInstanceOrThrow()
-                .getConfig().signInAndUpFeature.signUpForm.formFields,
+                .config.signInAndUpFeature.signUpForm.formFields,
             [
                 {
                     ...customEmailField,
@@ -196,7 +196,7 @@ describe("EmailPassword", function() {
         );
 
         const signUpEmailValidateError = await EmailPassword.getInstanceOrThrow()
-            .getConfig().signInAndUpFeature.signUpForm
+            .config.signInAndUpFeature.signUpForm
             .formFields[0]
             .validate("foo");
         assert.strictEqual(signUpEmailValidateError, "Custom Email Error");
@@ -204,7 +204,7 @@ describe("EmailPassword", function() {
         // Sign In fields changed.
         await assertFormFieldsEqual(
             EmailPassword.getInstanceOrThrow()
-                .getConfig().signInAndUpFeature.signInForm
+                .config.signInAndUpFeature.signInForm
                 .formFields,
             [
                 {
@@ -224,7 +224,7 @@ describe("EmailPassword", function() {
         );
 
         const signInEmailValidateError = await EmailPassword.getInstanceOrThrow()
-            .getConfig().signInAndUpFeature.signInForm
+            .config.signInAndUpFeature.signInForm
             .formFields[0]
             .validate("foo");
         assert.strictEqual(signInEmailValidateError, "Custom Email Error");
@@ -257,7 +257,7 @@ describe("EmailPassword", function() {
         // Sign Up fields unchanged.
         await assertFormFieldsEqual(
             EmailPassword.getInstanceOrThrow()
-                .getConfig().signInAndUpFeature.signUpForm
+                .config.signInAndUpFeature.signUpForm
                 .formFields,
             getDefaultFormFields().map(getFormattedFormField),
             [
@@ -269,7 +269,7 @@ describe("EmailPassword", function() {
         // Sign In email field changed only.
         await assertFormFieldsEqual(
             EmailPassword.getInstanceOrThrow()
-                .getConfig().signInAndUpFeature.signInForm
+                .config.signInAndUpFeature.signInForm
                 .formFields,
             [
                 {
@@ -289,7 +289,7 @@ describe("EmailPassword", function() {
         );
 
         const signInEmailValidateError = await EmailPassword.getInstanceOrThrow()
-            .getConfig().signInAndUpFeature.signInForm
+            .config.signInAndUpFeature.signInForm
             .formFields[0]
             .validate("foo");
         assert.strictEqual(signInEmailValidateError, "Custom Email Error");
@@ -313,7 +313,7 @@ describe("EmailPassword", function() {
         // Default Sign Up fields + Custom fields.
         await assertFormFieldsEqual(
             EmailPassword.getInstanceOrThrow()
-                .getConfig().signInAndUpFeature.signUpForm.formFields,
+                .config.signInAndUpFeature.signUpForm.formFields,
             [
                 getDefaultFormFields()[0],
                 getDefaultFormFields()[1],
@@ -332,7 +332,7 @@ describe("EmailPassword", function() {
         // Sign In fields unchanged.
         await assertFormFieldsEqual(
             EmailPassword.getInstanceOrThrow()
-                .getConfig().signInAndUpFeature.signInForm.formFields,
+                .config.signInAndUpFeature.signInForm.formFields,
             [
                 getDefaultFormFields()[0],
                 {
@@ -366,7 +366,7 @@ describe("EmailPassword", function() {
         // Default Sign Up fields + Custom fields.
         await assertFormFieldsEqual(
             EmailPassword.getInstanceOrThrow()
-                .getConfig().signInAndUpFeature.signUpForm.formFields,
+                .config.signInAndUpFeature.signUpForm.formFields,
             [
                 {
                     ...customEmailField,
@@ -381,7 +381,7 @@ describe("EmailPassword", function() {
         );
 
         const signUpEmailValidateError = await EmailPassword.getInstanceOrThrow()
-            .getConfig().signInAndUpFeature.signUpForm
+            .config.signInAndUpFeature.signUpForm
             .formFields[0]
             .validate("foo");
         assert.strictEqual(signUpEmailValidateError, "Custom Email Error");
@@ -389,7 +389,7 @@ describe("EmailPassword", function() {
         // Sign In fields changed.
         await assertFormFieldsEqual(
             EmailPassword.getInstanceOrThrow()
-                .getConfig().signInAndUpFeature.signInForm
+                .config.signInAndUpFeature.signInForm
                 .formFields,
             [
                 {
@@ -409,13 +409,13 @@ describe("EmailPassword", function() {
         );
 
         const signInEmailValidateError = await EmailPassword.getInstanceOrThrow()
-            .getConfig().signInAndUpFeature.signInForm
+            .config.signInAndUpFeature.signInForm
             .formFields[0]
             .validate("foo");
         assert.strictEqual(signInEmailValidateError, "Custom Email Error");
 
         const enterEmailPasswordResetEmailValidateError = await EmailPassword.getInstanceOrThrow()
-            .getConfig().resetPasswordUsingTokenFeature.enterEmailForm
+            .config.resetPasswordUsingTokenFeature.enterEmailForm
             .formFields[0]
             .validate("foo");
         assert.strictEqual(enterEmailPasswordResetEmailValidateError, "Custom Email Error");
@@ -442,7 +442,7 @@ describe("EmailPassword", function() {
         // Sign Up fields changed
         await assertFormFieldsEqual(
             EmailPassword.getInstanceOrThrow()
-                .getConfig().signInAndUpFeature.signUpForm.formFields,
+                .config.signInAndUpFeature.signUpForm.formFields,
             [
                 getDefaultFormFields()[0],
                 {
@@ -460,7 +460,7 @@ describe("EmailPassword", function() {
         // Sign In fields changed
         await assertFormFieldsEqual(
             EmailPassword.getInstanceOrThrow()
-                .getConfig().signInAndUpFeature.signInForm.formFields,
+                .config.signInAndUpFeature.signInForm.formFields,
             [
                 getDefaultFormFields()[0],
                 {
@@ -478,7 +478,7 @@ describe("EmailPassword", function() {
         // TODO: Fix to take into account field is not optional Reset password fields gets custom password field.
         // assert.deepStrictEqual(
         //     EmailPassword.getInstanceOrThrow()
-        //         .getConfig().resetPasswordUsingTokenFeature.submitNewPasswordForm.formFields[0].validate,
+        //         .config.resetPasswordUsingTokenFeature.submitNewPasswordForm.formFields[0].validate,
         //     customPasswordValidate
         // );
 
@@ -494,7 +494,7 @@ describe("EmailPassword", function() {
             id: "password",
             value: "test123E"
         }];
-        const inputErrors = await validateForm(formFields, EmailPassword.getInstanceOrThrow().getConfig().signInAndUpFeature.signInForm.formFields);
+        const inputErrors = await validateForm(formFields, EmailPassword.getInstanceOrThrow().config.signInAndUpFeature.signInForm.formFields);
             
         assert.deepStrictEqual(inputErrors, []);
     });
@@ -508,7 +508,7 @@ describe("EmailPassword", function() {
             id: "password",
             value: "test123E"
         }];
-        const inputErrors = await validateForm(formFields, EmailPassword.getInstanceOrThrow().getConfig().signInAndUpFeature.signInForm.formFields);
+        const inputErrors = await validateForm(formFields, EmailPassword.getInstanceOrThrow().config.signInAndUpFeature.signInForm.formFields);
         assert.deepStrictEqual(inputErrors, []);
     });
 
@@ -521,7 +521,7 @@ describe("EmailPassword", function() {
             id: "password",
             value: "test123E"
         }];
-        const inputErrors = await validateForm(formFields, EmailPassword.getInstanceOrThrow().getConfig().signInAndUpFeature.signInForm.formFields);
+        const inputErrors = await validateForm(formFields, EmailPassword.getInstanceOrThrow().config.signInAndUpFeature.signInForm.formFields);
         assert.deepStrictEqual(inputErrors, [{
             error: "Email is invalid",
             id: "email"
@@ -555,7 +555,7 @@ describe("EmailPassword", function() {
             id: "company",
             value: ""
         }];
-        const inputErrors = await validateForm(input, EmailPassword.getInstanceOrThrow().getConfig().signInAndUpFeature.signUpForm.formFields);
+        const inputErrors = await validateForm(input, EmailPassword.getInstanceOrThrow().config.signInAndUpFeature.signUpForm.formFields);
         
         assert.deepStrictEqual(inputErrors, [
             {
@@ -590,7 +590,7 @@ describe("EmailPassword", function() {
             value: "test123E"
         }];
 
-        assert.rejects(validateForm(input, EmailPassword.getInstanceOrThrow().getConfig().signInAndUpFeature.signUpForm.formFields), Error("Are you sending too many / too few formFields?"))
+        assert.rejects(validateForm(input, EmailPassword.getInstanceOrThrow().config.signInAndUpFeature.signUpForm.formFields), Error("Are you sending too many / too few formFields?"))
                 
     });
 


### PR DESCRIPTION
Sub PR 2/4 of https://github.com/supertokens/supertokens-auth-react/pull/163
- Create `AuthRecipeModule` abstraction
- config/recipeId/httpRequest as public instead of private instance attributes. No need for getter/setter methods.