### PR TITLE
fix(passwordless): Add missing defaultCountry to input type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## [unreleased]
+## [0.18.5] - 2022-01-27
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixes
+
+-   Added `defaultCountry` to passwordless config input in the `EMAIL_OR_PHONE` case
+
 ## [0.18.4] - 2022-01-24
 
 -   swapped out the PureComponent to functional + memo in the files i came across

--- a/lib/build/recipe/passwordless/types.d.ts
+++ b/lib/build/recipe/passwordless/types.d.ts
@@ -220,7 +220,7 @@ export declare type UserInput = (
           validateEmailAddress?: (email: string) => Promise<string | undefined> | string | undefined;
           validatePhoneNumber?: (phoneNumber: string) => Promise<string | undefined> | string | undefined;
           signInUpFeature?: SignInUpFeatureConfigInput & {
-              defaultCountryFromConfig?: CountryCode;
+              defaultCountry?: CountryCode;
               guessInternationPhoneNumberFromInputPhoneNumber?: (
                   inputPhoneNumber: string,
                   defaultCountryFromConfig?: CountryCode

--- a/lib/build/recipe/passwordless/types.d.ts
+++ b/lib/build/recipe/passwordless/types.d.ts
@@ -220,6 +220,7 @@ export declare type UserInput = (
           validateEmailAddress?: (email: string) => Promise<string | undefined> | string | undefined;
           validatePhoneNumber?: (phoneNumber: string) => Promise<string | undefined> | string | undefined;
           signInUpFeature?: SignInUpFeatureConfigInput & {
+              defaultCountryFromConfig?: CountryCode;
               guessInternationPhoneNumberFromInputPhoneNumber?: (
                   inputPhoneNumber: string,
                   defaultCountryFromConfig?: CountryCode

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const package_version = "0.18.4";
+export declare const package_version = "0.18.5";
 export declare const supported_fdi: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,5 +14,5 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.package_version = "0.18.4";
+exports.package_version = "0.18.5";
 exports.supported_fdi = ["1.8", "1.9", "1.10", "1.11", "1.12"];

--- a/lib/ts/recipe/passwordless/types.ts
+++ b/lib/ts/recipe/passwordless/types.ts
@@ -266,7 +266,7 @@ export type UserInput = (
               /*
                * Must be a two-letter ISO country code (e.g.: "US")
                */
-              defaultCountryFromConfig?: CountryCode;
+              defaultCountry?: CountryCode;
 
               guessInternationPhoneNumberFromInputPhoneNumber?: (
                   inputPhoneNumber: string,

--- a/lib/ts/recipe/passwordless/types.ts
+++ b/lib/ts/recipe/passwordless/types.ts
@@ -263,6 +263,11 @@ export type UserInput = (
           validatePhoneNumber?: (phoneNumber: string) => Promise<string | undefined> | string | undefined;
 
           signInUpFeature?: SignInUpFeatureConfigInput & {
+              /*
+               * Must be a two-letter ISO country code (e.g.: "US")
+               */
+              defaultCountryFromConfig?: CountryCode;
+
               guessInternationPhoneNumberFromInputPhoneNumber?: (
                   inputPhoneNumber: string,
                   defaultCountryFromConfig?: CountryCode

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,5 +12,5 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.18.4";
+export const package_version = "0.18.5";
 export const supported_fdi = ["1.8", "1.9", "1.10", "1.11", "1.12"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.18.4",
+    "version": "0.18.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.18.4",
+    "version": "0.18.5",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {


### PR DESCRIPTION
## Summary of change

Added `defaultCountry` to passwordless config input in the `EMAIL_OR_PHONE` case

## Related issues

-

## Test Plan

Typing only change

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Remaining TODOs for this PR

-   [ ] Update version
