### PR TITLE
refactor: Rename query param in SuperTokens branding component to utm_campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.20.1] - 2022-03-31
+
+### Changed
+
+-   Refactor to the URL for the powered by component displayed on the auth forms
+
 ## [0.20.0] - 2022-03-17
 
 ### Added

--- a/lib/build/components/SuperTokensBranding.js
+++ b/lib/build/components/SuperTokensBranding.js
@@ -32,7 +32,7 @@ function SuperTokensBranding() {
         {
             "data-supertokens": "superTokensBranding",
             css: styles.superTokensBranding,
-            href: "https://supertokens.com?campaign=poweredby",
+            href: "https://supertokens.com?utm_campaign=poweredby",
             target: "_blank",
         },
         t("BRANDING_POWERED_BY_START"),

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const package_version = "0.20.0";
+export declare const package_version = "0.20.1";
 export declare const supported_fdi: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,5 +14,5 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.package_version = "0.20.0";
+exports.package_version = "0.20.1";
 exports.supported_fdi = ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13"];

--- a/lib/ts/components/SuperTokensBranding.tsx
+++ b/lib/ts/components/SuperTokensBranding.tsx
@@ -26,7 +26,7 @@ export function SuperTokensBranding(): JSX.Element {
         <a
             data-supertokens="superTokensBranding"
             css={styles.superTokensBranding}
-            href="https://supertokens.com?campaign=poweredby"
+            href="https://supertokens.com?utm_campaign=poweredby"
             target="_blank">
             {t("BRANDING_POWERED_BY_START")}
             <strong>SuperTokens</strong>

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,5 +12,5 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.20.0";
+export const package_version = "0.20.1";
 export const supported_fdi = ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.20.0",
+    "version": "0.20.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.20.0",
+    "version": "0.20.1",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {


### PR DESCRIPTION
## Summary of change
- The branding component uses `https://supertokens.com?campaign=poweredby` as the `href`, this PR changes it to `https://supertokens.com?utm_campaign=poweredby` to make it adhere with UTM tracking

## Related issues
- 

## Test Plan
- All existing test cases should pass (Github Actions)

## Documentation changes
- None needed

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `lib/ts/version.ts`~~
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] ~~If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).~~
-   [ ] ~~If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.~~

## Remaining TODOs for this PR

-   [x] Verify tests pass on Github Actions
