### PR TITLE
Removed SuperTokensBranding from the oauth callback screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.18.1] - 2022-01-18
+
+### Changes
+
+-   Removed SuperTokensBranding from the oauth callback screen
+
 ## [0.18.0] - 2022-01-14
 
 ### Changes

--- a/lib/build/recipe/thirdparty/components/themes/signInAndUpCallback/index.js
+++ b/lib/build/recipe/thirdparty/components/themes/signInAndUpCallback/index.js
@@ -51,7 +51,6 @@ var react_2 = require("react");
 var spinnerIcon_1 = __importDefault(require("../../../../../components/assets/spinnerIcon"));
 var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
-var SuperTokensBranding_1 = require("../../../../../components/SuperTokensBranding");
 /*
  * Component.
  */
@@ -75,8 +74,7 @@ var ThirdPartySignInAndUpCallbackTheme = /** @class */ (function (_super) {
                         { "data-supertokens": "spinner", css: styles.spinner },
                         react_1.jsx(spinnerIcon_1.default, { color: styles.palette.colors.primary })
                     )
-                ),
-                react_1.jsx(SuperTokensBranding_1.SuperTokensBranding, null)
+                )
             );
         };
         return _this;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const package_version = "0.18.0";
+export declare const package_version = "0.18.1";
 export declare const supported_fdi: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,5 +14,5 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.package_version = "0.18.0";
+exports.package_version = "0.18.1";
 exports.supported_fdi = ["1.8", "1.9", "1.10", "1.11", "1.12"];

--- a/lib/ts/recipe/thirdparty/components/themes/signInAndUpCallback/index.tsx
+++ b/lib/ts/recipe/thirdparty/components/themes/signInAndUpCallback/index.tsx
@@ -21,11 +21,10 @@ import { PureComponent } from "react";
 import SpinnerIcon from "../../../../../components/assets/spinnerIcon";
 import StyleContext from "../../../../../styles/styleContext";
 import { withOverride } from "../../../../../components/componentOverride/withOverride";
-import { SuperTokensBranding } from "../../../../../components/SuperTokensBranding";
+
 /*
  * Component.
  */
-
 class ThirdPartySignInAndUpCallbackTheme extends PureComponent {
     static contextType = StyleContext;
 
@@ -43,7 +42,6 @@ class ThirdPartySignInAndUpCallbackTheme extends PureComponent {
                         <SpinnerIcon color={styles.palette.colors.primary} />
                     </div>
                 </div>
-                <SuperTokensBranding />
             </div>
         );
     };

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,5 +12,5 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.18.0";
+export const package_version = "0.18.1";
 export const supported_fdi = ["1.8", "1.9", "1.10", "1.11", "1.12"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.18.0",
+    "version": "0.18.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.18.0",
+    "version": "0.18.1",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "devDependencies": {


### PR DESCRIPTION
## Summary of change

Removed SuperTokensBranding from the oauth callback screen

## Related issues


## Test Plan

N/A

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
