### PR TITLE
add linter rules to make sure jsx is the first import

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -1,5 +1,23 @@
 module.exports = {
     rules: {
+
+        "jsx-first-import": {
+            create: function(context) {
+                return {
+                    Program(node) {
+                        const importDeclarations = node.body.filter(n => n.type === "ImportDeclaration");
+                        importDeclarations.forEach((importDeclaration, index) => {
+                            importDeclaration.specifiers.forEach(specifier => {
+                                 if (specifier.imported && specifier.imported.name === "jsx" && index > 0) {
+                                    context.report(node, '/** @jsx jsx */\nimport { jsx } from "@emotion/react";\n must be the first import of the file.');
+                                 }
+                            });
+                        });
+                    }
+                };
+            }
+        },
+
         "no-direct-window-object": {
             create: function(context) {
                 return {
@@ -11,6 +29,7 @@ module.exports = {
                 };
             }
         },
+
         "no-css-without-data-supertokens": {
             create: function(context) {
                 return {

--- a/lib/.eslintrc.js
+++ b/lib/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
         "react-hooks/exhaustive-deps": "warn", // Checks effect dependencies
         "supertokens-auth-react/no-direct-window-object": "error",
         "supertokens-auth-react/no-css-without-data-supertokens": "error",
+        "supertokens-auth-react/jsx-first-import": "error",
         "typescript-eslint/indent": "off", // Prettier takes care of indentation.
         "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/member-delimiter-style": [

--- a/lib/build/components/featureWrapper.js
+++ b/lib/build/components/featureWrapper.js
@@ -35,7 +35,6 @@ var React = __importStar(require("react"));
 var emotion_1 = __importDefault(require("react-shadow/emotion"));
 var constants_1 = require("../constants");
 var errorBoundary_1 = __importDefault(require("./errorBoundary"));
-/** @jsx jsx */
 var react_1 = require("@emotion/react");
 var cache_1 = __importDefault(require("@emotion/cache"));
 var superTokensEmotionCache = cache_1.default({

--- a/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/index copy.d.ts
+++ b/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/index copy.d.ts
@@ -14,4 +14,5 @@ declare class ResetPasswordUsingToken extends PureComponent<FeatureBaseProps, {
     enterEmail: (formFields: APIFormField[]) => Promise<FormBaseAPIResponse>;
     render: () => JSX.Element;
 }
+export declare function ResetPasswordUsingTokenFeature(): JSX.Element;
 export default ResetPasswordUsingToken;

--- a/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/index copy.js
+++ b/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/index copy.js
@@ -192,6 +192,7 @@ var api_1 = require("./api");
 var featureWrapper_1 = __importDefault(require("../../../../../components/featureWrapper"));
 var authRecipeModule_1 = __importDefault(require("../../../../authRecipeModule"));
 var superTokens_1 = __importDefault(require("../../../../../superTokens"));
+var emailPassword_1 = __importDefault(require("../../../emailPassword"));
 /*
  * Component.
  */
@@ -381,4 +382,11 @@ var ResetPasswordUsingToken = /** @class */ (function(_super) {
     }
     return ResetPasswordUsingToken;
 })(react_2.PureComponent);
+/*
+ * Used for embedding in page.
+ */
+function ResetPasswordUsingTokenFeature() {
+    return react_1.jsx(ResetPasswordUsingToken, { recipeId: emailPassword_1.default.getInstanceOrThrow().recipeId });
+}
+exports.ResetPasswordUsingTokenFeature = ResetPasswordUsingTokenFeature;
 exports.default = ResetPasswordUsingToken;

--- a/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/wrapper.d.ts
+++ b/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/wrapper.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="react" />
+export default function ResetPasswordUsingToken(props: any): JSX.Element;

--- a/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/wrapper.js
+++ b/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/wrapper.js
@@ -1,0 +1,52 @@
+"use strict";
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+var __assign =
+    (this && this.__assign) ||
+    function() {
+        __assign =
+            Object.assign ||
+            function(t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function(mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+/*
+ * Imports.
+ */
+var react_1 = __importDefault(require("react"));
+var _1 = __importDefault(require("."));
+var emailPassword_1 = __importDefault(require("../../../emailPassword"));
+/*
+ * Used for embedding in page.
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+function ResetPasswordUsingToken(props) {
+    return react_1.default.createElement(
+        _1.default,
+        __assign({ recipeId: emailPassword_1.default.getInstanceOrThrow().recipeId }, props)
+    );
+}
+exports.default = ResetPasswordUsingToken;

--- a/lib/build/recipe/emailpassword/components/features/signInAndUp/index.d.ts
+++ b/lib/build/recipe/emailpassword/components/features/signInAndUp/index.d.ts
@@ -17,5 +17,4 @@ declare class SignInAndUp extends PureComponent<FeatureBaseProps, SignInAndUpSta
     componentDidMount: () => Promise<void>;
     render: () => JSX.Element;
 }
-export declare function SignInAndUpFeature(): JSX.Element;
 export default SignInAndUp;

--- a/lib/build/recipe/emailpassword/components/features/signInAndUp/index.js
+++ b/lib/build/recipe/emailpassword/components/features/signInAndUp/index.js
@@ -206,7 +206,6 @@ var utils_1 = require("../../../../../utils");
 var featureWrapper_1 = __importDefault(require("../../../../../components/featureWrapper"));
 var authRecipeModule_1 = __importDefault(require("../../../../authRecipeModule"));
 var superTokens_1 = __importDefault(require("../../../../../superTokens"));
-var emailPassword_1 = __importDefault(require("../../../emailPassword"));
 /*
  * Component.
  */
@@ -539,11 +538,4 @@ var SignInAndUp = /** @class */ (function(_super) {
     };
     return SignInAndUp;
 })(react_2.PureComponent);
-/*
- * Used for embedding in page.
- */
-function SignInAndUpFeature() {
-    return react_1.jsx(SignInAndUp, { recipeId: emailPassword_1.default.getInstanceOrThrow().recipeId });
-}
-exports.SignInAndUpFeature = SignInAndUpFeature;
 exports.default = SignInAndUp;

--- a/lib/build/recipe/emailpassword/components/features/signInAndUp/wrapper.d.ts
+++ b/lib/build/recipe/emailpassword/components/features/signInAndUp/wrapper.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="react" />
+export default function SignInAndUp(props: any): JSX.Element;

--- a/lib/build/recipe/emailpassword/components/features/signInAndUp/wrapper.js
+++ b/lib/build/recipe/emailpassword/components/features/signInAndUp/wrapper.js
@@ -1,0 +1,51 @@
+"use strict";
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+var __assign =
+    (this && this.__assign) ||
+    function() {
+        __assign =
+            Object.assign ||
+            function(t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function(mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+/*
+ * Imports.
+ */
+var react_1 = __importDefault(require("react"));
+var _1 = __importDefault(require("."));
+var emailPassword_1 = __importDefault(require("../../../emailPassword"));
+/*
+ * Used for embedding in page.
+ */
+function SignInAndUp(props) {
+    return react_1.default.createElement(
+        _1.default,
+        __assign({ recipeId: emailPassword_1.default.getInstanceOrThrow().recipeId }, props)
+    );
+}
+exports.default = SignInAndUp;

--- a/lib/build/recipe/emailpassword/emailPassword.js
+++ b/lib/build/recipe/emailpassword/emailPassword.js
@@ -190,10 +190,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var authRecipeModule_1 = __importDefault(require("../authRecipeModule"));
 var utils_1 = require("../../utils");
 var utils_2 = require("./utils");
-var _1 = require(".");
 var normalisedURLPath_1 = __importDefault(require("../../normalisedURLPath"));
 var constants_1 = require("./constants");
 var constants_2 = require("../../constants");
+var wrapper_1 = __importDefault(require("./components/features/signInAndUp/wrapper"));
+var wrapper_2 = __importDefault(require("./components/features/resetPasswordUsingToken/wrapper"));
 /*
  * Class.
  */
@@ -214,7 +215,7 @@ var EmailPassword = /** @class */ (function(_super) {
                 features[normalisedFullPath.getAsStringDangerous()] = {
                     matches: utils_1.matchRecipeIdUsingQueryParams(_this.recipeId),
                     rid: _this.recipeId,
-                    component: _1.SignInAndUp
+                    component: wrapper_1.default
                 };
             }
             if (_this.config.resetPasswordUsingTokenFeature.disableDefaultImplementation !== true) {
@@ -224,7 +225,7 @@ var EmailPassword = /** @class */ (function(_super) {
                 features[normalisedFullPath.getAsStringDangerous()] = {
                     matches: utils_1.matchRecipeIdUsingQueryParams(_this.recipeId),
                     rid: _this.recipeId,
-                    component: _1.ResetPasswordUsingToken
+                    component: wrapper_2.default
                 };
             }
             return __assign({}, features, _this.getAuthRecipeModuleFeatures());

--- a/lib/build/recipe/emailpassword/index.d.ts
+++ b/lib/build/recipe/emailpassword/index.d.ts
@@ -1,9 +1,9 @@
 import { CreateRecipeFunction, SuccessAPIResponse } from "../../types";
 import { EmailPasswordUserInput } from "./types";
 import EmailPasswordAuth from "./components/emailPasswordAuth";
-import { SignInAndUpFeature as SignInAndUp } from "./components/features/signInAndUp";
+import SignInAndUp from "./components/features/signInAndUp/wrapper";
 import SignInAndUpTheme from "./components/themes/signInAndUp";
-import { ResetPasswordUsingTokenFeature as ResetPasswordUsingToken } from "./components/features/resetPasswordUsingToken";
+import ResetPasswordUsingToken from "./components/features/resetPasswordUsingToken/wrapper";
 import ResetPasswordUsingTokenTheme from "./components/themes/resetPasswordUsingToken";
 import EmailVerificationTheme from "../emailverification/components/themes/emailVerification";
 import EmailVerification from "./components/features/emailVerification";

--- a/lib/build/recipe/emailpassword/index.js
+++ b/lib/build/recipe/emailpassword/index.js
@@ -150,14 +150,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var emailPassword_1 = __importDefault(require("./emailPassword"));
 var emailPasswordAuth_1 = __importDefault(require("./components/emailPasswordAuth"));
 exports.EmailPasswordAuth = emailPasswordAuth_1.default;
-var signInAndUp_1 = require("./components/features/signInAndUp");
-exports.SignInAndUp = signInAndUp_1.SignInAndUpFeature;
-var signInAndUp_2 = __importDefault(require("./components/themes/signInAndUp"));
-exports.SignInAndUpTheme = signInAndUp_2.default;
-var resetPasswordUsingToken_1 = require("./components/features/resetPasswordUsingToken");
-exports.ResetPasswordUsingToken = resetPasswordUsingToken_1.ResetPasswordUsingTokenFeature;
-var resetPasswordUsingToken_2 = __importDefault(require("./components/themes/resetPasswordUsingToken"));
-exports.ResetPasswordUsingTokenTheme = resetPasswordUsingToken_2.default;
+var wrapper_1 = __importDefault(require("./components/features/signInAndUp/wrapper"));
+exports.SignInAndUp = wrapper_1.default;
+var signInAndUp_1 = __importDefault(require("./components/themes/signInAndUp"));
+exports.SignInAndUpTheme = signInAndUp_1.default;
+var wrapper_2 = __importDefault(require("./components/features/resetPasswordUsingToken/wrapper"));
+exports.ResetPasswordUsingToken = wrapper_2.default;
+var resetPasswordUsingToken_1 = __importDefault(require("./components/themes/resetPasswordUsingToken"));
+exports.ResetPasswordUsingTokenTheme = resetPasswordUsingToken_1.default;
 var emailVerification_1 = __importDefault(require("../emailverification/components/themes/emailVerification"));
 exports.EmailVerificationTheme = emailVerification_1.default;
 var emailVerification_2 = __importDefault(require("./components/features/emailVerification"));
@@ -191,10 +191,10 @@ var EmailPasswordAPIWrapper = /** @class */ (function() {
      * Static attributes.
      */
     EmailPasswordAPIWrapper.EmailPasswordAuth = emailPasswordAuth_1.default;
-    EmailPasswordAPIWrapper.SignInAndUp = signInAndUp_1.SignInAndUpFeature;
-    EmailPasswordAPIWrapper.SignInAndUpTheme = signInAndUp_2.default;
-    EmailPasswordAPIWrapper.ResetPasswordUsingToken = resetPasswordUsingToken_1.ResetPasswordUsingTokenFeature;
-    EmailPasswordAPIWrapper.ResetPasswordUsingTokenTheme = resetPasswordUsingToken_2.default;
+    EmailPasswordAPIWrapper.SignInAndUp = wrapper_1.default;
+    EmailPasswordAPIWrapper.SignInAndUpTheme = signInAndUp_1.default;
+    EmailPasswordAPIWrapper.ResetPasswordUsingToken = wrapper_2.default;
+    EmailPasswordAPIWrapper.ResetPasswordUsingTokenTheme = resetPasswordUsingToken_1.default;
     EmailPasswordAPIWrapper.EmailVerification = emailVerification_2.default;
     EmailPasswordAPIWrapper.EmailVerificationTheme = emailVerification_1.default;
     return EmailPasswordAPIWrapper;

--- a/lib/build/recipe/thirdparty/index.js
+++ b/lib/build/recipe/thirdparty/index.js
@@ -1,4 +1,18 @@
 "use strict";
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 var __awaiter =
     (this && this.__awaiter) ||
     function(thisArg, _arguments, P, generator) {
@@ -133,20 +147,10 @@ var __importDefault =
         return mod && mod.__esModule ? mod : { default: mod };
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
- *
- * This software is licensed under the Apache License, Version 2.0 (the
- * "License") as published by the Apache Software Foundation.
- *
- * You may not use this file except in compliance with the License. You may
- * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+/*
+ * Import
  */
+// /!\ ThirdParty must be imported before any of the providers to prevent circular dependencies.
 var thirdparty_1 = __importDefault(require("./thirdparty"));
 var emailVerification_1 = __importDefault(require("../emailverification/components/themes/emailVerification"));
 exports.EmailVerificationTheme = emailVerification_1.default;

--- a/lib/build/recipe/thirdpartyemailpassword/components/features/resetPaswsordUsingToken/index.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/components/features/resetPaswsordUsingToken/index.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="react" />
+export default function ResetPasswordUsingToken(): JSX.Element;

--- a/lib/build/recipe/thirdpartyemailpassword/components/features/resetPaswsordUsingToken/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/components/features/resetPaswsordUsingToken/index.js
@@ -1,0 +1,35 @@
+"use strict";
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+var __importDefault =
+    (this && this.__importDefault) ||
+    function(mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+/*
+ * Imports.
+ */
+var react_1 = __importDefault(require("react"));
+var resetPasswordUsingToken_1 = __importDefault(
+    require("../../../../emailpassword/components/features/resetPasswordUsingToken")
+);
+var thirdpartyEmailpassword_1 = __importDefault(require("../../../thirdpartyEmailpassword"));
+function ResetPasswordUsingToken() {
+    return react_1.default.createElement(resetPasswordUsingToken_1.default, {
+        recipeId: thirdpartyEmailpassword_1.default.getInstanceOrThrow().recipeId
+    });
+}
+exports.default = ResetPasswordUsingToken;

--- a/lib/build/recipe/thirdpartyemailpassword/thirdpartyEmailpassword.js
+++ b/lib/build/recipe/thirdpartyemailpassword/thirdpartyEmailpassword.js
@@ -195,8 +195,10 @@ var constants_1 = require("../../constants");
 var signInAndUp_1 = __importDefault(require("./components/features/signInAndUp"));
 var signInAndUpCallback_1 = __importDefault(require("../thirdparty/components/features/signInAndUpCallback"));
 var constants_2 = require("../emailpassword/constants");
-var emailpassword_1 = require("../emailpassword");
 var utils_3 = require("../thirdparty/utils");
+var resetPasswordUsingToken_1 = __importDefault(
+    require("../emailpassword/components/features/resetPasswordUsingToken")
+);
 /*
  * Class.
  */
@@ -227,7 +229,7 @@ var ThirdPartyEmailPassword = /** @class */ (function(_super) {
                 features[normalisedFullPath.getAsStringDangerous()] = {
                     matches: utils_1.matchRecipeIdUsingQueryParams(_this.recipeId),
                     rid: _this.recipeId,
-                    component: emailpassword_1.ResetPasswordUsingToken
+                    component: resetPasswordUsingToken_1.default
                 };
             }
             // Add callback route for each provider.

--- a/lib/ts/components/featureWrapper.tsx
+++ b/lib/ts/components/featureWrapper.tsx
@@ -21,9 +21,7 @@ import * as React from "react";
 import root from "react-shadow/emotion";
 import { ST_ROOT_ID } from "../constants";
 import ErrorBoundary from "./errorBoundary";
-
-/** @jsx jsx */
-import { CacheProvider, jsx } from "@emotion/react";
+import { CacheProvider } from "@emotion/react";
 import createCache from "@emotion/cache";
 
 const superTokensEmotionCache = createCache({

--- a/lib/ts/recipe/emailpassword/components/features/resetPasswordUsingToken/index.tsx
+++ b/lib/ts/recipe/emailpassword/components/features/resetPasswordUsingToken/index.tsx
@@ -37,7 +37,6 @@ import FeatureWrapper from "../../../../../components/featureWrapper";
 import AuthRecipeModule from "../../../../authRecipeModule";
 import { NormalisedAuthRecipeConfig } from "../../../../authRecipeModule/types";
 import SuperTokens from "../../../../../superTokens";
-import EmailPassword from "../../../emailPassword";
 
 /*
  * Component.
@@ -207,13 +206,6 @@ class ResetPasswordUsingToken extends PureComponent<FeatureBaseProps, { token: s
             </FeatureWrapper>
         );
     };
-}
-
-/*
- * Used for embedding in page.
- */
-export function ResetPasswordUsingTokenFeature(): JSX.Element {
-    return <ResetPasswordUsingToken recipeId={EmailPassword.getInstanceOrThrow().recipeId} />;
 }
 
 export default ResetPasswordUsingToken;

--- a/lib/ts/recipe/emailpassword/components/features/resetPasswordUsingToken/wrapper.tsx
+++ b/lib/ts/recipe/emailpassword/components/features/resetPasswordUsingToken/wrapper.tsx
@@ -1,0 +1,29 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Imports.
+ */
+import React from "react";
+import { default as ResetPasswordUsingTokenBase } from ".";
+import EmailPassword from "../../../emailPassword";
+
+/*
+ * Used for embedding in page.
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export default function ResetPasswordUsingToken(props: any): JSX.Element {
+    return <ResetPasswordUsingTokenBase recipeId={EmailPassword.getInstanceOrThrow().recipeId} {...props} />;
+}

--- a/lib/ts/recipe/emailpassword/components/features/signInAndUp/index.tsx
+++ b/lib/ts/recipe/emailpassword/components/features/signInAndUp/index.tsx
@@ -37,7 +37,6 @@ import FeatureWrapper from "../../../../../components/featureWrapper";
 import { NormalisedAuthRecipeConfig, SignInAndUpState } from "../../../../authRecipeModule/types";
 import AuthRecipeModule from "../../../../authRecipeModule";
 import SuperTokens from "../../../../../superTokens";
-import EmailPassword from "../../../emailPassword";
 /*
  * Component.
  */
@@ -324,13 +323,6 @@ class SignInAndUp extends PureComponent<FeatureBaseProps, SignInAndUpState> {
             </FeatureWrapper>
         );
     };
-}
-
-/*
- * Used for embedding in page.
- */
-export function SignInAndUpFeature(): JSX.Element {
-    return <SignInAndUp recipeId={EmailPassword.getInstanceOrThrow().recipeId} />;
 }
 
 export default SignInAndUp;

--- a/lib/ts/recipe/emailpassword/components/features/signInAndUp/wrapper.tsx
+++ b/lib/ts/recipe/emailpassword/components/features/signInAndUp/wrapper.tsx
@@ -1,0 +1,28 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Imports.
+ */
+import React from "react";
+import { default as SignInAndUpBase } from ".";
+import EmailPassword from "../../../emailPassword";
+
+/*
+ * Used for embedding in page.
+ */
+export default function SignInAndUp(props: any): JSX.Element {
+    return <SignInAndUpBase recipeId={EmailPassword.getInstanceOrThrow().recipeId} {...props} />;
+}

--- a/lib/ts/recipe/emailpassword/emailPassword.ts
+++ b/lib/ts/recipe/emailpassword/emailPassword.ts
@@ -29,12 +29,13 @@ import {
 } from "./types";
 import { isTest, matchRecipeIdUsingQueryParams } from "../../utils";
 import { normaliseEmailPasswordConfig } from "./utils";
-import { ResetPasswordUsingToken, SignInAndUp } from ".";
 import NormalisedURLPath from "../../normalisedURLPath";
 import { DEFAULT_RESET_PASSWORD_PATH } from "./constants";
 import { SSR_ERROR } from "../../constants";
 import RecipeModule from "../recipeModule";
 import { NormalisedAuthRecipeConfig } from "../authRecipeModule/types";
+import SignInAndUp from "./components/features/signInAndUp/wrapper";
+import ResetPasswordUsingToken from "./components/features/resetPasswordUsingToken/wrapper";
 
 /*
  * Class.

--- a/lib/ts/recipe/emailpassword/index.ts
+++ b/lib/ts/recipe/emailpassword/index.ts
@@ -21,9 +21,9 @@ import { EmailPasswordUserInput } from "./types";
 
 import EmailPassword from "./emailPassword";
 import EmailPasswordAuth from "./components/emailPasswordAuth";
-import { SignInAndUpFeature as SignInAndUp } from "./components/features/signInAndUp";
+import SignInAndUp from "./components/features/signInAndUp/wrapper";
 import SignInAndUpTheme from "./components/themes/signInAndUp";
-import { ResetPasswordUsingTokenFeature as ResetPasswordUsingToken } from "./components/features/resetPasswordUsingToken";
+import ResetPasswordUsingToken from "./components/features/resetPasswordUsingToken/wrapper";
 import ResetPasswordUsingTokenTheme from "./components/themes/resetPasswordUsingToken";
 import EmailVerificationTheme from "../emailverification/components/themes/emailVerification";
 import EmailVerification from "./components/features/emailVerification";

--- a/lib/ts/recipe/thirdparty/index.ts
+++ b/lib/ts/recipe/thirdparty/index.ts
@@ -12,6 +12,12 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
+/*
+ * Import
+ */
+
+// /!\ ThirdParty must be imported before any of the providers to prevent circular dependencies.
 import ThirdParty from "./thirdparty";
 import { CreateRecipeFunction, SuccessAPIResponse } from "../../types";
 import EmailVerificationTheme from "../emailverification/components/themes/emailVerification";

--- a/lib/ts/recipe/thirdpartyemailpassword/thirdpartyEmailpassword.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/thirdpartyEmailpassword.ts
@@ -36,8 +36,8 @@ import { NormalisedAuthRecipeConfig } from "../authRecipeModule/types";
 import SignInAndUp from "./components/features/signInAndUp";
 import SignInAndUpCallback from "../thirdparty/components/features/signInAndUpCallback";
 import { DEFAULT_RESET_PASSWORD_PATH } from "../emailpassword/constants";
-import { ResetPasswordUsingToken } from "../emailpassword";
 import { matchRecipeIdUsingState } from "../thirdparty/utils";
+import ResetPasswordUsingToken from "../emailpassword/components/features/resetPasswordUsingToken";
 
 /*
  * Class.


### PR DESCRIPTION
Make sure that emotion `jsx` is imported as the first import when used in a file.

Fix issue with embedding components in a page. 