### PR TITLE
Reset pw improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 -   Extracts away AuthRecipe into one with email verification and one without email verification
+-   Updated the reset password form to match the single input forms of passwordless (showing label, removed placeholder and autofocus)
+-   Using the default label and no placeholder for the reset password email form instead of the ones configured for the signup form
+-   Removed ":" from labels
 
 ### Adds
 
@@ -22,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking changes
 
 -   `getRoutingComponent` now returns ` JSX.Element | null` instead of ` JSX.Element | undefined`
+-   Removed ":" from labels
 
 ## [0.17.9] - 2022-01-07
 

--- a/lib/build/recipe/emailpassword/components/library/label.js
+++ b/lib/build/recipe/emailpassword/components/library/label.js
@@ -36,6 +36,6 @@ function Label(_a) {
      * Render.
      */
     var styles = react_2.useContext(styleContext_1.default);
-    return react_1.jsx("div", { "data-supertokens": "label", css: styles.label }, value, ":", showIsRequired && " *");
+    return react_1.jsx("div", { "data-supertokens": "label", css: styles.label }, value, showIsRequired && " *");
 }
 exports.default = Label;

--- a/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/resetPasswordEmail.js
+++ b/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/resetPasswordEmail.js
@@ -272,7 +272,7 @@ var EmailPasswordResetPasswordEmail = /** @class */ (function (_super) {
                             });
                         });
                     },
-                    showLabels: false,
+                    showLabels: true,
                     validateOnBlur: true,
                     header: react_1.jsx(
                         react_2.Fragment,

--- a/lib/build/recipe/emailpassword/utils.js
+++ b/lib/build/recipe/emailpassword/utils.js
@@ -340,7 +340,13 @@ function normaliseResetPasswordUsingTokenFeature(signUpPasswordFieldValidate, si
             : {};
     var enterEmailForm = {
         style: enterEmailFormStyle,
-        formFields: [signUpEmailField],
+        formFields: [
+            __assign(__assign({}, getDefaultEmailFormField()), {
+                validate: signUpEmailField.validate,
+                placeholder: "",
+                autofocus: true,
+            }),
+        ],
     };
     return {
         disableDefaultImplementation: disableDefaultImplementation,

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -56,6 +56,7 @@ export declare type NormalisedFormField = {
     validate: (value: any) => Promise<string | undefined> | string | undefined;
     optional: boolean;
     autoComplete?: string;
+    autofocus?: boolean;
 };
 export declare type ReactComponentClass = ComponentClass<any, any> | (<T>(props: T) => JSX.Element);
 export declare type Styles = Record<string, CSSObject>;

--- a/lib/ts/recipe/emailpassword/components/library/label.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/label.tsx
@@ -44,7 +44,6 @@ export default function Label({ value, showIsRequired }: LabelProps): JSX.Elemen
     return (
         <div data-supertokens="label" css={styles.label}>
             {value}
-            {":"}
             {showIsRequired && " *"}
         </div>
     );

--- a/lib/ts/recipe/emailpassword/components/themes/resetPasswordUsingToken/resetPasswordEmail.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/resetPasswordUsingToken/resetPasswordEmail.tsx
@@ -92,7 +92,7 @@ class EmailPasswordResetPasswordEmail extends PureComponent<EnterEmailProps, Ent
                                 config: this.props.config,
                             })
                         }
-                        showLabels={false}
+                        showLabels={true}
                         validateOnBlur={true}
                         header={
                             <Fragment>

--- a/lib/ts/recipe/emailpassword/utils.ts
+++ b/lib/ts/recipe/emailpassword/utils.ts
@@ -250,7 +250,14 @@ export function normaliseResetPasswordUsingTokenFeature(
 
     const enterEmailForm: NormalisedEnterEmailForm = {
         style: enterEmailFormStyle,
-        formFields: [signUpEmailField],
+        formFields: [
+            {
+                ...getDefaultEmailFormField(),
+                validate: signUpEmailField.validate,
+                placeholder: "",
+                autofocus: true,
+            },
+        ],
     };
 
     return {

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -193,6 +193,11 @@ export type NormalisedFormField = {
      * Autocomplete input.
      */
     autoComplete?: string;
+
+    /*
+     * Moves focus to the input element when it mounts
+     */
+    autofocus?: boolean;
 };
 
 export type ReactComponentClass = ComponentClass<any, any> | (<T>(props: T) => JSX.Element);

--- a/test/end-to-end/resetpasswordusingtoken.test.js
+++ b/test/end-to-end/resetpasswordusingtoken.test.js
@@ -117,10 +117,10 @@ describe("SuperTokens Reset password", function () {
             assert.deepStrictEqual(inputNames, ["email"]);
 
             const labelNames = await getLabelsText(page);
-            assert.deepStrictEqual(labelNames, []); // No labels.
+            assert.deepStrictEqual(labelNames, ["Email"]);
 
             const placeholders = await getPlaceholders(page);
-            assert.deepStrictEqual(placeholders, ["Your work email"]); // Email placeholder as defined in signUpForm.formFields.
+            assert.deepStrictEqual(placeholders, [""]);
 
             // Set incorrect email.
             await setInputValues(page, [{ name: "email", value: "john.doe.io" }]);
@@ -197,7 +197,7 @@ describe("SuperTokens Reset password", function () {
             assert.deepStrictEqual(inputNames, ["password", "confirm-password"]);
 
             const labelNames = await getLabelsText(page);
-            assert.deepStrictEqual(labelNames, ["New password:", "Confirm password:"]);
+            assert.deepStrictEqual(labelNames, ["New password", "Confirm password"]);
 
             const placeholders = await getPlaceholders(page);
             assert.deepStrictEqual(placeholders, ["New password", "Confirm your password"]); // Email placeholder as defined in signUpForm.formFields.

--- a/test/end-to-end/signin-rrdv5.test.js
+++ b/test/end-to-end/signin-rrdv5.test.js
@@ -118,7 +118,7 @@ describe("SuperTokens SignIn with react router dom v5", function () {
             assert.deepStrictEqual(inputNames, ["email", "password"]);
 
             const labelNames = await getLabelsText(page);
-            assert.deepStrictEqual(labelNames, ["Your Email:", "Password:"]);
+            assert.deepStrictEqual(labelNames, ["Your Email", "Password"]);
 
             const placeholders = await getPlaceholders(page);
             assert.deepStrictEqual(placeholders, ["Your work email", "Password"]);

--- a/test/end-to-end/signin-rrdv6.test.js
+++ b/test/end-to-end/signin-rrdv6.test.js
@@ -116,7 +116,7 @@ describe("SuperTokens SignIn with react router dom v6", function () {
             assert.deepStrictEqual(inputNames, ["email", "password"]);
 
             const labelNames = await getLabelsText(page);
-            assert.deepStrictEqual(labelNames, ["Your Email:", "Password:"]);
+            assert.deepStrictEqual(labelNames, ["Your Email", "Password"]);
 
             const placeholders = await getPlaceholders(page);
             assert.deepStrictEqual(placeholders, ["Your work email", "Password"]);

--- a/test/end-to-end/signin.test.js
+++ b/test/end-to-end/signin.test.js
@@ -109,7 +109,7 @@ describe("SuperTokens SignIn", function () {
             assert.deepStrictEqual(inputNames, ["email", "password"]);
 
             const labelNames = await getLabelsText(page);
-            assert.deepStrictEqual(labelNames, ["Your Email:", "Password:"]);
+            assert.deepStrictEqual(labelNames, ["Your Email", "Password"]);
 
             const placeholders = await getPlaceholders(page);
             assert.deepStrictEqual(placeholders, ["Your work email", "Password"]);

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -123,11 +123,11 @@ describe("SuperTokens SignUp", function () {
 
             const labelNames = await getLabelsText(page);
             assert.deepStrictEqual(labelNames, [
-                "Your Email: *",
-                "Password: *",
-                "Full name: *",
-                "Your age: *",
-                "Your Country:",
+                "Your Email *",
+                "Password *",
+                "Full name *",
+                "Your age *",
+                "Your Country",
             ]);
 
             const placeholders = await getPlaceholders(page);


### PR DESCRIPTION
## Summary of change

Updated the reset password form to match the single input forms from passwordless.
+ Removed ":" from labels

## Related issues

-   #341 

## Test Plan

Manual/visual tests

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
