### PR TITLE
fix(thirdpartypasswordless): add missing header divider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixes
+
+-   Added missing divider below the header in thirdpartypasswordless
+
 ## [0.20.0] - 2022-03-17
 
 ### Added

--- a/lib/build/recipe/thirdpartypasswordless/components/themes/signInUp/header.js
+++ b/lib/build/recipe/thirdpartypasswordless/components/themes/signInUp/header.js
@@ -35,8 +35,13 @@ exports.Header = withOverride_1.withOverride("ThirdPartyPasswordlessHeader", fun
     var styles = react_2.useContext(styleContext_1.default);
     var t = __1.useTranslation();
     return react_1.jsx(
-        "div",
-        { "data-supertokens": "headerTitle", css: styles.headerTitle },
-        t("THIRD_PARTY_PASSWORDLESS_SIGN_IN_AND_UP_HEADER_TITLE")
+        react_2.Fragment,
+        null,
+        react_1.jsx(
+            "div",
+            { "data-supertokens": "headerTitle", css: styles.headerTitle },
+            t("THIRD_PARTY_PASSWORDLESS_SIGN_IN_AND_UP_HEADER_TITLE")
+        ),
+        react_1.jsx("div", { "data-supertokens": "divider", css: styles.divider })
     );
 });

--- a/lib/ts/recipe/thirdpartypasswordless/components/themes/signInUp/header.tsx
+++ b/lib/ts/recipe/thirdpartypasswordless/components/themes/signInUp/header.tsx
@@ -17,7 +17,7 @@
  */
 /** @jsx jsx */
 import { jsx } from "@emotion/react";
-import { useContext } from "react";
+import { Fragment, useContext } from "react";
 import { useTranslation } from "../../../../..";
 import { withOverride } from "../../../../../components/componentOverride/withOverride";
 import StyleContext from "../../../../../styles/styleContext";
@@ -30,8 +30,11 @@ export const Header = withOverride("ThirdPartyPasswordlessHeader", function Thir
     const t = useTranslation();
 
     return (
-        <div data-supertokens="headerTitle" css={styles.headerTitle}>
-            {t("THIRD_PARTY_PASSWORDLESS_SIGN_IN_AND_UP_HEADER_TITLE")}
-        </div>
+        <Fragment>
+            <div data-supertokens="headerTitle" css={styles.headerTitle}>
+                {t("THIRD_PARTY_PASSWORDLESS_SIGN_IN_AND_UP_HEADER_TITLE")}
+            </div>
+            <div data-supertokens="divider" css={styles.divider}></div>
+        </Fragment>
     );
 });


### PR DESCRIPTION
## Summary of change

Adding a divider below the thirdpartypasswordless header

## Related issues

-   #404 

## Test Plan

Design only change

## Documentation changes

Design only change

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

