### PR TITLE
Fix text centering for custom provider buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.17.8] - 2021-12-27
+
+###
+
+-   Issuer where custom provider buttons would not render text in the center of the button
+
 ## [0.17.7] - 2021-12-21
 
 ### Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ We're so excited you're interested in helping with SuperTokens! We are happy to 
 
 1. `npm run start`
 
+Note: To test different recipes you need to update the value of `authRecipe` in local storage. For example `thirdpartyemailpassword` would result in that recipe being used. If there is no value for `authRecipe` set, the Email Password recipe is used by default
+
 ## Pull Request
 
 1. Before submitting a pull request make sure all tests have passed

--- a/lib/build/recipe/thirdparty/components/library/providerButton.js
+++ b/lib/build/recipe/thirdparty/components/library/providerButton.js
@@ -41,10 +41,10 @@ function ProviderButton(_a) {
     return react_1.jsx(
         "button",
         { css: [styles.providerButton, providerStyle], "data-supertokens": "providerButton" },
-        react_1.jsx(
-            "div",
-            { css: styles.providerButtonLeft, "data-supertokens": "providerButtonLeft" },
-            logo !== undefined &&
+        logo !== undefined &&
+            react_1.jsx(
+                "div",
+                { css: styles.providerButtonLeft, "data-supertokens": "providerButtonLeft" },
                 react_1.jsx(
                     "div",
                     { css: styles.providerButtonLogo, "data-supertokens": "providerButtonLogo" },
@@ -54,7 +54,7 @@ function ProviderButton(_a) {
                         logo
                     )
                 )
-        ),
+            ),
         react_1.jsx("div", { css: styles.providerButtonText, "data-supertokens": "providerButtonText" }, children)
     );
 }

--- a/lib/build/recipe/thirdparty/components/themes/styles.js
+++ b/lib/build/recipe/thirdparty/components/themes/styles.js
@@ -55,10 +55,17 @@ function getStyles(palette) {
             paddingBottom: "9px",
         },
         providerButton: {
+            // Default button height in 34
+            minHeight: "34px",
+            // this will allow the button to scale with different font sizes and text lengths
+            height: "auto !important",
             display: "flex",
             flexDirection: "row",
             paddingLeft: "0px",
             paddingRight: "0px",
+            // This makes the button look somewhat cleaner if the text wraps
+            paddingTop: "2px",
+            paddingBottom: "2px",
         },
         providerButtonLeft: {
             width: "40px",
@@ -75,9 +82,6 @@ function getStyles(palette) {
             margin: "auto",
             textAlign: "center",
             justifyContent: "center",
-            "@media (max-width: 380px)": {
-                marginLeft: "10%",
-            },
         },
         providerGoogle: styles_1.getButtonStyle(providerColors.google),
         providerGithub: styles_1.getButtonStyle(providerColors.github, true),

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const package_version = "0.17.7";
+export declare const package_version = "0.17.8";
 export declare const supported_fdi: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,5 +14,5 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.package_version = "0.17.7";
+exports.package_version = "0.17.8";
 exports.supported_fdi = ["1.8", "1.9", "1.10", "1.11"];

--- a/lib/ts/recipe/thirdparty/components/library/providerButton.tsx
+++ b/lib/ts/recipe/thirdparty/components/library/providerButton.tsx
@@ -42,17 +42,18 @@ export default function ProviderButton({ children, logo, providerName }: Provide
      */
     const styles = useContext(StyleContext);
     const providerStyle = styles[`provider${providerName}`];
+
     return (
         <button css={[styles.providerButton, providerStyle]} data-supertokens="providerButton">
-            <div css={styles.providerButtonLeft} data-supertokens="providerButtonLeft">
-                {logo !== undefined && (
+            {logo !== undefined && (
+                <div css={styles.providerButtonLeft} data-supertokens="providerButtonLeft">
                     <div css={styles.providerButtonLogo} data-supertokens="providerButtonLogo">
                         <div css={styles.providerButtonLogoCenter} data-supertokens="providerButtonLogoCenter">
                             {logo}
                         </div>
                     </div>
-                )}
-            </div>
+                </div>
+            )}
             <div css={styles.providerButtonText} data-supertokens="providerButtonText">
                 {children}
             </div>

--- a/lib/ts/recipe/thirdparty/components/themes/styles.ts
+++ b/lib/ts/recipe/thirdparty/components/themes/styles.ts
@@ -40,10 +40,17 @@ export function getStyles(palette: NormalisedPalette): NormalisedDefaultStyles {
         },
 
         providerButton: {
+            // Default button height in 34
+            minHeight: "34px",
+            // this will allow the button to scale with different font sizes and text lengths
+            height: "auto !important",
             display: "flex",
             flexDirection: "row",
             paddingLeft: "0px",
             paddingRight: "0px",
+            // This makes the button look somewhat cleaner if the text wraps
+            paddingTop: "2px",
+            paddingBottom: "2px",
         },
 
         providerButtonLeft: {
@@ -64,9 +71,6 @@ export function getStyles(palette: NormalisedPalette): NormalisedDefaultStyles {
             margin: "auto",
             textAlign: "center",
             justifyContent: "center",
-            "@media (max-width: 380px)": {
-                marginLeft: "10%",
-            },
         },
 
         providerGoogle: getButtonStyle(providerColors.google),

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,5 +12,5 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.17.7";
+export const package_version = "0.17.8";
 export const supported_fdi = ["1.8", "1.9", "1.10", "1.11"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.17.7",
+    "version": "0.17.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.17.7",
+    "version": "0.17.8",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "devDependencies": {


### PR DESCRIPTION
## Summary of change
- Changes the provider button component to render the left div (used as the logo container) only if a logo component is provided. Previously this would render an empty div, resulting in the text never being centered.
- Changes the styling for the provider button to handle size changes because of large font sizes or long texts
- Updates the CONTRIBUTING guide

## Related issues

- https://github.com/supertokens/supertokens-auth-react/issues/348

## Test Plan

Tested with the sample application in the repo.

#### Default render
<img width="347" alt="Screenshot 2021-12-27 at 3 14 15 PM" src="https://user-images.githubusercontent.com/18233774/147459686-7af7d0de-7a87-44f9-9c5d-55575b103efd.png">

#### With long text
<img width="355" alt="Screenshot 2021-12-27 at 3 12 45 PM" src="https://user-images.githubusercontent.com/18233774/147459731-249b6812-62b7-47ae-94f0-a8055b9db924.png">

#### With long text and increased font size
<img width="361" alt="Screenshot 2021-12-27 at 3 12 58 PM" src="https://user-images.githubusercontent.com/18233774/147459767-35deca57-e70d-4439-a4ad-6977b443629a.png">

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `lib/ts/version.ts`~~
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] ~~If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).~~
-   [ ] ~~If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.~~

## Remaining TODOs for this PR

-   [x] Update CHANGELOG
-   [x] Update version
