### PR TITLE
Apple fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Fixes issue two in https://github.com/supertokens/supertokens-node/issues/199
 -   Adds FDI 1.10 as supported
+-   Does not set `redirect_uri` third party authorisation URL if it's already set by the backend.
 
 ## [0.17.1] - 2021-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Fixes issue two in https://github.com/supertokens/supertokens-node/issues/199
 -   Adds FDI 1.10 as supported
 -   Does not set `redirect_uri` third party authorisation URL if it's already set by the backend.
+-   Adds an optional `clientId` input to providers to be sent during the `signinup` API.
 
 ## [0.17.1] - 2021-10-28
 

--- a/examples/with-thirdparty/api-server.js
+++ b/examples/with-thirdparty/api-server.js
@@ -40,12 +40,15 @@ supertokens.init({
                         clientSecret: "e97051221f4b6426e8fe8d51486396703012f5bd",
                         clientId: "467101b197249757c71f",
                     }),
-
-                    // we have commented the below because our app domain (thirdparty.demo.supertokens.io) is not approved by Facebook since it's only a demo app.
-                    // ThirdParty.Facebook({
-                    //     clientSecret: process.env.FACEBOOK_CLIENT_SECRET,
-                    //     clientId: process.env.FACEBOOK_CLIENT_ID
-                    // })
+                    ThirdParty.Apple({
+                        clientId: "4398792-io.supertokens.example.service",
+                        clientSecret: {
+                            keyId: "7M48Y4RYDL",
+                            privateKey:
+                                "-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgu8gXs+XYkqXD6Ala9Sf/iJXzhbwcoG5dMh1OonpdJUmgCgYIKoZIzj0DAQehRANCAASfrvlFbFCYqn3I2zeknYXLwtH30JuOKestDbSfZYxZNMqhF/OzdZFTV0zc5u5s3eN+oCWbnvl0hM+9IW0UlkdA\n-----END PRIVATE KEY-----",
+                            teamId: "YWQCXGJRJL",
+                        },
+                    }),
                 ],
             },
         }),

--- a/examples/with-thirdparty/src/App.js
+++ b/examples/with-thirdparty/src/App.js
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import "./App.css";
 import SuperTokens, { getSuperTokensRoutesForReactRouterDom } from "supertokens-auth-react";
-import ThirdParty, { ThirdPartyAuth, Google, Github } from "supertokens-auth-react/recipe/thirdparty";
+import ThirdParty, { ThirdPartyAuth, Google, Github, Apple } from "supertokens-auth-react/recipe/thirdparty";
 import Session from "supertokens-auth-react/recipe/session";
 import Home from "./Home";
 import { Switch, BrowserRouter as Router, Route } from "react-router-dom";
@@ -29,7 +29,7 @@ SuperTokens.init({
     recipeList: [
         ThirdParty.init({
             signInAndUpFeature: {
-                providers: [Github.init(), Google.init()],
+                providers: [Github.init(), Google.init(), Apple.init()],
             },
             emailVerificationFeature: {
                 mode: "REQUIRED",

--- a/examples/with-thirdpartyemailpassword/api-server.js
+++ b/examples/with-thirdpartyemailpassword/api-server.js
@@ -39,7 +39,7 @@ supertokens.init({
                     clientId: "467101b197249757c71f",
                 }),
                 ThirdPartyEmailPassword.Apple({
-                    clientId: "io.supertokens.example.service",
+                    clientId: "4398792-io.supertokens.example.service",
                     clientSecret: {
                         keyId: "7M48Y4RYDL",
                         privateKey:

--- a/examples/with-thirdpartyemailpassword/api-server.js
+++ b/examples/with-thirdpartyemailpassword/api-server.js
@@ -1,6 +1,5 @@
 const express = require("express");
 const cors = require("cors");
-const morgan = require("morgan");
 const helmet = require("helmet");
 require("dotenv").config();
 let supertokens = require("supertokens-node");
@@ -39,12 +38,15 @@ supertokens.init({
                     clientSecret: "e97051221f4b6426e8fe8d51486396703012f5bd",
                     clientId: "467101b197249757c71f",
                 }),
-
-                // we have commented the below because our app domain (ThirdPartyEmailPassword.demo.supertokens.io) is not approved by Facebook since it's only a demo app.
-                // ThirdPartyEmailPassword.Facebook({
-                //     clientSecret: process.env.FACEBOOK_CLIENT_SECRET,
-                //     clientId: process.env.FACEBOOK_CLIENT_ID
-                // })
+                ThirdPartyEmailPassword.Apple({
+                    clientId: "io.supertokens.example.service",
+                    clientSecret: {
+                        keyId: "7M48Y4RYDL",
+                        privateKey:
+                            "-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgu8gXs+XYkqXD6Ala9Sf/iJXzhbwcoG5dMh1OonpdJUmgCgYIKoZIzj0DAQehRANCAASfrvlFbFCYqn3I2zeknYXLwtH30JuOKestDbSfZYxZNMqhF/OzdZFTV0zc5u5s3eN+oCWbnvl0hM+9IW0UlkdA\n-----END PRIVATE KEY-----",
+                        teamId: "YWQCXGJRJL",
+                    },
+                }),
             ],
         }),
         Session.init(),
@@ -62,7 +64,6 @@ app.use(
     })
 );
 
-app.use(morgan("dev"));
 app.use(
     helmet({
         contentSecurityPolicy: false,

--- a/examples/with-thirdpartyemailpassword/src/App.js
+++ b/examples/with-thirdpartyemailpassword/src/App.js
@@ -5,6 +5,7 @@ import ThirdPartyEmailPassword, {
     ThirdPartyEmailPasswordAuth,
     Google,
     Github,
+    Apple,
 } from "supertokens-auth-react/recipe/thirdpartyemailpassword";
 import Session from "supertokens-auth-react/recipe/session";
 import Home from "./Home";
@@ -33,7 +34,7 @@ SuperTokens.init({
     recipeList: [
         ThirdPartyEmailPassword.init({
             signInAndUpFeature: {
-                providers: [Github.init(), Google.init()],
+                providers: [Github.init(), Google.init(), Apple.init()],
             },
             emailVerificationFeature: {
                 mode: "REQUIRED",

--- a/lib/build/recipe/thirdparty/providers/apple.js
+++ b/lib/build/recipe/thirdparty/providers/apple.js
@@ -61,6 +61,7 @@ var Apple = /** @class */ (function (_super) {
             _super.call(this, {
                 id: "apple",
                 name: "Apple",
+                clientId: config === null || config === void 0 ? void 0 : config.clientId,
             }) || this;
         _this.getButton = function () {
             if (_this.buttonComponent !== undefined) {

--- a/lib/build/recipe/thirdparty/providers/facebook.js
+++ b/lib/build/recipe/thirdparty/providers/facebook.js
@@ -61,6 +61,7 @@ var Facebook = /** @class */ (function (_super) {
             _super.call(this, {
                 id: "facebook",
                 name: "Facebook",
+                clientId: config === null || config === void 0 ? void 0 : config.clientId,
             }) || this;
         _this.getButton = function () {
             if (_this.buttonComponent !== undefined) {

--- a/lib/build/recipe/thirdparty/providers/github.js
+++ b/lib/build/recipe/thirdparty/providers/github.js
@@ -61,6 +61,7 @@ var Github = /** @class */ (function (_super) {
             _super.call(this, {
                 id: "github",
                 name: "Github",
+                clientId: config === null || config === void 0 ? void 0 : config.clientId,
             }) || this;
         _this.getButton = function () {
             if (_this.buttonComponent !== undefined) {

--- a/lib/build/recipe/thirdparty/providers/google.js
+++ b/lib/build/recipe/thirdparty/providers/google.js
@@ -61,6 +61,7 @@ var Google = /** @class */ (function (_super) {
             _super.call(this, {
                 id: "google",
                 name: "Google",
+                clientId: config === null || config === void 0 ? void 0 : config.clientId,
             }) || this;
         _this.getButton = function () {
             if (_this.buttonComponent !== undefined) {

--- a/lib/build/recipe/thirdparty/providers/index.d.ts
+++ b/lib/build/recipe/thirdparty/providers/index.d.ts
@@ -3,6 +3,7 @@ import { ProviderConfig } from "./types";
 export default abstract class Provider {
     id: string;
     name: string;
+    clientId?: string;
     constructor(config: ProviderConfig);
     getDefaultButton(name?: string): JSX.Element;
     getRedirectURL(): string;

--- a/lib/build/recipe/thirdparty/providers/index.js
+++ b/lib/build/recipe/thirdparty/providers/index.js
@@ -57,6 +57,7 @@ var Provider = /** @class */ (function () {
         };
         this.id = config.id;
         this.name = config.name;
+        this.clientId = config.clientId;
     }
     /*
      * Components.

--- a/lib/build/recipe/thirdparty/providers/twitter.js
+++ b/lib/build/recipe/thirdparty/providers/twitter.js
@@ -61,6 +61,7 @@ var Twitter = /** @class */ (function (_super) {
             _super.call(this, {
                 id: "twitter",
                 name: "Twitter",
+                clientId: config === null || config === void 0 ? void 0 : config.clientId,
             }) || this;
         _this.getButton = function () {
             if (_this.buttonComponent !== undefined) {

--- a/lib/build/recipe/thirdparty/providers/types.d.ts
+++ b/lib/build/recipe/thirdparty/providers/types.d.ts
@@ -2,12 +2,15 @@
 export declare type ProviderConfig = {
     id: string;
     name: string;
+    clientId?: string;
 };
 export declare type BuiltInProviderConfig = {
     buttonComponent?: JSX.Element;
+    clientId?: string;
 };
 export declare type CustomProviderConfig = {
     id: string;
     name: string;
+    clientId?: string;
     buttonComponent?: JSX.Element;
 };

--- a/lib/build/recipe/thirdparty/recipeImplementation.js
+++ b/lib/build/recipe/thirdparty/recipeImplementation.js
@@ -265,7 +265,7 @@ function getRecipeImplementation(recipeId, appInfo) {
         },
         redirectToThirdPartyLogin: function (input) {
             return __awaiter(this, void 0, void 0, function () {
-                var provider, state, url, urlWithState;
+                var provider, state, url, urlObj, alreadyContainsRedirectURI, urlWithState;
                 return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
@@ -302,10 +302,16 @@ function getRecipeImplementation(recipeId, appInfo) {
                             ];
                         case 1:
                             url = _a.sent();
-                            urlWithState = utils_1.appendQueryParamsToURL(url, {
-                                state: state,
-                                redirect_uri: provider.getRedirectURL(),
-                            });
+                            urlObj = new URL(url);
+                            alreadyContainsRedirectURI = urlObj.searchParams.get("redirect_uri") !== undefined;
+                            urlWithState = alreadyContainsRedirectURI
+                                ? utils_1.appendQueryParamsToURL(url, {
+                                      state: state,
+                                  })
+                                : utils_1.appendQueryParamsToURL(url, {
+                                      state: state,
+                                      redirect_uri: provider.getRedirectURL(),
+                                  });
                             // 4. Redirect to provider authorisation URL.
                             utils_1.redirectWithFullPageReload(urlWithState);
                             return [2 /*return*/, { status: "OK" }];

--- a/lib/build/recipe/thirdparty/recipeImplementation.js
+++ b/lib/build/recipe/thirdparty/recipeImplementation.js
@@ -303,7 +303,7 @@ function getRecipeImplementation(recipeId, appInfo) {
                         case 1:
                             url = _a.sent();
                             urlObj = new URL(url);
-                            alreadyContainsRedirectURI = urlObj.searchParams.get("redirect_uri") !== undefined;
+                            alreadyContainsRedirectURI = urlObj.searchParams.get("redirect_uri") !== null;
                             urlWithState = alreadyContainsRedirectURI
                                 ? utils_1.appendQueryParamsToURL(url, {
                                       state: state,

--- a/lib/build/recipe/thirdparty/recipeImplementation.js
+++ b/lib/build/recipe/thirdparty/recipeImplementation.js
@@ -215,6 +215,7 @@ function getRecipeImplementation(recipeId, appInfo) {
                                             code: code,
                                             thirdPartyId: input.thirdPartyId,
                                             redirectURI: redirectURI,
+                                            clientId: provider.clientId,
                                         }),
                                     },
                                     function (context) {

--- a/lib/ts/recipe/thirdparty/providers/apple.tsx
+++ b/lib/ts/recipe/thirdparty/providers/apple.tsx
@@ -38,6 +38,7 @@ export default class Apple extends Provider {
         super({
             id: "apple",
             name: "Apple",
+            clientId: config?.clientId,
         });
 
         if (config === undefined) {

--- a/lib/ts/recipe/thirdparty/providers/facebook.tsx
+++ b/lib/ts/recipe/thirdparty/providers/facebook.tsx
@@ -38,6 +38,7 @@ export default class Facebook extends Provider {
         super({
             id: "facebook",
             name: "Facebook",
+            clientId: config?.clientId,
         });
 
         if (config === undefined) {

--- a/lib/ts/recipe/thirdparty/providers/github.tsx
+++ b/lib/ts/recipe/thirdparty/providers/github.tsx
@@ -38,6 +38,7 @@ export default class Github extends Provider {
         super({
             id: "github",
             name: "Github",
+            clientId: config?.clientId,
         });
 
         if (config === undefined) {

--- a/lib/ts/recipe/thirdparty/providers/google.tsx
+++ b/lib/ts/recipe/thirdparty/providers/google.tsx
@@ -38,6 +38,7 @@ export default class Google extends Provider {
         super({
             id: "google",
             name: "Google",
+            clientId: config?.clientId,
         });
 
         if (config === undefined) {

--- a/lib/ts/recipe/thirdparty/providers/index.tsx
+++ b/lib/ts/recipe/thirdparty/providers/index.tsx
@@ -32,6 +32,7 @@ export default abstract class Provider {
      */
     id: string;
     name: string;
+    clientId?: string;
 
     /*
      * Constructor.
@@ -40,6 +41,7 @@ export default abstract class Provider {
     constructor(config: ProviderConfig) {
         this.id = config.id;
         this.name = config.name;
+        this.clientId = config.clientId;
     }
 
     /*

--- a/lib/ts/recipe/thirdparty/providers/twitter.tsx
+++ b/lib/ts/recipe/thirdparty/providers/twitter.tsx
@@ -38,6 +38,7 @@ export default class Twitter extends Provider {
         super({
             id: "twitter",
             name: "Twitter",
+            clientId: config?.clientId,
         });
 
         if (config === undefined) {

--- a/lib/ts/recipe/thirdparty/providers/types.ts
+++ b/lib/ts/recipe/thirdparty/providers/types.ts
@@ -22,6 +22,8 @@ export type ProviderConfig = {
      * Provider Name
      */
     name: string;
+
+    clientId?: string; // optional clientId to be sent during signinup API
 };
 
 export type BuiltInProviderConfig = {
@@ -29,6 +31,8 @@ export type BuiltInProviderConfig = {
      * Button Component
      */
     buttonComponent?: JSX.Element;
+
+    clientId?: string; // optional clientId to be sent during signinup API
 };
 
 export type CustomProviderConfig = {
@@ -41,6 +45,8 @@ export type CustomProviderConfig = {
      * Provider Name
      */
     name: string;
+
+    clientId?: string;
 
     /*
      * Button Component

--- a/lib/ts/recipe/thirdparty/recipeImplementation.ts
+++ b/lib/ts/recipe/thirdparty/recipeImplementation.ts
@@ -161,7 +161,7 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
 
             // for some third party providers, the redirect_uri is set on the backend itself (for example in the case of apple). In these cases, we don't set them here...
             const urlObj = new URL(url);
-            const alreadyContainsRedirectURI = urlObj.searchParams.get("redirect_uri") !== undefined;
+            const alreadyContainsRedirectURI = urlObj.searchParams.get("redirect_uri") !== null;
 
             const urlWithState = alreadyContainsRedirectURI
                 ? appendQueryParamsToURL(url, {

--- a/lib/ts/recipe/thirdparty/recipeImplementation.ts
+++ b/lib/ts/recipe/thirdparty/recipeImplementation.ts
@@ -74,6 +74,7 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                         code,
                         thirdPartyId: input.thirdPartyId,
                         redirectURI,
+                        clientId: provider.clientId,
                     }),
                 },
                 (context) => {

--- a/lib/ts/recipe/thirdparty/recipeImplementation.ts
+++ b/lib/ts/recipe/thirdparty/recipeImplementation.ts
@@ -159,10 +159,18 @@ export default function getRecipeImplementation(recipeId: string, appInfo: Norma
                 config: input.config,
             });
 
-            const urlWithState = appendQueryParamsToURL(url, {
-                state,
-                redirect_uri: provider.getRedirectURL(),
-            });
+            // for some third party providers, the redirect_uri is set on the backend itself (for example in the case of apple). In these cases, we don't set them here...
+            const urlObj = new URL(url);
+            const alreadyContainsRedirectURI = urlObj.searchParams.get("redirect_uri") !== undefined;
+
+            const urlWithState = alreadyContainsRedirectURI
+                ? appendQueryParamsToURL(url, {
+                      state,
+                  })
+                : appendQueryParamsToURL(url, {
+                      state,
+                      redirect_uri: provider.getRedirectURL(),
+                  });
 
             // 4. Redirect to provider authorisation URL.
             redirectWithFullPageReload(urlWithState);

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -354,7 +354,9 @@ function getThirdPartyConfigs() {
             termsOfServiceLink: "https://supertokens.io/legal/terms-and-conditions",
             providers: [
                 ThirdParty.Github.init(),
-                ThirdParty.Google.init(),
+                ThirdParty.Google.init({
+                    clientId: "some client ID",
+                }),
                 ThirdParty.Facebook.init(),
                 ThirdParty.Apple.init(),
                 {


### PR DESCRIPTION
## Summary of change

- Does not add a redirect_uri if it's already set from the backend.
- Adds sign in with apple to all relevant examples.
- Adds optional `clientId` to providers

## Related issues

-   https://github.com/supertokens/supertokens-core/issues/320
- https://github.com/supertokens/frontend-driver-interface/issues/24

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`). If creating a sub recipe, make sure to use `bind(this)` when calling the original implementation from your functions
