### PR TITLE
fix: multiple children were provided error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [unreleased]
+
+### Changes
+
+- fix sample code in docs which gives error "multiple children were provided"
 ## [0.18.1] - 2022-01-18
 
 ### Changes

--- a/examples/with-account-linking/src/App.js
+++ b/examples/with-account-linking/src/App.js
@@ -63,8 +63,10 @@ function App() {
                                 onSessionExpired={() => {
                                     updateShowSessionExpiredPopup(true);
                                 }}>
-                                <Home />
-                                {showSessionExpiredPopup && <SessionExpiredPopup />}
+                                    <>
+                                        <Home />
+                                        {showSessionExpiredPopup && <SessionExpiredPopup />}
+                                    </>
                             </ThirdPartyEmailPasswordAuth>
                         </Route>
                     </Switch>

--- a/examples/with-emailpassword/src/App.js
+++ b/examples/with-emailpassword/src/App.js
@@ -57,8 +57,10 @@ function App() {
                                     onSessionExpired={() => {
                                         updateShowSessionExpiredPopup(true);
                                     }}>
-                                    <Home />
-                                    {showSessionExpiredPopup && <SessionExpiredPopup />}
+                                        <>
+                                            <Home />
+                                            {showSessionExpiredPopup && <SessionExpiredPopup />}
+                                        </>
                                 </EmailPassword.EmailPasswordAuth>
                             }
                         />

--- a/examples/with-localstorage/src/App.js
+++ b/examples/with-localstorage/src/App.js
@@ -168,8 +168,10 @@ function App() {
                                 onSessionExpired={() => {
                                     updateShowSessionExpiredPopup(true);
                                 }}>
-                                <Home />
-                                {showSessionExpiredPopup && <SessionExpiredPopup />}
+                                <>
+                                    <Home />
+                                    {showSessionExpiredPopup && <SessionExpiredPopup />}
+                                </>
                             </EmailPassword.EmailPasswordAuth>
                         </Route>
                     </Switch>

--- a/examples/with-thirdparty/src/App.js
+++ b/examples/with-thirdparty/src/App.js
@@ -60,8 +60,10 @@ function App() {
                                     onSessionExpired={() => {
                                         updateShowSessionExpiredPopup(true);
                                     }}>
-                                    <Home />
-                                    {showSessionExpiredPopup && <SessionExpiredPopup />}
+                                    <>
+                                        <Home />
+                                        {showSessionExpiredPopup && <SessionExpiredPopup />}
+                                    </>
                                 </ThirdPartyAuth>
                             }
                         />

--- a/examples/with-thirdpartyemailpassword/src/App.js
+++ b/examples/with-thirdpartyemailpassword/src/App.js
@@ -65,8 +65,10 @@ function App() {
                                     onSessionExpired={() => {
                                         updateShowSessionExpiredPopup(true);
                                     }}>
-                                    <Home />
-                                    {showSessionExpiredPopup && <SessionExpiredPopup />}
+                                    <>
+                                        <Home />
+                                        {showSessionExpiredPopup && <SessionExpiredPopup />}
+                                    </>
                                 </ThirdPartyEmailPasswordAuth>
                             }
                         />


### PR DESCRIPTION
## Summary of change

There are 2 elements provided as the children of EmailPassword.EmailPasswordAuth, giving the error:

> This JSX tag's 'children' prop expects a single child of type 'Element', but multiple children were provided

Fixed it by adding a fragment.

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Notes

It seems like a really trivial change. But if there is any other work that is CRITICAL to merge this PR let me know.