### PR TITLE
Bump version to 0.15.10 and add FDI 1.9 to supported FDI versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.15.10] - 2021-09-27
+
+### Changed
+
+-   New FDI 2.9
+
 ## [0.15.9] - 2021-09-19
 
 ### Added

--- a/frontendDriverInterfaceSupported.json
+++ b/frontendDriverInterfaceSupported.json
@@ -1,4 +1,4 @@
 {
     "_comment": "contains a list of frontend-backend interface versions that this package supports",
-    "versions": ["1.8"]
+    "versions": ["1.8", "1.9"]
 }

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const package_version = "0.15.9";
+export declare const package_version = "0.15.10";
 export declare const supported_fdi: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,6 +14,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.package_version = "0.15.9";
-exports.supported_fdi = ["1.8"];
+exports.package_version = "0.15.10";
+exports.supported_fdi = ["1.8", "1.9"];
 //# sourceMappingURL=version.js.map

--- a/lib/build/version.js.map
+++ b/lib/build/version.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"version.js","sourceRoot":"","sources":["../ts/version.ts"],"names":[],"mappings":";;AAAA;;;;;;;;;;;;;GAaG;AACU,QAAA,eAAe,GAAG,QAAQ,CAAC;AAC3B,QAAA,aAAa,GAAG,CAAC,KAAK,CAAC,CAAC"}
+{"version":3,"file":"version.js","sourceRoot":"","sources":["../ts/version.ts"],"names":[],"mappings":";;AAAA;;;;;;;;;;;;;GAaG;AACU,QAAA,eAAe,GAAG,SAAS,CAAC;AAC5B,QAAA,aAAa,GAAG,CAAC,KAAK,EAAE,KAAK,CAAC,CAAC"}

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,5 +12,5 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.15.9";
-export const supported_fdi = ["1.8"];
+export const package_version = "0.15.10";
+export const supported_fdi = ["1.8", "1.9"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.15.9",
+    "version": "0.15.10",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.15.9",
+    "version": "0.15.10",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "devDependencies": {
@@ -57,7 +57,7 @@
         "react": ">=16.8.0"
     },
     "scripts": {
-        "init": "npm i -d && (cd ./test/server && npm i ) && (cd ./examples/for-tests && npm i -d)",
+        "init": "npm i -d && (cd ./test/server && npm i ) && (cd ./examples/for-tests && npm i -d) && (cd ./test/with-typescript && npm i -d)",
         "start": "npm-run-all --parallel front server watch",
         "front": "(cd ./examples/for-tests/ && BROWSER=none PORT=3031 npm run start)",
         "server": "cd test/server/ && START=true INSTALL_PATH=../../../supertokens-root NODE_PORT=8082 node .",


### PR DESCRIPTION
## Summary of change
- Changes the package version to 0.15.10
- Adds FDI 1.9 to supported FDI versions (both frontendDriverInterfaceSupported.json and version.ts)
- Changed `init` script in package.json to include running `npm i -d` in `test/with-typescript`

## Related issues
- https://github.com/supertokens/for-zenhub/issues/38

## Test Plan
No tests needed as there is no logical change

## Documentation changes
None

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
None
