### PR TITLE
adds "OPTIONAL" mode for email validation

### DIFF
--- a/lib/build/recipe/emailverification/types.d.ts
+++ b/lib/build/recipe/emailverification/types.d.ts
@@ -4,7 +4,7 @@ import { ComponentOverride } from "../../components/componentOverride/componentO
 import { SendVerifyEmail } from "./components/themes/emailVerification/sendVerifyEmail";
 import { VerifyEmailLinkClicked } from "./components/themes/emailVerification/verifyEmailLinkClicked";
 export declare type UserInputForAuthRecipeModule = {
-    mode?: "OFF" | "REQUIRED";
+    mode?: "OFF" | "REQUIRED" | "OPTIONAL";
     disableDefaultImplementation?: boolean;
     sendVerifyEmailScreen?: FeatureBaseConfig;
     verifyEmailLinkClickedScreen?: FeatureBaseConfig;
@@ -25,7 +25,7 @@ export declare type UserInput = UserInputForAuthRecipeModule & {
 export declare type Config = UserInput &
     RecipeModuleConfig<GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext>;
 export declare type NormalisedConfig = {
-    mode: "OFF" | "REQUIRED";
+    mode: "OFF" | "REQUIRED" | "OPTIONAL";
     disableDefaultImplementation: boolean;
     sendVerifyEmailScreen: FeatureBaseConfig;
     verifyEmailLinkClickedScreen: FeatureBaseConfig;

--- a/lib/ts/recipe/emailverification/types.ts
+++ b/lib/ts/recipe/emailverification/types.ts
@@ -24,7 +24,7 @@ import { VerifyEmailLinkClicked } from "./components/themes/emailVerification/ve
 // So we have UserInputForAuthRecipeModule for AuthRecipeModule, and UserInput
 // for anyone who wants to use this recipe directly.
 export type UserInputForAuthRecipeModule = {
-    mode?: "OFF" | "REQUIRED";
+    mode?: "OFF" | "REQUIRED" | "OPTIONAL";
     disableDefaultImplementation?: boolean;
     sendVerifyEmailScreen?: FeatureBaseConfig;
     verifyEmailLinkClickedScreen?: FeatureBaseConfig;
@@ -49,7 +49,7 @@ export type UserInput = UserInputForAuthRecipeModule & {
 export type Config = UserInput & RecipeModuleConfig<GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext>;
 
 export type NormalisedConfig = {
-    mode: "OFF" | "REQUIRED";
+    mode: "OFF" | "REQUIRED" | "OPTIONAL";
     disableDefaultImplementation: boolean;
     sendVerifyEmailScreen: FeatureBaseConfig;
     verifyEmailLinkClickedScreen: FeatureBaseConfig;


### PR DESCRIPTION
Related to https://github.com/supertokens/supertokens-core/issues/159

This does not fully implement the linked issue, but it is useful in that it allows optional validation to be done. Without this there is no way to do it because "OFF" does not create the necessary routes while "REQUIRED" adds an undesired redirect.

This PR adds "OPTIONAL", which does create the necessary routes but does not redirect, and `isEmailVerificationRequired` continues to return `false`.

The way I am using this is in a NextJS app, with React browser code similar to this:

```jsx
<Button onClick={handleVerifyClick}>Verify Email Address</Button>
```

```ts
const handleVerifyClick = async (): Promise<void> => {
    if (isEmailVerified) return

    const response = await fetch(`${appInfo.apiBasePath}user/email/verify/token`, {
      method: 'POST',
      headers: {
        'Content-Type': 'application/json',
        'fdi-version': '1.8',
        rid: 'emailpassword'
      }
    })
    const responseObj = await response.json()
    if (responseObj.status === 'OK') {
      openEmailVerificationSentSnackbar('We sent you an email. Click the button in the email to verify your address.')
    }
  }
```

I think it would be good to also export a `sendVerifyEmail` API util function in browser code, similar to how `isEmailVerified` is exported, so that I don't have to hack the fetch call. But I'm a little lost about how to properly make this change.

I would also need some guidance about where to update or add tests for this change.

The issue mentions having built-in UI for optional validation. I guess this would be similar to what exists but requiring a button click to send the email. I actually would prefer if "REQUIRED" UI did not automatically send the email on mount. It tends to get stuck in a redirect cycle sometimes, which causes it to send many emails in a row. If "REQUIRED" and "OPTIONAL" both require you to click a button first, it would solve both problems. I could simply manually redirect to the router, or render `EmailVerification` component anywhere, without worrying about either one automatically sending emails.

Anyway, just wanted to provide a starting point for this feature.