### PR TITLE
feat!: Integrate thirdpartypasswordless from web-js SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   All recipe functions now accept an additional parameter `userContext`, learn more about this by visiting the advanced cusotmisations section in the documentation
 -   All UI components exported by the SDK now accept an additional `userContext` prop, learn more about this by visiting the advanced cusotmisations section in the documentation
 -   Exports more recipe functions for emailverification recipe to allow them to be called without using the pre-built UI. Newly exported functions: `verifyEmail`, `sendVerificationEmail`
--   Exports all emailverification recipe functions from emailpassword, thirdparty and thirdpartyemailpassword recipes.
+-   Exports all emailverification recipe functions from emailpassword, thirdparty, thirdpartyemailpassword and thirdpartypasswordless recipes.
 -   Exports more recipe functions for emailpassword recipe to allow them to be called without using the pre-built UI. Newly exported functions: `submitNewPassword`, `sendPasswordResetEmail`, `signUp`, `signIn`, `doesEmailExist`.
 -   Exports more recipe functions for thirdparty recipe to allow them to be called without using the pre-built UI. Newly exported functions: `getAuthorizationURLWithQueryParamsAndSetState`, `signInAndUp`.
 -   Exports emailpassword and thidparty recipe functions from thirdpartyemailpassword recipe to allow them to be called without using the pre-built UI. Also exports `redirectToThirdPartyLogin` from thirdpartyemailpassword recipe.
+-   Exports more recipe functions for passwordless recipe to allow them to be called without using the pre-built UI. Newly exported functions: `createCode`, `resendCode`, `consumeCode`, `doesEmailExist`, `doesPhoneNumberExist`
 -   Changes recipe functions for email verification recipe **(this is breaking change if you use the override feature)**:
     -   `verifyEmail` -> No longer accepts `token` as a parameter, instead it calls `getEmailVerificationTokenFromURL`
     -   `getEmailVerificationTokenFromURL` -> NEW FUNCTION
@@ -46,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `emailPasswordSignUp` -> NEW FUNCTION
     -   `emailPasswordSignIn` -> NEW FUNCTION
     -   `thirdPartySignInAndUp` -> NEW FUNCTION
+-   Changes recipe functions for passwordless recipe **(this is breaking change if you use the override feature)**:
+    -   `getLinkCodeFromURL` -> NEW FUNCTION
+    -   `getPreAuthSessionIdFromURL` -> NEW FUNCTION
 -   Session recipe now uses supertokens-web-js internally (previously used supertokens-website)
 -   All recipes now include a `postAPIHook` configuration parameter that can be used to respond to network actions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Exports more recipe functions for emailverification recipe to allow them to be called without using the pre-built UI. Newly exported functions: `verifyEmail`, `sendVerificationEmail`
 -   Exports all emailverification recipe functions from emailpassword, thirdparty, thirdpartyemailpassword and thirdpartypasswordless recipes.
 -   Exports more recipe functions for emailpassword recipe to allow them to be called without using the pre-built UI. Newly exported functions: `submitNewPassword`, `sendPasswordResetEmail`, `signUp`, `signIn`, `doesEmailExist`.
--   Exports more recipe functions for thirdparty recipe to allow them to be called without using the pre-built UI. Newly exported functions: `getAuthorizationURLWithQueryParamsAndSetState`, `signInAndUp`.
+-   Exports more recipe functions for thirdparty recipe to allow them to be called without using the pre-built UI. Newly exported functions: `getAuthorisationURLWithQueryParamsAndSetState`, `signInAndUp`.
 -   Exports emailpassword and thidparty recipe functions from thirdpartyemailpassword recipe to allow them to be called without using the pre-built UI. Also exports `redirectToThirdPartyLogin` from thirdpartyemailpassword recipe.
 -   Exports more recipe functions for passwordless recipe to allow them to be called without using the pre-built UI. Newly exported functions: `createCode`, `resendCode`, `consumeCode`, `doesEmailExist`, `doesPhoneNumberExist`
 -   Exports more recipe functions for thirdpartypasswordless recipe to allow them to be called without using the pre-built UI. Newly exported functions: `redirectToThirdPartyLogin`, `thirdPartySignInAndUp`, `createCode`, `resendCode`, `consumeCode`, `doesPasswordlessUserEmailExist`, `doesPasswordlessUserPhoneNumberExist`
@@ -34,13 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `getOAuthState` -> RENAMED TO `getStateAndOtherInfoFromStorage`
     -   `setOAuthState` -> RENAMED TO `setStateAndOtherInfoToStorage`
     -   `getOAuthAuthorisationURL` -> RENAMED TO `getAuthorisationURLFromBackend`
-    -   `getAuthorizationURLWithQueryParamsAndSetState` -> NEW FUNCTION
+    -   `getAuthorisationURLWithQueryParamsAndSetState` -> NEW FUNCTION
     -   `generateStateToSendToOAuthProvider` -> NEW FUNCTION
     -   `verifyAndGetStateOrThrowError` -> NEW FUNCTION
     -   `getAuthCodeFromURL` -> NEW FUNCTION
     -   `getAuthErrorFromURL` -> NEW FUNCTION
     -   `getAuthStateFromURL` -> NEW FUNCTION
-    -   `redirectToThirdPartyLogin` -> REMOVED (use `getAuthorizationURLWithQueryParamsAndSetState` instead). NOTE: If you call this function yourself the SDK will no longer auto-redirect, you will need to redirect to the result url manually.
+    -   `redirectToThirdPartyLogin` -> REMOVED (use `getAuthorisationURLWithQueryParamsAndSetState` instead). NOTE: If you call this function yourself the SDK will no longer auto-redirect, you will need to redirect to the result url manually.
 -   Changes recipe funtions for third party email password recipe **(this is breaking change if you use the override feature)**:
     -   Changes for email password functions explained above
     -   Changes for third party functions explained above

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Exports more recipe functions for thirdparty recipe to allow them to be called without using the pre-built UI. Newly exported functions: `getAuthorizationURLWithQueryParamsAndSetState`, `signInAndUp`.
 -   Exports emailpassword and thidparty recipe functions from thirdpartyemailpassword recipe to allow them to be called without using the pre-built UI. Also exports `redirectToThirdPartyLogin` from thirdpartyemailpassword recipe.
 -   Exports more recipe functions for passwordless recipe to allow them to be called without using the pre-built UI. Newly exported functions: `createCode`, `resendCode`, `consumeCode`, `doesEmailExist`, `doesPhoneNumberExist`
+-   Exports more recipe functions for thirdpartypasswordless recipe to allow them to be called without using the pre-built UI. Newly exported functions: `redirectToThirdPartyLogin`, `thirdPartySignInAndUp`, `createCode`, `resendCode`, `consumeCode`, `doesPasswordlessUserEmailExist`, `doesPasswordlessUserPhoneNumberExist`
 -   Changes recipe functions for email verification recipe **(this is breaking change if you use the override feature)**:
     -   `verifyEmail` -> No longer accepts `token` as a parameter, instead it calls `getEmailVerificationTokenFromURL`
     -   `getEmailVerificationTokenFromURL` -> NEW FUNCTION
@@ -50,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Changes recipe functions for passwordless recipe **(this is breaking change if you use the override feature)**:
     -   `getLinkCodeFromURL` -> NEW FUNCTION
     -   `getPreAuthSessionIdFromURL` -> NEW FUNCTION
+-   Changes recipe functions for thirdpartpasswordless recipe : **(this is breaking change if you use the override feature)**:
+    -   Changes for third party functions explained above
+    -   Changes for passwordless recipe explained above
+    -   `clearLoginAttemptInfo` -> RENAMED TO `clearPasswordlessLoginAttemptInfo`
 -   Session recipe now uses supertokens-web-js internally (previously used supertokens-website)
 -   All recipes now include a `postAPIHook` configuration parameter that can be used to respond to network actions.
 

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -609,17 +609,17 @@ function getThirdPartyPasswordlessConfigs({ disableDefaultImplementation }) {
                         log(`DOES_PASSWORDLESS_USER_PHONE_NUMBER_EXIST`);
                         return implementation.doesPasswordlessUserPhoneNumberExist(...args);
                     },
-                    createCode(...args) {
+                    createPasswordlessCode(...args) {
                         log(`CREATE_CODE`);
-                        return implementation.createCode(...args);
+                        return implementation.createPasswordlessCode(...args);
                     },
-                    resendCode(...args) {
+                    resendPasswordlessCode(...args) {
                         log(`RESEND_CODE`);
-                        return implementation.resendCode(...args);
+                        return implementation.resendPasswordlessCode(...args);
                     },
-                    consumeCode(...args) {
+                    consumePasswordlessCode(...args) {
                         log(`CONSUME_CODE`);
-                        return implementation.consumeCode(...args);
+                        return implementation.consumePasswordlessCode(...args);
                     },
                     getPasswordlessLoginAttemptInfo(...args) {
                         log(`GET_LOGIN_ATTEMPT_INFO`);
@@ -637,17 +637,17 @@ function getThirdPartyPasswordlessConfigs({ disableDefaultImplementation }) {
                         log(`GET_OAUTH_AUTHORISATION_URL`);
                         return implementation.getAuthorisationURLFromBackend(...args);
                     },
-                    getStateAndOtherInfoFromStorage(...args) {
+                    getThirdPartyAuthorisationURLWithQueryParamsAndSetState(...args) {
                         log(`GET_OAUTH_STATE`);
-                        return implementation.getStateAndOtherInfoFromStorage(...args);
+                        return implementation.getThirdPartyAuthorisationURLWithQueryParamsAndSetState(...args);
                     },
-                    getAuthorizationURLWithQueryParamsAndSetState(...args) {
+                    getAuthorisationURLWithQueryParamsAndSetState(...args) {
                         log(`GET_AUTH_URL_WITH_QUERY_PARAMS_AND_SET_STATE`);
-                        return implementation.getAuthorizationURLWithQueryParamsAndSetState(...args);
+                        return implementation.getAuthorisationURLWithQueryParamsAndSetState(...args);
                     },
-                    setStateAndOtherInfoToStorage(...args) {
+                    setThirdPartyStateAndOtherInfoToStorage(...args) {
                         log(`SET_OAUTH_STATE`);
-                        return implementation.setStateAndOtherInfoToStorage(...args);
+                        return implementation.setThirdPartyStateAndOtherInfoToStorage(...args);
                     },
                     thirdPartySignInAndUp(...args) {
                         log(`THIRD_PARTY_SIGN_IN_AND_UP`);
@@ -840,9 +840,9 @@ function getThirdPartyConfigs({ disableDefaultImplementation }) {
 
                 return {
                     ...implementation,
-                    getAuthorizationURLWithQueryParamsAndSetState(...args) {
+                    getAuthorisationURLWithQueryParamsAndSetState(...args) {
                         log(`GET_AUTH_URL_WITH_QUERY_PARAMS_AND_SET_STATE`);
-                        return implementation.getAuthorizationURLWithQueryParamsAndSetState(...args);
+                        return implementation.getAuthorisationURLWithQueryParamsAndSetState(...args);
                     },
                     getAuthorisationURLFromBackend(...args) {
                         log(`GET_OAUTH_AUTHORISATION_URL`);
@@ -938,13 +938,13 @@ function getThirdPartyEmailPasswordConfigs({ disableDefaultImplementation }) {
 
                 return {
                     ...implementation,
-                    getAuthorizationURLWithQueryParamsAndSetState(input) {
+                    getAuthorisationURLWithQueryParamsAndSetState(input) {
                         if (input.userContext["key"] !== undefined) {
                             log(`GET_AUTH_URL_WITH_QUERY_PARAMS_AND_SET_STATE RECEIVED_USER_CONTEXT`);
                         }
 
                         log(`GET_AUTH_URL_WITH_QUERY_PARAMS_AND_SET_STATE`);
-                        return implementation.getAuthorizationURLWithQueryParamsAndSetState(input);
+                        return implementation.getAuthorisationURLWithQueryParamsAndSetState(input);
                     },
                     generateStateToSendToOAuthProvider(input) {
                         if (input.userContext["key"] !== undefined) {

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -637,13 +637,13 @@ function getThirdPartyPasswordlessConfigs({ disableDefaultImplementation }) {
                         log(`GET_OAUTH_AUTHORISATION_URL`);
                         return implementation.getAuthorisationURLFromBackend(...args);
                     },
-                    getThirdPartyAuthorisationURLWithQueryParamsAndSetState(...args) {
+                    getThirdPartyStateAndOtherInfoFromStorage(...args) {
                         log(`GET_OAUTH_STATE`);
-                        return implementation.getThirdPartyAuthorisationURLWithQueryParamsAndSetState(...args);
+                        return implementation.getThirdPartyStateAndOtherInfoFromStorage(...args);
                     },
-                    getAuthorisationURLWithQueryParamsAndSetState(...args) {
+                    getThirdPartyAuthorisationURLWithQueryParamsAndSetState(...args) {
                         log(`GET_AUTH_URL_WITH_QUERY_PARAMS_AND_SET_STATE`);
-                        return implementation.getAuthorisationURLWithQueryParamsAndSetState(...args);
+                        return implementation.getThirdPartyAuthorisationURLWithQueryParamsAndSetState(...args);
                     },
                     setThirdPartyStateAndOtherInfoToStorage(...args) {
                         log(`SET_OAUTH_STATE`);

--- a/lib/build/recipe/passwordless/index.js
+++ b/lib/build/recipe/passwordless/index.js
@@ -205,13 +205,13 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.createCode = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipe;
             return __generator(this, function (_a) {
-                recipe = recipe_1.default.getInstanceOrThrow();
                 return [
                     2 /*return*/,
                     UtilFunctions.createCode(
-                        __assign(__assign({}, input), { recipeImplementation: recipe.recipeImpl })
+                        __assign(__assign({}, input), {
+                            recipeImplementation: recipe_1.default.getInstanceOrThrow().recipeImpl,
+                        })
                     ),
                 ];
             });
@@ -219,13 +219,13 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.resendCode = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipe;
             return __generator(this, function (_a) {
-                recipe = recipe_1.default.getInstanceOrThrow();
                 return [
                     2 /*return*/,
                     UtilFunctions.resendCode(
-                        __assign(__assign({}, input), { recipeImplementation: recipe.recipeImpl })
+                        __assign(__assign({}, input), {
+                            recipeImplementation: recipe_1.default.getInstanceOrThrow().recipeImpl,
+                        })
                     ),
                 ];
             });
@@ -233,13 +233,13 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.consumeCode = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipe;
             return __generator(this, function (_a) {
-                recipe = recipe_1.default.getInstanceOrThrow();
                 return [
                     2 /*return*/,
                     UtilFunctions.consumeCode(
-                        __assign(__assign({}, input), { recipeImplementation: recipe.recipeImpl })
+                        __assign(__assign({}, input), {
+                            recipeImplementation: recipe_1.default.getInstanceOrThrow().recipeImpl,
+                        })
                     ),
                 ];
             });

--- a/lib/build/recipe/passwordless/index.js
+++ b/lib/build/recipe/passwordless/index.js
@@ -163,12 +163,22 @@ var __importDefault =
     function (mod) {
         return mod && mod.__esModule ? mod : { default: mod };
     };
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+        result["default"] = mod;
+        return result;
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 var recipe_1 = __importDefault(require("./recipe"));
 var passwordlessAuth_1 = __importDefault(require("./passwordlessAuth"));
 exports.PasswordlessAuth = passwordlessAuth_1.default;
 var signInUp_1 = __importDefault(require("./components/themes/signInUp"));
 var utils_1 = require("../../utils");
+var UtilFunctions = __importStar(require("./utils"));
 var Wrapper = /** @class */ (function () {
     function Wrapper() {}
     Wrapper.init = function (config) {
@@ -195,128 +205,43 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.createCode = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipe, normalisedUserContext, createCodeResponse;
+            var recipe;
             return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        recipe = recipe_1.default.getInstanceOrThrow();
-                        normalisedUserContext = utils_1.getNormalisedUserContext(input.userContext);
-                        return [
-                            4 /*yield*/,
-                            recipe.recipeImpl.createCode(
-                                __assign(__assign({}, input), { userContext: normalisedUserContext })
-                            ),
-                        ];
-                    case 1:
-                        createCodeResponse = _a.sent();
-                        return [
-                            4 /*yield*/,
-                            recipe.recipeImpl.setLoginAttemptInfo({
-                                attemptInfo: {
-                                    deviceId: createCodeResponse.deviceId,
-                                    preAuthSessionId: createCodeResponse.preAuthSessionId,
-                                    flowType: createCodeResponse.flowType,
-                                },
-                                userContext: normalisedUserContext,
-                            }),
-                        ];
-                    case 2:
-                        _a.sent();
-                        return [2 /*return*/, createCodeResponse];
-                }
+                recipe = recipe_1.default.getInstanceOrThrow();
+                return [
+                    2 /*return*/,
+                    UtilFunctions.createCode(
+                        __assign(__assign({}, input), { recipeImplementation: recipe.recipeImpl })
+                    ),
+                ];
             });
         });
     };
     Wrapper.resendCode = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipe, normalisedUserContext, previousAttemptInfo;
+            var recipe;
             return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        recipe = recipe_1.default.getInstanceOrThrow();
-                        normalisedUserContext = utils_1.getNormalisedUserContext(input.userContext);
-                        return [
-                            4 /*yield*/,
-                            recipe.recipeImpl.getLoginAttemptInfo({
-                                userContext: normalisedUserContext,
-                            }),
-                        ];
-                    case 1:
-                        previousAttemptInfo = _a.sent();
-                        /**
-                         * If previousAttemptInfo is undefined then local storage was probably cleared by another tab.
-                         * In this case we use empty strings when calling the API because we want to
-                         * return "RESTART_FLOW_ERROR"
-                         */
-                        return [
-                            2 /*return*/,
-                            recipe.recipeImpl.resendCode(
-                                __assign(__assign({}, input), {
-                                    userContext: normalisedUserContext,
-                                    deviceId: previousAttemptInfo === undefined ? "" : previousAttemptInfo.deviceId,
-                                    preAuthSessionId:
-                                        previousAttemptInfo === undefined ? "" : previousAttemptInfo.preAuthSessionId,
-                                })
-                            ),
-                        ];
-                }
+                recipe = recipe_1.default.getInstanceOrThrow();
+                return [
+                    2 /*return*/,
+                    UtilFunctions.resendCode(
+                        __assign(__assign({}, input), { recipeImplementation: recipe.recipeImpl })
+                    ),
+                ];
             });
         });
     };
     Wrapper.consumeCode = function (input) {
         return __awaiter(this, void 0, void 0, function () {
-            var recipe, normalisedUserContext, additionalParams, attemptInfoFromStorage, linkCode, preAuthSessionId;
+            var recipe;
             return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        recipe = recipe_1.default.getInstanceOrThrow();
-                        normalisedUserContext = utils_1.getNormalisedUserContext(input.userContext);
-                        if (!("userInputCode" in input)) return [3 /*break*/, 2];
-                        return [
-                            4 /*yield*/,
-                            recipe.recipeImpl.getLoginAttemptInfo({
-                                userContext: normalisedUserContext,
-                            }),
-                        ];
-                    case 1:
-                        attemptInfoFromStorage = _a.sent();
-                        /**
-                         * If attemptInfoFromStorage is undefined then local storage was probably cleared by another tab.
-                         * In this case we use empty strings when calling the API because we want to
-                         * return "RESTART_FLOW_ERROR"
-                         *
-                         * Note: We dont do this for the linkCode flow because that does not depend on local storage.
-                         */
-                        additionalParams = {
-                            userInputCode: input.userInputCode,
-                            deviceId: attemptInfoFromStorage === undefined ? "" : attemptInfoFromStorage.deviceId,
-                            preAuthSessionId:
-                                attemptInfoFromStorage === undefined ? "" : attemptInfoFromStorage.preAuthSessionId,
-                        };
-                        return [3 /*break*/, 3];
-                    case 2:
-                        linkCode = recipe.recipeImpl.getLinkCodeFromURL({
-                            userContext: input.userContext,
-                        });
-                        preAuthSessionId = recipe.recipeImpl.getPreAuthSessionIdFromURL({
-                            userContext: input.userContext,
-                        });
-                        additionalParams = {
-                            linkCode: linkCode,
-                            preAuthSessionId: preAuthSessionId,
-                        };
-                        _a.label = 3;
-                    case 3:
-                        return [
-                            2 /*return*/,
-                            recipe.recipeImpl.consumeCode(
-                                __assign(
-                                    { userContext: normalisedUserContext, options: input.options },
-                                    additionalParams
-                                )
-                            ),
-                        ];
-                }
+                recipe = recipe_1.default.getInstanceOrThrow();
+                return [
+                    2 /*return*/,
+                    UtilFunctions.consumeCode(
+                        __assign(__assign({}, input), { recipeImplementation: recipe.recipeImpl })
+                    ),
+                ];
             });
         });
     };

--- a/lib/build/recipe/passwordless/utils.d.ts
+++ b/lib/build/recipe/passwordless/utils.d.ts
@@ -1,6 +1,7 @@
 import { CountryCode, NumberType } from "libphonenumber-js";
 import { Config, LoginAttemptInfo, NormalisedConfig } from "./types";
-import { RecipeInterface } from "supertokens-web-js/recipe/passwordless";
+import { RecipeFunctionOptions, RecipeInterface } from "supertokens-web-js/recipe/passwordless";
+import { PasswordlessFlowType, PasswordlessUser } from "supertokens-web-js/lib/build/recipe/passwordless/types";
 export declare function normalisePasswordlessConfig(config: Config): NormalisedConfig;
 export declare function defaultGuessInternationPhoneNumberFromInputPhoneNumber(
     value: string,
@@ -15,3 +16,63 @@ export declare function setLoginAttemptInfo(input: {
     userContext: NumberType;
     attemptInfo: LoginAttemptInfo;
 }): Promise<void>;
+export declare function createCode(
+    input:
+        | {
+              email: string;
+              userContext?: any;
+              options?: RecipeFunctionOptions;
+              recipeImplementation: RecipeInterface;
+          }
+        | {
+              phoneNumber: string;
+              userContext?: any;
+              options?: RecipeFunctionOptions;
+              recipeImplementation: RecipeInterface;
+          }
+): Promise<{
+    status: "OK";
+    deviceId: string;
+    preAuthSessionId: string;
+    flowType: PasswordlessFlowType;
+    fetchResponse: Response;
+}>;
+export declare function resendCode(input: {
+    userContext?: any;
+    options?: RecipeFunctionOptions;
+    recipeImplementation: RecipeInterface;
+}): Promise<{
+    status: "OK" | "RESTART_FLOW_ERROR";
+    fetchResponse: Response;
+}>;
+export declare function consumeCode(
+    input:
+        | {
+              userInputCode: string;
+              userContext?: any;
+              options?: RecipeFunctionOptions;
+              recipeImplementation: RecipeInterface;
+          }
+        | {
+              userContext?: any;
+              options?: RecipeFunctionOptions;
+              recipeImplementation: RecipeInterface;
+          }
+): Promise<
+    | {
+          status: "OK";
+          createdUser: boolean;
+          user: PasswordlessUser;
+          fetchResponse: Response;
+      }
+    | {
+          status: "INCORRECT_USER_INPUT_CODE_ERROR" | "EXPIRED_USER_INPUT_CODE_ERROR";
+          failedCodeInputAttemptCount: number;
+          maximumCodeInputAttempts: number;
+          fetchResponse: Response;
+      }
+    | {
+          status: "RESTART_FLOW_ERROR";
+          fetchResponse: Response;
+      }
+>;

--- a/lib/build/recipe/passwordless/utils.d.ts
+++ b/lib/build/recipe/passwordless/utils.d.ts
@@ -16,6 +16,10 @@ export declare function setLoginAttemptInfo(input: {
     userContext: NumberType;
     attemptInfo: LoginAttemptInfo;
 }): Promise<void>;
+/**
+ * These functions are helper functions so that the logic can be exposed from both
+ * passwordless and thirdpartypasswordless recipes without having to duplicate code
+ */
 export declare function createCode(
     input:
         | {

--- a/lib/build/recipe/passwordless/utils.js
+++ b/lib/build/recipe/passwordless/utils.js
@@ -167,11 +167,16 @@ var __importStar =
         result["default"] = mod;
         return result;
     };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 var min_1 = __importStar(require("libphonenumber-js/min"));
 var utils_1 = require("../authRecipe/utils");
 var validators_1 = require("./validators");
-var utils_2 = require("../../utils");
+var utils_2 = __importDefault(require("supertokens-web-js/lib/build/recipe/passwordless/utils"));
 function normalisePasswordlessConfig(config) {
     if (!["EMAIL", "PHONE", "EMAIL_OR_PHONE"].includes(config.contactMethod)) {
         throw new Error("Please pass one of 'PHONE', 'EMAIL' or 'EMAIL_OR_PHONE' as the contactMethod");
@@ -336,124 +341,24 @@ exports.setLoginAttemptInfo = setLoginAttemptInfo;
  */
 function createCode(input) {
     return __awaiter(this, void 0, void 0, function () {
-        var normalisedUserContext, createCodeResponse;
         return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0:
-                    normalisedUserContext = utils_2.getNormalisedUserContext(input.userContext);
-                    return [
-                        4 /*yield*/,
-                        input.recipeImplementation.createCode(
-                            __assign(__assign({}, input), { userContext: normalisedUserContext })
-                        ),
-                    ];
-                case 1:
-                    createCodeResponse = _a.sent();
-                    return [
-                        4 /*yield*/,
-                        input.recipeImplementation.setLoginAttemptInfo({
-                            attemptInfo: {
-                                deviceId: createCodeResponse.deviceId,
-                                preAuthSessionId: createCodeResponse.preAuthSessionId,
-                                flowType: createCodeResponse.flowType,
-                            },
-                            userContext: normalisedUserContext,
-                        }),
-                    ];
-                case 2:
-                    _a.sent();
-                    return [2 /*return*/, createCodeResponse];
-            }
+            return [2 /*return*/, utils_2.default.createCode(input)];
         });
     });
 }
 exports.createCode = createCode;
 function resendCode(input) {
     return __awaiter(this, void 0, void 0, function () {
-        var normalisedUserContext, previousAttemptInfo;
         return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0:
-                    normalisedUserContext = utils_2.getNormalisedUserContext(input.userContext);
-                    return [
-                        4 /*yield*/,
-                        input.recipeImplementation.getLoginAttemptInfo({
-                            userContext: normalisedUserContext,
-                        }),
-                    ];
-                case 1:
-                    previousAttemptInfo = _a.sent();
-                    /**
-                     * If previousAttemptInfo is undefined then local storage was probably cleared by another tab.
-                     * In this case we use empty strings when calling the API because we want to
-                     * return "RESTART_FLOW_ERROR"
-                     */
-                    return [
-                        2 /*return*/,
-                        input.recipeImplementation.resendCode(
-                            __assign(__assign({}, input), {
-                                userContext: normalisedUserContext,
-                                deviceId: previousAttemptInfo === undefined ? "" : previousAttemptInfo.deviceId,
-                                preAuthSessionId:
-                                    previousAttemptInfo === undefined ? "" : previousAttemptInfo.preAuthSessionId,
-                            })
-                        ),
-                    ];
-            }
+            return [2 /*return*/, utils_2.default.resendCode(input)];
         });
     });
 }
 exports.resendCode = resendCode;
 function consumeCode(input) {
     return __awaiter(this, void 0, void 0, function () {
-        var normalisedUserContext, additionalParams, attemptInfoFromStorage, linkCode, preAuthSessionId;
         return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0:
-                    normalisedUserContext = utils_2.getNormalisedUserContext(input.userContext);
-                    if (!("userInputCode" in input)) return [3 /*break*/, 2];
-                    return [
-                        4 /*yield*/,
-                        input.recipeImplementation.getLoginAttemptInfo({
-                            userContext: normalisedUserContext,
-                        }),
-                    ];
-                case 1:
-                    attemptInfoFromStorage = _a.sent();
-                    /**
-                     * If attemptInfoFromStorage is undefined then local storage was probably cleared by another tab.
-                     * In this case we use empty strings when calling the API because we want to
-                     * return "RESTART_FLOW_ERROR"
-                     *
-                     * Note: We dont do this for the linkCode flow because that does not depend on local storage.
-                     */
-                    additionalParams = {
-                        userInputCode: input.userInputCode,
-                        deviceId: attemptInfoFromStorage === undefined ? "" : attemptInfoFromStorage.deviceId,
-                        preAuthSessionId:
-                            attemptInfoFromStorage === undefined ? "" : attemptInfoFromStorage.preAuthSessionId,
-                    };
-                    return [3 /*break*/, 3];
-                case 2:
-                    linkCode = input.recipeImplementation.getLinkCodeFromURL({
-                        userContext: input.userContext,
-                    });
-                    preAuthSessionId = input.recipeImplementation.getPreAuthSessionIdFromURL({
-                        userContext: input.userContext,
-                    });
-                    additionalParams = {
-                        linkCode: linkCode,
-                        preAuthSessionId: preAuthSessionId,
-                    };
-                    _a.label = 3;
-                case 3:
-                    return [
-                        2 /*return*/,
-                        input.recipeImplementation.consumeCode(
-                            __assign({ userContext: normalisedUserContext, options: input.options }, additionalParams)
-                        ),
-                    ];
-            }
+            return [2 /*return*/, utils_2.default.consumeCode(input)];
         });
     });
 }

--- a/lib/build/recipe/passwordless/utils.js
+++ b/lib/build/recipe/passwordless/utils.js
@@ -171,6 +171,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var min_1 = __importStar(require("libphonenumber-js/min"));
 var utils_1 = require("../authRecipe/utils");
 var validators_1 = require("./validators");
+var utils_2 = require("../../utils");
 function normalisePasswordlessConfig(config) {
     if (!["EMAIL", "PHONE", "EMAIL_OR_PHONE"].includes(config.contactMethod)) {
         throw new Error("Please pass one of 'PHONE', 'EMAIL' or 'EMAIL_OR_PHONE' as the contactMethod");
@@ -329,3 +330,127 @@ function setLoginAttemptInfo(input) {
     });
 }
 exports.setLoginAttemptInfo = setLoginAttemptInfo;
+function createCode(input) {
+    return __awaiter(this, void 0, void 0, function () {
+        var normalisedUserContext, createCodeResponse;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    normalisedUserContext = utils_2.getNormalisedUserContext(input.userContext);
+                    return [
+                        4 /*yield*/,
+                        input.recipeImplementation.createCode(
+                            __assign(__assign({}, input), { userContext: normalisedUserContext })
+                        ),
+                    ];
+                case 1:
+                    createCodeResponse = _a.sent();
+                    return [
+                        4 /*yield*/,
+                        input.recipeImplementation.setLoginAttemptInfo({
+                            attemptInfo: {
+                                deviceId: createCodeResponse.deviceId,
+                                preAuthSessionId: createCodeResponse.preAuthSessionId,
+                                flowType: createCodeResponse.flowType,
+                            },
+                            userContext: normalisedUserContext,
+                        }),
+                    ];
+                case 2:
+                    _a.sent();
+                    return [2 /*return*/, createCodeResponse];
+            }
+        });
+    });
+}
+exports.createCode = createCode;
+function resendCode(input) {
+    return __awaiter(this, void 0, void 0, function () {
+        var normalisedUserContext, previousAttemptInfo;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    normalisedUserContext = utils_2.getNormalisedUserContext(input.userContext);
+                    return [
+                        4 /*yield*/,
+                        input.recipeImplementation.getLoginAttemptInfo({
+                            userContext: normalisedUserContext,
+                        }),
+                    ];
+                case 1:
+                    previousAttemptInfo = _a.sent();
+                    /**
+                     * If previousAttemptInfo is undefined then local storage was probably cleared by another tab.
+                     * In this case we use empty strings when calling the API because we want to
+                     * return "RESTART_FLOW_ERROR"
+                     */
+                    return [
+                        2 /*return*/,
+                        input.recipeImplementation.resendCode(
+                            __assign(__assign({}, input), {
+                                userContext: normalisedUserContext,
+                                deviceId: previousAttemptInfo === undefined ? "" : previousAttemptInfo.deviceId,
+                                preAuthSessionId:
+                                    previousAttemptInfo === undefined ? "" : previousAttemptInfo.preAuthSessionId,
+                            })
+                        ),
+                    ];
+            }
+        });
+    });
+}
+exports.resendCode = resendCode;
+function consumeCode(input) {
+    return __awaiter(this, void 0, void 0, function () {
+        var normalisedUserContext, additionalParams, attemptInfoFromStorage, linkCode, preAuthSessionId;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    normalisedUserContext = utils_2.getNormalisedUserContext(input.userContext);
+                    if (!("userInputCode" in input)) return [3 /*break*/, 2];
+                    return [
+                        4 /*yield*/,
+                        input.recipeImplementation.getLoginAttemptInfo({
+                            userContext: normalisedUserContext,
+                        }),
+                    ];
+                case 1:
+                    attemptInfoFromStorage = _a.sent();
+                    /**
+                     * If attemptInfoFromStorage is undefined then local storage was probably cleared by another tab.
+                     * In this case we use empty strings when calling the API because we want to
+                     * return "RESTART_FLOW_ERROR"
+                     *
+                     * Note: We dont do this for the linkCode flow because that does not depend on local storage.
+                     */
+                    additionalParams = {
+                        userInputCode: input.userInputCode,
+                        deviceId: attemptInfoFromStorage === undefined ? "" : attemptInfoFromStorage.deviceId,
+                        preAuthSessionId:
+                            attemptInfoFromStorage === undefined ? "" : attemptInfoFromStorage.preAuthSessionId,
+                    };
+                    return [3 /*break*/, 3];
+                case 2:
+                    linkCode = input.recipeImplementation.getLinkCodeFromURL({
+                        userContext: input.userContext,
+                    });
+                    preAuthSessionId = input.recipeImplementation.getPreAuthSessionIdFromURL({
+                        userContext: input.userContext,
+                    });
+                    additionalParams = {
+                        linkCode: linkCode,
+                        preAuthSessionId: preAuthSessionId,
+                    };
+                    _a.label = 3;
+                case 3:
+                    return [
+                        2 /*return*/,
+                        input.recipeImplementation.consumeCode(
+                            __assign({ userContext: normalisedUserContext, options: input.options }, additionalParams)
+                        ),
+                    ];
+            }
+        });
+    });
+}
+exports.consumeCode = consumeCode;

--- a/lib/build/recipe/passwordless/utils.js
+++ b/lib/build/recipe/passwordless/utils.js
@@ -330,6 +330,10 @@ function setLoginAttemptInfo(input) {
     });
 }
 exports.setLoginAttemptInfo = setLoginAttemptInfo;
+/**
+ * These functions are helper functions so that the logic can be exposed from both
+ * passwordless and thirdpartypasswordless recipes without having to duplicate code
+ */
 function createCode(input) {
     return __awaiter(this, void 0, void 0, function () {
         var normalisedUserContext, createCodeResponse;

--- a/lib/build/recipe/thirdparty/recipeImplementation.js
+++ b/lib/build/recipe/thirdparty/recipeImplementation.js
@@ -223,12 +223,12 @@ function getRecipeImplementation(recipeInput) {
                 userContext: input.userContext,
             });
         },
-        getAuthorizationURLWithQueryParamsAndSetState: function (input) {
+        getAuthorisationURLWithQueryParamsAndSetState: function (input) {
             return __awaiter(this, void 0, void 0, function () {
                 return __generator(this, function (_a) {
                     return [
                         2 /*return*/,
-                        webJsImplementation.getAuthorizationURLWithQueryParamsAndSetState.bind(this)(
+                        webJsImplementation.getAuthorisationURLWithQueryParamsAndSetState.bind(this)(
                             __assign({}, input)
                         ),
                     ];

--- a/lib/build/recipe/thirdparty/utils.js
+++ b/lib/build/recipe/thirdparty/utils.js
@@ -269,7 +269,7 @@ function redirectToThirdPartyLogin(input) {
                     }
                     return [
                         4 /*yield*/,
-                        input.recipeImplementation.getAuthorizationURLWithQueryParamsAndSetState({
+                        input.recipeImplementation.getAuthorisationURLWithQueryParamsAndSetState({
                             providerId: input.thirdPartyId,
                             authorisationURL: provider.getRedirectURL(),
                             providerClientId: provider.clientId,

--- a/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.js
@@ -232,12 +232,12 @@ function getRecipeImplementation(recipeInput) {
                 });
             });
         },
-        getAuthorizationURLWithQueryParamsAndSetState: function (input) {
+        getAuthorisationURLWithQueryParamsAndSetState: function (input) {
             return __awaiter(this, void 0, void 0, function () {
                 return __generator(this, function (_a) {
                     return [
                         2 /*return*/,
-                        thirdPartyImpl.getAuthorizationURLWithQueryParamsAndSetState.bind(
+                        thirdPartyImpl.getAuthorisationURLWithQueryParamsAndSetState.bind(
                             thirdPartyImplementation_1.default(this)
                         )(input),
                     ];

--- a/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/thirdPartyImplementation.js
+++ b/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/thirdPartyImplementation.js
@@ -23,8 +23,8 @@ function getRecipeImplementation(originalImplementation) {
         getAuthStateFromURL: originalImplementation.getAuthStateFromURL.bind(originalImplementation),
         getAuthorisationURLFromBackend:
             originalImplementation.getAuthorisationURLFromBackend.bind(originalImplementation),
-        getAuthorizationURLWithQueryParamsAndSetState:
-            originalImplementation.getAuthorizationURLWithQueryParamsAndSetState.bind(originalImplementation),
+        getAuthorisationURLWithQueryParamsAndSetState:
+            originalImplementation.getAuthorisationURLWithQueryParamsAndSetState.bind(originalImplementation),
         getStateAndOtherInfoFromStorage:
             originalImplementation.getStateAndOtherInfoFromStorage.bind(originalImplementation),
         setStateAndOtherInfoToStorage:

--- a/lib/build/recipe/thirdpartypasswordless/index.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/index.d.ts
@@ -5,7 +5,13 @@ import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventCo
 import ThirdPartyPasswordlessAuth from "./thirdpartyPasswordlessAuth";
 import SignInUpTheme from "./components/themes/signInUp";
 import { Apple, Google, Facebook, Github } from "../thirdparty/";
-import { RecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
+import {
+    PasswordlessFlowType,
+    PasswordlessUser,
+    RecipeFunctionOptions,
+    RecipeInterface,
+} from "supertokens-web-js/recipe/thirdpartypasswordless";
+import { UserType } from "supertokens-web-js/recipe/thirdparty";
 export default class Wrapper {
     static init(
         config: UserInput
@@ -19,6 +25,99 @@ export default class Wrapper {
     static isEmailVerified(input?: { userContext?: any }): Promise<{
         status: "OK";
         isVerified: boolean;
+        fetchResponse: Response;
+    }>;
+    static verifyEmail(input?: { userContext?: any }): Promise<{
+        status: "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR" | "OK";
+        fetchResponse: Response;
+    }>;
+    static sendVerificationEmail(input?: { userContext?: any }): Promise<{
+        status: "EMAIL_ALREADY_VERIFIED_ERROR" | "OK";
+        fetchResponse: Response;
+    }>;
+    static redirectToThirdPartyLogin(input: { thirdPartyId: string; userContext?: any }): Promise<{
+        status: "OK" | "ERROR";
+    }>;
+    static thirdPartySignInAndUp(input?: { userContext?: any }): Promise<
+        | {
+              status: "OK";
+              user: UserType;
+              createdNewUser: boolean;
+              fetchResponse: Response;
+          }
+        | {
+              status: "NO_EMAIL_GIVEN_BY_PROVIDER";
+              fetchResponse: Response;
+          }
+    >;
+    static createCode(
+        input:
+            | {
+                  email: string;
+                  userContext?: any;
+                  options?: RecipeFunctionOptions;
+              }
+            | {
+                  phoneNumber: string;
+                  userContext?: any;
+                  options?: RecipeFunctionOptions;
+              }
+    ): Promise<{
+        status: "OK";
+        deviceId: string;
+        preAuthSessionId: string;
+        flowType: PasswordlessFlowType;
+        fetchResponse: Response;
+    }>;
+    static resendCode(input: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+        status: "OK" | "RESTART_FLOW_ERROR";
+        fetchResponse: Response;
+    }>;
+    static consumeCode(
+        input:
+            | {
+                  userInputCode: string;
+                  userContext?: any;
+                  options?: RecipeFunctionOptions;
+              }
+            | {
+                  userContext?: any;
+                  options?: RecipeFunctionOptions;
+              }
+    ): Promise<
+        | {
+              status: "OK";
+              createdUser: boolean;
+              user: PasswordlessUser;
+              fetchResponse: Response;
+          }
+        | {
+              status: "INCORRECT_USER_INPUT_CODE_ERROR" | "EXPIRED_USER_INPUT_CODE_ERROR";
+              failedCodeInputAttemptCount: number;
+              maximumCodeInputAttempts: number;
+              fetchResponse: Response;
+          }
+        | {
+              status: "RESTART_FLOW_ERROR";
+              fetchResponse: Response;
+          }
+    >;
+    static doesPasswordlessUserEmailExist(input: {
+        email: string;
+        userContext?: any;
+        options?: RecipeFunctionOptions;
+    }): Promise<{
+        status: "OK";
+        doesExist: boolean;
+        fetchResponse: Response;
+    }>;
+    static doesPasswordlessUserPhoneNumberExist(input: {
+        phoneNumber: string;
+        userContext?: any;
+        options?: RecipeFunctionOptions;
+    }): Promise<{
+        status: "OK";
+        doesExist: boolean;
         fetchResponse: Response;
     }>;
     static redirectToAuth(
@@ -47,6 +146,15 @@ export default class Wrapper {
 declare const init: typeof Wrapper.init;
 declare const signOut: typeof Wrapper.signOut;
 declare const isEmailVerified: typeof Wrapper.isEmailVerified;
+declare const sendVerificationEmail: typeof Wrapper.sendVerificationEmail;
+declare const verifyEmail: typeof Wrapper.verifyEmail;
+declare const redirectToThirdPartyLogin: typeof Wrapper.redirectToThirdPartyLogin;
+declare const thirdPartySignInAndUp: typeof Wrapper.thirdPartySignInAndUp;
+declare const createCode: typeof Wrapper.createCode;
+declare const resendCode: typeof Wrapper.resendCode;
+declare const consumeCode: typeof Wrapper.consumeCode;
+declare const doesPasswordlessUserEmailExist: typeof Wrapper.doesPasswordlessUserEmailExist;
+declare const doesPasswordlessUserPhoneNumberExist: typeof Wrapper.doesPasswordlessUserPhoneNumberExist;
 declare const redirectToAuth: typeof Wrapper.redirectToAuth;
 declare const SignInAndUp: (prop?: any) => JSX.Element;
 declare const ThirdPartySignInAndUpCallback: (prop?: any) => JSX.Element;
@@ -60,6 +168,15 @@ export {
     Facebook,
     Github,
     isEmailVerified,
+    sendVerificationEmail,
+    verifyEmail,
+    redirectToThirdPartyLogin,
+    thirdPartySignInAndUp,
+    createCode,
+    resendCode,
+    consumeCode,
+    doesPasswordlessUserEmailExist,
+    doesPasswordlessUserPhoneNumberExist,
     SignInAndUp,
     SignInUpTheme,
     ThirdPartySignInAndUpCallback,

--- a/lib/build/recipe/thirdpartypasswordless/index.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/index.d.ts
@@ -50,7 +50,7 @@ export default class Wrapper {
               fetchResponse: Response;
           }
     >;
-    static createCode(
+    static createPasswordlessCode(
         input:
             | {
                   email: string;
@@ -69,11 +69,11 @@ export default class Wrapper {
         flowType: PasswordlessFlowType;
         fetchResponse: Response;
     }>;
-    static resendCode(input: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static resendPasswordlessCode(input: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
         status: "OK" | "RESTART_FLOW_ERROR";
         fetchResponse: Response;
     }>;
-    static consumeCode(
+    static consumePasswordlessCode(
         input:
             | {
                   userInputCode: string;
@@ -150,9 +150,9 @@ declare const sendVerificationEmail: typeof Wrapper.sendVerificationEmail;
 declare const verifyEmail: typeof Wrapper.verifyEmail;
 declare const redirectToThirdPartyLogin: typeof Wrapper.redirectToThirdPartyLogin;
 declare const thirdPartySignInAndUp: typeof Wrapper.thirdPartySignInAndUp;
-declare const createCode: typeof Wrapper.createCode;
-declare const resendCode: typeof Wrapper.resendCode;
-declare const consumeCode: typeof Wrapper.consumeCode;
+declare const createPasswordlessCode: typeof Wrapper.createPasswordlessCode;
+declare const resendPasswordlessCode: typeof Wrapper.resendPasswordlessCode;
+declare const consumePasswordlessCode: typeof Wrapper.consumePasswordlessCode;
 declare const doesPasswordlessUserEmailExist: typeof Wrapper.doesPasswordlessUserEmailExist;
 declare const doesPasswordlessUserPhoneNumberExist: typeof Wrapper.doesPasswordlessUserPhoneNumberExist;
 declare const redirectToAuth: typeof Wrapper.redirectToAuth;
@@ -172,9 +172,9 @@ export {
     verifyEmail,
     redirectToThirdPartyLogin,
     thirdPartySignInAndUp,
-    createCode,
-    resendCode,
-    consumeCode,
+    createPasswordlessCode,
+    resendPasswordlessCode,
+    consumePasswordlessCode,
     doesPasswordlessUserEmailExist,
     doesPasswordlessUserPhoneNumberExist,
     SignInAndUp,

--- a/lib/build/recipe/thirdpartypasswordless/index.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/index.d.ts
@@ -1,16 +1,11 @@
 /// <reference types="react" />
 /// <reference types="@emotion/react/types/css-prop" />
 import EmailVerificationTheme from "../emailverification/components/themes/emailVerification";
-import {
-    UserInput,
-    GetRedirectionURLContext,
-    PreAPIHookContext,
-    OnHandleEventContext,
-    TPPWlessRecipeInterface as RecipeInterface,
-} from "./types";
+import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 import ThirdPartyPasswordlessAuth from "./thirdpartyPasswordlessAuth";
 import SignInUpTheme from "./components/themes/signInUp";
 import { Apple, Google, Facebook, Github } from "../thirdparty/";
+import { RecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 export default class Wrapper {
     static init(
         config: UserInput

--- a/lib/build/recipe/thirdpartypasswordless/index.js
+++ b/lib/build/recipe/thirdpartypasswordless/index.js
@@ -275,7 +275,7 @@ var Wrapper = /** @class */ (function () {
             })
         );
     };
-    Wrapper.createCode = function (input) {
+    Wrapper.createPasswordlessCode = function (input) {
         return __awaiter(this, void 0, void 0, function () {
             var recipe;
             return __generator(this, function (_a) {
@@ -294,7 +294,7 @@ var Wrapper = /** @class */ (function () {
             });
         });
     };
-    Wrapper.resendCode = function (input) {
+    Wrapper.resendPasswordlessCode = function (input) {
         return __awaiter(this, void 0, void 0, function () {
             var recipe;
             return __generator(this, function (_a) {
@@ -313,7 +313,7 @@ var Wrapper = /** @class */ (function () {
             });
         });
     };
-    Wrapper.consumeCode = function (input) {
+    Wrapper.consumePasswordlessCode = function (input) {
         return __awaiter(this, void 0, void 0, function () {
             var recipe;
             return __generator(this, function (_a) {
@@ -395,12 +395,12 @@ var redirectToThirdPartyLogin = Wrapper.redirectToThirdPartyLogin;
 exports.redirectToThirdPartyLogin = redirectToThirdPartyLogin;
 var thirdPartySignInAndUp = Wrapper.thirdPartySignInAndUp;
 exports.thirdPartySignInAndUp = thirdPartySignInAndUp;
-var createCode = Wrapper.createCode;
-exports.createCode = createCode;
-var resendCode = Wrapper.resendCode;
-exports.resendCode = resendCode;
-var consumeCode = Wrapper.consumeCode;
-exports.consumeCode = consumeCode;
+var createPasswordlessCode = Wrapper.createPasswordlessCode;
+exports.createPasswordlessCode = createPasswordlessCode;
+var resendPasswordlessCode = Wrapper.resendPasswordlessCode;
+exports.resendPasswordlessCode = resendPasswordlessCode;
+var consumePasswordlessCode = Wrapper.consumePasswordlessCode;
+exports.consumePasswordlessCode = consumePasswordlessCode;
 var doesPasswordlessUserEmailExist = Wrapper.doesPasswordlessUserEmailExist;
 exports.doesPasswordlessUserEmailExist = doesPasswordlessUserEmailExist;
 var doesPasswordlessUserPhoneNumberExist = Wrapper.doesPasswordlessUserPhoneNumberExist;

--- a/lib/build/recipe/thirdpartypasswordless/index.js
+++ b/lib/build/recipe/thirdpartypasswordless/index.js
@@ -1,4 +1,18 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 var __awaiter =
     (this && this.__awaiter) ||
     function (thisArg, _arguments, P, generator) {
@@ -135,6 +149,15 @@ var __importDefault =
     function (mod) {
         return mod && mod.__esModule ? mod : { default: mod };
     };
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+        result["default"] = mod;
+        return result;
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -164,6 +187,8 @@ exports.Facebook = thirdparty_1.Facebook;
 exports.Github = thirdparty_1.Github;
 var linkClickedScreen_1 = require("../passwordless/components/themes/linkClickedScreen");
 var utils_1 = require("../../utils");
+var utils_2 = require("../thirdparty/utils");
+var PasswordlessUtilFunctions = __importStar(require("../passwordless/utils"));
 var Wrapper = /** @class */ (function () {
     function Wrapper() {}
     Wrapper.init = function (config) {
@@ -191,6 +216,135 @@ var Wrapper = /** @class */ (function () {
                 ];
             });
         });
+    };
+    Wrapper.verifyEmail = function (input) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [
+                    2 /*return*/,
+                    recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.verifyEmail({
+                        userContext: utils_1.getNormalisedUserContext(
+                            input === null || input === void 0 ? void 0 : input.userContext
+                        ),
+                    }),
+                ];
+            });
+        });
+    };
+    Wrapper.sendVerificationEmail = function (input) {
+        return recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.sendVerificationEmail({
+            userContext: utils_1.getNormalisedUserContext(
+                input === null || input === void 0 ? void 0 : input.userContext
+            ),
+        });
+    };
+    Wrapper.redirectToThirdPartyLogin = function (input) {
+        return __awaiter(this, void 0, void 0, function () {
+            var recipeInstance;
+            return __generator(this, function (_a) {
+                recipeInstance = recipe_1.default.getInstanceOrThrow();
+                if (recipeInstance.thirdPartyRecipe === undefined) {
+                    throw new Error(
+                        "Third party passwordless was initialised without any social providers. This function is only available if at least one social provider is initialised"
+                    );
+                }
+                return [
+                    2 /*return*/,
+                    utils_2.redirectToThirdPartyLogin({
+                        thirdPartyId: input.thirdPartyId,
+                        config: recipeInstance.thirdPartyRecipe.config,
+                        userContext: utils_1.getNormalisedUserContext(input.userContext),
+                        recipeImplementation: recipeInstance.thirdPartyRecipe.recipeImpl,
+                    }),
+                ];
+            });
+        });
+    };
+    Wrapper.thirdPartySignInAndUp = function (input) {
+        /**
+         * We do it this way here because prettier behaves in a weird way without it.
+         * If you return directly, build-pretty will succeed but pretty-check will fail
+         * when you try to commit and you will have to run pretty manually every time
+         */
+        var recipeInstance = recipe_1.default.getInstanceOrThrow();
+        return recipeInstance.recipeImpl.thirdPartySignInAndUp(
+            __assign(__assign({}, input), {
+                userContext: utils_1.getNormalisedUserContext(
+                    input === null || input === void 0 ? void 0 : input.userContext
+                ),
+            })
+        );
+    };
+    Wrapper.createCode = function (input) {
+        return __awaiter(this, void 0, void 0, function () {
+            var recipe;
+            return __generator(this, function (_a) {
+                recipe = recipe_1.default.getInstanceOrThrow();
+                if (recipe.passwordlessRecipe === undefined) {
+                    throw new Error(
+                        "createCode requires the passwordless recipe to be enabled. Please check the value of disablePasswordless in the configuration."
+                    );
+                }
+                return [
+                    2 /*return*/,
+                    PasswordlessUtilFunctions.createCode(
+                        __assign(__assign({}, input), { recipeImplementation: recipe.passwordlessRecipe.recipeImpl })
+                    ),
+                ];
+            });
+        });
+    };
+    Wrapper.resendCode = function (input) {
+        return __awaiter(this, void 0, void 0, function () {
+            var recipe;
+            return __generator(this, function (_a) {
+                recipe = recipe_1.default.getInstanceOrThrow();
+                if (recipe.passwordlessRecipe === undefined) {
+                    throw new Error(
+                        "createCode requires the passwordless recipe to be enabled. Please check the value of disablePasswordless in the configuration."
+                    );
+                }
+                return [
+                    2 /*return*/,
+                    PasswordlessUtilFunctions.resendCode(
+                        __assign(__assign({}, input), { recipeImplementation: recipe.passwordlessRecipe.recipeImpl })
+                    ),
+                ];
+            });
+        });
+    };
+    Wrapper.consumeCode = function (input) {
+        return __awaiter(this, void 0, void 0, function () {
+            var recipe;
+            return __generator(this, function (_a) {
+                recipe = recipe_1.default.getInstanceOrThrow();
+                if (recipe.passwordlessRecipe === undefined) {
+                    throw new Error(
+                        "createCode requires the passwordless recipe to be enabled. Please check the value of disablePasswordless in the configuration."
+                    );
+                }
+                return [
+                    2 /*return*/,
+                    PasswordlessUtilFunctions.consumeCode(
+                        __assign(__assign({}, input), { recipeImplementation: recipe.passwordlessRecipe.recipeImpl })
+                    ),
+                ];
+            });
+        });
+    };
+    Wrapper.doesPasswordlessUserEmailExist = function (input) {
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImpl.doesPasswordlessUserEmailExist(
+                __assign(__assign({}, input), { userContext: utils_1.getNormalisedUserContext(input.userContext) })
+            );
+    };
+    Wrapper.doesPasswordlessUserPhoneNumberExist = function (input) {
+        return recipe_1.default
+            .getInstanceOrThrow()
+            .recipeImpl.doesPasswordlessUserPhoneNumberExist(
+                __assign(__assign({}, input), { userContext: utils_1.getNormalisedUserContext(input.userContext) })
+            );
     };
     // have backwards compatibility to allow input as "signin" | "signup"
     Wrapper.redirectToAuth = function (input) {
@@ -233,6 +387,24 @@ var signOut = Wrapper.signOut;
 exports.signOut = signOut;
 var isEmailVerified = Wrapper.isEmailVerified;
 exports.isEmailVerified = isEmailVerified;
+var sendVerificationEmail = Wrapper.sendVerificationEmail;
+exports.sendVerificationEmail = sendVerificationEmail;
+var verifyEmail = Wrapper.verifyEmail;
+exports.verifyEmail = verifyEmail;
+var redirectToThirdPartyLogin = Wrapper.redirectToThirdPartyLogin;
+exports.redirectToThirdPartyLogin = redirectToThirdPartyLogin;
+var thirdPartySignInAndUp = Wrapper.thirdPartySignInAndUp;
+exports.thirdPartySignInAndUp = thirdPartySignInAndUp;
+var createCode = Wrapper.createCode;
+exports.createCode = createCode;
+var resendCode = Wrapper.resendCode;
+exports.resendCode = resendCode;
+var consumeCode = Wrapper.consumeCode;
+exports.consumeCode = consumeCode;
+var doesPasswordlessUserEmailExist = Wrapper.doesPasswordlessUserEmailExist;
+exports.doesPasswordlessUserEmailExist = doesPasswordlessUserEmailExist;
+var doesPasswordlessUserPhoneNumberExist = Wrapper.doesPasswordlessUserPhoneNumberExist;
+exports.doesPasswordlessUserPhoneNumberExist = doesPasswordlessUserPhoneNumberExist;
 var redirectToAuth = Wrapper.redirectToAuth;
 exports.redirectToAuth = redirectToAuth;
 var SignInAndUp = Wrapper.SignInAndUp;

--- a/lib/build/recipe/thirdpartypasswordless/recipe.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/recipe.d.ts
@@ -7,12 +7,12 @@ import {
     NormalisedConfig,
     OnHandleEventContext,
     UserInput,
-    TPPWlessRecipeInterface,
     PreAndPostAPIHookAction,
 } from "./types";
 import Passwordless from "../passwordless/recipe";
 import ThirdParty from "../thirdparty/recipe";
 import EmailVerification from "../emailverification/recipe";
+import { RecipeInterface as TPPWlessRecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 export default class ThirdPartyPasswordless extends AuthRecipeWithEmailVerification<
     GetRedirectionURLContext,
     OnHandleEventContext,

--- a/lib/build/recipe/thirdpartypasswordless/recipeImplementation/index.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/recipeImplementation/index.d.ts
@@ -1,10 +1,11 @@
-import { TPPWlessRecipeInterface, PreAndPostAPIHookAction, OnHandleEventContext } from "../types";
+import { PreAndPostAPIHookAction, OnHandleEventContext } from "../types";
 import { NormalisedAppInfo } from "../../../types";
 import {
     RecipeOnHandleEventFunction,
     RecipePostAPIHookFunction,
     RecipePreAPIHookFunction,
 } from "../../recipeModule/types";
+import { RecipeInterface as TPPWlessRecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 export default function getRecipeImplementation(recipeInput: {
     recipeId: string;
     appInfo: NormalisedAppInfo;

--- a/lib/build/recipe/thirdpartypasswordless/recipeImplementation/index.js
+++ b/lib/build/recipe/thirdpartypasswordless/recipeImplementation/index.js
@@ -158,10 +158,10 @@ function getRecipeImplementation(recipeInput) {
     var passwordlessImpl = recipeImplementation_1.default(__assign({}, recipeInput));
     var thirdPartyImpl = recipeImplementation_2.default(__assign({}, recipeInput));
     return {
-        consumeCode: function (input) {
+        consumePasswordlessCode: function (input) {
             return passwordlessImpl.consumeCode.bind(passwordlessImplementation_1.default(this))(input);
         },
-        createCode: function (input) {
+        createPasswordlessCode: function (input) {
             return passwordlessImpl.createCode.bind(passwordlessImplementation_1.default(this))(input);
         },
         doesPasswordlessUserPhoneNumberExist: function (input) {
@@ -177,7 +177,7 @@ function getRecipeImplementation(recipeInput) {
                 });
             });
         },
-        resendCode: function (input) {
+        resendPasswordlessCode: function (input) {
             return passwordlessImpl.resendCode.bind(passwordlessImplementation_1.default(this))(input);
         },
         clearPasswordlessLoginAttemptInfo: function (input) {
@@ -217,32 +217,32 @@ function getRecipeImplementation(recipeInput) {
                 });
             });
         },
-        getStateAndOtherInfoFromStorage: function (input) {
+        getThirdPartyStateAndOtherInfoFromStorage: function (input) {
             return thirdPartyImpl.getStateAndOtherInfoFromStorage.bind(thirdPartyImplementation_1.default(this))(input);
         },
-        setStateAndOtherInfoToStorage: function (input) {
+        setThirdPartyStateAndOtherInfoToStorage: function (input) {
             return thirdPartyImpl.setStateAndOtherInfoToStorage.bind(thirdPartyImplementation_1.default(this))(input);
         },
-        getAuthorizationURLWithQueryParamsAndSetState: function (input) {
-            return thirdPartyImpl.getAuthorizationURLWithQueryParamsAndSetState.bind(
+        getThirdPartyAuthorisationURLWithQueryParamsAndSetState: function (input) {
+            return thirdPartyImpl.getAuthorisationURLWithQueryParamsAndSetState.bind(
                 thirdPartyImplementation_1.default(this)
             )(input);
         },
-        generateStateToSendToOAuthProvider: function (input) {
+        generateThirdPartyStateToSendToOAuthProvider: function (input) {
             return thirdPartyImpl.generateStateToSendToOAuthProvider.bind(thirdPartyImplementation_1.default(this))(
                 input
             );
         },
-        verifyAndGetStateOrThrowError: function (input) {
+        verifyAndGetThirdPartyStateOrThrowError: function (input) {
             return thirdPartyImpl.verifyAndGetStateOrThrowError.bind(thirdPartyImplementation_1.default(this))(input);
         },
-        getAuthCodeFromURL: function (input) {
+        getThirdPartyAuthCodeFromURL: function (input) {
             return thirdPartyImpl.getAuthCodeFromURL.bind(thirdPartyImplementation_1.default(this))(input);
         },
-        getAuthErrorFromURL: function (input) {
+        getThirdPartyAuthErrorFromURL: function (input) {
             return thirdPartyImpl.getAuthErrorFromURL.bind(thirdPartyImplementation_1.default(this))(input);
         },
-        getAuthStateFromURL: function (input) {
+        getThirdPartyAuthStateFromURL: function (input) {
             return thirdPartyImpl.getAuthStateFromURL.bind(thirdPartyImplementation_1.default(this))(input);
         },
     };

--- a/lib/build/recipe/thirdpartypasswordless/recipeImplementation/passwordlessImplementation.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/recipeImplementation/passwordlessImplementation.d.ts
@@ -1,5 +1,5 @@
 import { RecipeInterface as WebJSPasswordlessRecipeInterface } from "supertokens-web-js/recipe/passwordless";
-import { TPPWlessRecipeInterface } from "../types";
+import { RecipeInterface as TPPWlessRecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 export default function getRecipeImplementation(
     originalImplementation: TPPWlessRecipeInterface
 ): WebJSPasswordlessRecipeInterface;

--- a/lib/build/recipe/thirdpartypasswordless/recipeImplementation/passwordlessImplementation.js
+++ b/lib/build/recipe/thirdpartypasswordless/recipeImplementation/passwordlessImplementation.js
@@ -3,12 +3,12 @@ Object.defineProperty(exports, "__esModule", { value: true });
 function getRecipeImplementation(originalImplementation) {
     return {
         clearLoginAttemptInfo: originalImplementation.clearPasswordlessLoginAttemptInfo.bind(originalImplementation),
-        consumeCode: originalImplementation.consumeCode.bind(originalImplementation),
-        createCode: originalImplementation.createCode.bind(originalImplementation),
+        consumeCode: originalImplementation.consumePasswordlessCode.bind(originalImplementation),
+        createCode: originalImplementation.createPasswordlessCode.bind(originalImplementation),
         doesEmailExist: originalImplementation.doesPasswordlessUserEmailExist.bind(originalImplementation),
         doesPhoneNumberExist: originalImplementation.doesPasswordlessUserPhoneNumberExist.bind(originalImplementation),
         getLoginAttemptInfo: originalImplementation.getPasswordlessLoginAttemptInfo.bind(originalImplementation),
-        resendCode: originalImplementation.resendCode.bind(originalImplementation),
+        resendCode: originalImplementation.resendPasswordlessCode.bind(originalImplementation),
         setLoginAttemptInfo: originalImplementation.setPasswordlessLoginAttemptInfo.bind(originalImplementation),
         getLinkCodeFromURL: originalImplementation.getPasswordlessLinkCodeFromURL.bind(originalImplementation),
         getPreAuthSessionIdFromURL:

--- a/lib/build/recipe/thirdpartypasswordless/recipeImplementation/thirdPartyImplementation.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/recipeImplementation/thirdPartyImplementation.d.ts
@@ -1,5 +1,5 @@
 import { RecipeInterface as WebJSThirdPartyRecipeInterface } from "supertokens-web-js/recipe/thirdparty";
-import { TPPWlessRecipeInterface } from "../types";
+import { RecipeInterface as TPPWlessRecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 export default function getRecipeImplementation(
     originalImplementation: TPPWlessRecipeInterface
 ): WebJSThirdPartyRecipeInterface;

--- a/lib/build/recipe/thirdpartypasswordless/recipeImplementation/thirdPartyImplementation.js
+++ b/lib/build/recipe/thirdpartypasswordless/recipeImplementation/thirdPartyImplementation.js
@@ -3,21 +3,21 @@ Object.defineProperty(exports, "__esModule", { value: true });
 function getRecipeImplementation(originalImplementation) {
     return {
         generateStateToSendToOAuthProvider:
-            originalImplementation.generateStateToSendToOAuthProvider.bind(originalImplementation),
-        getAuthCodeFromURL: originalImplementation.getAuthCodeFromURL.bind(originalImplementation),
-        getAuthErrorFromURL: originalImplementation.getAuthErrorFromURL.bind(originalImplementation),
-        getAuthStateFromURL: originalImplementation.getAuthStateFromURL.bind(originalImplementation),
+            originalImplementation.generateThirdPartyStateToSendToOAuthProvider.bind(originalImplementation),
+        getAuthCodeFromURL: originalImplementation.getThirdPartyAuthCodeFromURL.bind(originalImplementation),
+        getAuthErrorFromURL: originalImplementation.getThirdPartyAuthErrorFromURL.bind(originalImplementation),
+        getAuthStateFromURL: originalImplementation.getThirdPartyAuthStateFromURL.bind(originalImplementation),
         getAuthorisationURLFromBackend:
             originalImplementation.getAuthorisationURLFromBackend.bind(originalImplementation),
-        getAuthorizationURLWithQueryParamsAndSetState:
-            originalImplementation.getAuthorizationURLWithQueryParamsAndSetState.bind(originalImplementation),
+        getAuthorisationURLWithQueryParamsAndSetState:
+            originalImplementation.getThirdPartyAuthorisationURLWithQueryParamsAndSetState.bind(originalImplementation),
         getStateAndOtherInfoFromStorage:
-            originalImplementation.getStateAndOtherInfoFromStorage.bind(originalImplementation),
+            originalImplementation.getThirdPartyStateAndOtherInfoFromStorage.bind(originalImplementation),
         setStateAndOtherInfoToStorage:
-            originalImplementation.setStateAndOtherInfoToStorage.bind(originalImplementation),
+            originalImplementation.setThirdPartyStateAndOtherInfoToStorage.bind(originalImplementation),
         signInAndUp: originalImplementation.thirdPartySignInAndUp.bind(originalImplementation),
         verifyAndGetStateOrThrowError:
-            originalImplementation.verifyAndGetStateOrThrowError.bind(originalImplementation),
+            originalImplementation.verifyAndGetThirdPartyStateOrThrowError.bind(originalImplementation),
     };
 }
 exports.default = getRecipeImplementation;

--- a/lib/build/recipe/thirdpartypasswordless/types.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/types.d.ts
@@ -19,7 +19,6 @@ import {
     PreAPIHookContext as ThirdPartyPreAPIHookContext,
 } from "../thirdparty";
 import {
-    StateObject,
     ThirdPartySignInAndUpState,
     ThirdPartySignInUpActions,
     ThirdPartySignInUpChildProps,
@@ -44,9 +43,7 @@ import { Header } from "./components/themes/signInUp/header";
 import { CountryCode } from "libphonenumber-js";
 import { Dispatch } from "react";
 import { SignInUpScreens } from "../passwordless/components/themes/signInUp";
-import { PasswordlessUser, RecipeFunctionOptions } from "supertokens-web-js/recipe/passwordless";
-import { PasswordlessFlowType } from "supertokens-web-js/lib/build/recipe/passwordless/types";
-import { UserType } from "supertokens-web-js/lib/build/recipe/authRecipeWithEmailVerification/types";
+import { RecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 declare type WithRenamedOptionalProp<T, K extends keyof T, L extends string> = Omit<T, K> & {
     [P in L]?: T[K];
 };
@@ -89,9 +86,9 @@ export declare type UserInput = (
 ) & {
     override?: {
         functions?: (
-            originalImplementation: TPPWlessRecipeInterface,
-            builder?: OverrideableBuilder<TPPWlessRecipeInterface>
-        ) => TPPWlessRecipeInterface;
+            originalImplementation: RecipeInterface,
+            builder?: OverrideableBuilder<RecipeInterface>
+        ) => RecipeInterface;
         components?: ComponentOverrideMap;
     } & AuthRecipeUserInputOverride;
     linkClickedScreenFeature?: PasswordlessFeatureBaseConfig;
@@ -106,9 +103,9 @@ export declare type NormalisedConfig = {
     thirdPartyProviderAndEmailOrPhoneFormStyle: Styles | undefined;
     override: {
         functions: (
-            originalImplementation: TPPWlessRecipeInterface,
-            builder?: OverrideableBuilder<TPPWlessRecipeInterface>
-        ) => TPPWlessRecipeInterface;
+            originalImplementation: RecipeInterface,
+            builder?: OverrideableBuilder<RecipeInterface>
+        ) => RecipeInterface;
         components: ComponentOverrideMap;
     };
 } & NormalisedAuthRecipeModuleConfig<GetRedirectionURLContext, PreAndPostAPIHookAction, OnHandleEventContext>;
@@ -159,155 +156,4 @@ export declare type ThirdPartyPasswordlessSignInAndUpThemePropsWithActiveScreen 
           pwlessChildProps: PwlessChildProps;
       }
 );
-export declare type TPPWlessRecipeInterface = {
-    createCode: (
-        input:
-            | {
-                  email: string;
-                  userContext: any;
-                  options?: RecipeFunctionOptions;
-              }
-            | {
-                  phoneNumber: string;
-                  userContext: any;
-                  options?: RecipeFunctionOptions;
-              }
-    ) => Promise<{
-        status: "OK";
-        deviceId: string;
-        preAuthSessionId: string;
-        flowType: PasswordlessFlowType;
-        fetchResponse: Response;
-    }>;
-    resendCode: (input: {
-        userContext: any;
-        deviceId: string;
-        preAuthSessionId: string;
-        options?: RecipeFunctionOptions;
-    }) => Promise<{
-        status: "OK" | "RESTART_FLOW_ERROR";
-        fetchResponse: Response;
-    }>;
-    consumeCode: (
-        input:
-            | {
-                  userInputCode: string;
-                  deviceId: string;
-                  preAuthSessionId: string;
-                  userContext: any;
-                  options?: RecipeFunctionOptions;
-              }
-            | {
-                  preAuthSessionId: string;
-                  linkCode: string;
-                  userContext: any;
-                  options?: RecipeFunctionOptions;
-              }
-    ) => Promise<
-        | {
-              status: "OK";
-              createdUser: boolean;
-              user: PasswordlessUser;
-              fetchResponse: Response;
-          }
-        | {
-              status: "INCORRECT_USER_INPUT_CODE_ERROR" | "EXPIRED_USER_INPUT_CODE_ERROR";
-              failedCodeInputAttemptCount: number;
-              maximumCodeInputAttempts: number;
-              fetchResponse: Response;
-          }
-        | {
-              status: "RESTART_FLOW_ERROR";
-              fetchResponse: Response;
-          }
-    >;
-    getPasswordlessLinkCodeFromURL: (input: { userContext: any }) => string;
-    getPasswordlessPreAuthSessionIdFromURL: (input: { userContext: any }) => string;
-    doesPasswordlessUserEmailExist: (input: {
-        email: string;
-        userContext: any;
-        options?: RecipeFunctionOptions;
-    }) => Promise<{
-        status: "OK";
-        doesExist: boolean;
-        fetchResponse: Response;
-    }>;
-    doesPasswordlessUserPhoneNumberExist: (input: {
-        phoneNumber: string;
-        userContext: any;
-        options?: RecipeFunctionOptions;
-    }) => Promise<{
-        status: "OK";
-        doesExist: boolean;
-        fetchResponse: Response;
-    }>;
-    getPasswordlessLoginAttemptInfo: <CustomLoginAttemptInfoProperties>(input: { userContext: any }) =>
-        | Promise<
-              | undefined
-              | ({
-                    deviceId: string;
-                    preAuthSessionId: string;
-                    flowType: PasswordlessFlowType;
-                } & CustomLoginAttemptInfoProperties)
-          >
-        | ({
-              deviceId: string;
-              preAuthSessionId: string;
-              flowType: PasswordlessFlowType;
-          } & CustomLoginAttemptInfoProperties)
-        | undefined;
-    setPasswordlessLoginAttemptInfo: <CustomStateProperties>(input: {
-        attemptInfo: {
-            deviceId: string;
-            preAuthSessionId: string;
-            flowType: PasswordlessFlowType;
-        } & CustomStateProperties;
-        userContext: any;
-    }) => Promise<void> | void;
-    clearPasswordlessLoginAttemptInfo: (input: { userContext: any }) => Promise<void> | void;
-    getAuthorisationURLFromBackend: (input: {
-        providerId: string;
-        userContext: any;
-        options?: RecipeFunctionOptions;
-    }) => Promise<{
-        status: "OK";
-        url: string;
-        fetchResponse: Response;
-    }>;
-    thirdPartySignInAndUp: (input: { userContext: any; options?: RecipeFunctionOptions }) => Promise<
-        | {
-              status: "OK";
-              user: UserType;
-              createdNewUser: boolean;
-              fetchResponse: Response;
-          }
-        | {
-              status: "NO_EMAIL_GIVEN_BY_PROVIDER";
-              fetchResponse: Response;
-          }
-    >;
-    getStateAndOtherInfoFromStorage: <CustomStateProperties>(input: {
-        userContext: any;
-    }) => (StateObject & CustomStateProperties) | undefined;
-    setStateAndOtherInfoToStorage: <CustomStateProperties>(input: {
-        state: StateObject & CustomStateProperties;
-        userContext: any;
-    }) => void;
-    getAuthorizationURLWithQueryParamsAndSetState: (input: {
-        providerId: string;
-        authorisationURL: string;
-        userContext: any;
-        providerClientId?: string;
-        options?: RecipeFunctionOptions;
-    }) => Promise<string>;
-    generateStateToSendToOAuthProvider: (input: { userContext: any }) => string;
-    verifyAndGetStateOrThrowError: <CustomStateProperties>(input: {
-        stateFromAuthProvider: string | undefined;
-        stateObjectFromStorage: (StateObject & CustomStateProperties) | undefined;
-        userContext: any;
-    }) => Promise<StateObject & CustomStateProperties>;
-    getAuthCodeFromURL: (input: { userContext: any }) => string;
-    getAuthErrorFromURL: (input: { userContext: any }) => string | undefined;
-    getAuthStateFromURL: (input: { userContext: any }) => string;
-};
 export {};

--- a/lib/ts/recipe/passwordless/index.ts
+++ b/lib/ts/recipe/passwordless/index.ts
@@ -64,11 +64,9 @@ export default class Wrapper {
         flowType: PasswordlessFlowType;
         fetchResponse: Response;
     }> {
-        const recipe: Passwordless = Passwordless.getInstanceOrThrow();
-
         return UtilFunctions.createCode({
             ...input,
-            recipeImplementation: recipe.recipeImpl,
+            recipeImplementation: Passwordless.getInstanceOrThrow().recipeImpl,
         });
     }
 
@@ -76,11 +74,9 @@ export default class Wrapper {
         status: "OK" | "RESTART_FLOW_ERROR";
         fetchResponse: Response;
     }> {
-        const recipe: Passwordless = Passwordless.getInstanceOrThrow();
-
         return UtilFunctions.resendCode({
             ...input,
-            recipeImplementation: recipe.recipeImpl,
+            recipeImplementation: Passwordless.getInstanceOrThrow().recipeImpl,
         });
     }
 
@@ -110,11 +106,9 @@ export default class Wrapper {
           }
         | { status: "RESTART_FLOW_ERROR"; fetchResponse: Response }
     > {
-        const recipe: Passwordless = Passwordless.getInstanceOrThrow();
-
         return UtilFunctions.consumeCode({
             ...input,
-            recipeImplementation: recipe.recipeImpl,
+            recipeImplementation: Passwordless.getInstanceOrThrow().recipeImpl,
         });
     }
 

--- a/lib/ts/recipe/passwordless/index.ts
+++ b/lib/ts/recipe/passwordless/index.ts
@@ -22,6 +22,7 @@ import SignInUpThemeWrapper from "./components/themes/signInUp";
 import { RecipeFunctionOptions, RecipeInterface } from "supertokens-web-js/recipe/passwordless";
 import { PasswordlessFlowType, PasswordlessUser } from "supertokens-web-js/lib/build/recipe/passwordless/types";
 import { getNormalisedUserContext } from "../../utils";
+import * as UtilFunctions from "./utils";
 
 export default class Wrapper {
     static init(config: UserInput) {
@@ -64,23 +65,11 @@ export default class Wrapper {
         fetchResponse: Response;
     }> {
         const recipe: Passwordless = Passwordless.getInstanceOrThrow();
-        const normalisedUserContext = getNormalisedUserContext(input.userContext);
 
-        const createCodeResponse = await recipe.recipeImpl.createCode({
+        return UtilFunctions.createCode({
             ...input,
-            userContext: normalisedUserContext,
+            recipeImplementation: recipe.recipeImpl,
         });
-
-        await recipe.recipeImpl.setLoginAttemptInfo({
-            attemptInfo: {
-                deviceId: createCodeResponse.deviceId,
-                preAuthSessionId: createCodeResponse.preAuthSessionId,
-                flowType: createCodeResponse.flowType,
-            },
-            userContext: normalisedUserContext,
-        });
-
-        return createCodeResponse;
     }
 
     static async resendCode(input: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
@@ -88,22 +77,10 @@ export default class Wrapper {
         fetchResponse: Response;
     }> {
         const recipe: Passwordless = Passwordless.getInstanceOrThrow();
-        const normalisedUserContext = getNormalisedUserContext(input.userContext);
 
-        const previousAttemptInfo = await recipe.recipeImpl.getLoginAttemptInfo({
-            userContext: normalisedUserContext,
-        });
-
-        /**
-         * If previousAttemptInfo is undefined then local storage was probably cleared by another tab.
-         * In this case we use empty strings when calling the API because we want to
-         * return "RESTART_FLOW_ERROR"
-         */
-        return recipe.recipeImpl.resendCode({
+        return UtilFunctions.resendCode({
             ...input,
-            userContext: normalisedUserContext,
-            deviceId: previousAttemptInfo === undefined ? "" : previousAttemptInfo.deviceId,
-            preAuthSessionId: previousAttemptInfo === undefined ? "" : previousAttemptInfo.preAuthSessionId,
+            recipeImplementation: recipe.recipeImpl,
         });
     }
 
@@ -134,56 +111,10 @@ export default class Wrapper {
         | { status: "RESTART_FLOW_ERROR"; fetchResponse: Response }
     > {
         const recipe: Passwordless = Passwordless.getInstanceOrThrow();
-        const normalisedUserContext = getNormalisedUserContext(input.userContext);
 
-        let additionalParams:
-            | {
-                  userInputCode: string;
-                  deviceId: string;
-                  preAuthSessionId: string;
-              }
-            | {
-                  linkCode: string;
-                  preAuthSessionId: string;
-              };
-
-        if ("userInputCode" in input) {
-            const attemptInfoFromStorage = await recipe.recipeImpl.getLoginAttemptInfo({
-                userContext: normalisedUserContext,
-            });
-
-            /**
-             * If attemptInfoFromStorage is undefined then local storage was probably cleared by another tab.
-             * In this case we use empty strings when calling the API because we want to
-             * return "RESTART_FLOW_ERROR"
-             *
-             * Note: We dont do this for the linkCode flow because that does not depend on local storage.
-             */
-
-            additionalParams = {
-                userInputCode: input.userInputCode,
-                deviceId: attemptInfoFromStorage === undefined ? "" : attemptInfoFromStorage.deviceId,
-                preAuthSessionId: attemptInfoFromStorage === undefined ? "" : attemptInfoFromStorage.preAuthSessionId,
-            };
-        } else {
-            const linkCode = recipe.recipeImpl.getLinkCodeFromURL({
-                userContext: input.userContext,
-            });
-
-            const preAuthSessionId = recipe.recipeImpl.getPreAuthSessionIdFromURL({
-                userContext: input.userContext,
-            });
-
-            additionalParams = {
-                linkCode,
-                preAuthSessionId,
-            };
-        }
-
-        return recipe.recipeImpl.consumeCode({
-            userContext: normalisedUserContext,
-            options: input.options,
-            ...additionalParams,
+        return UtilFunctions.consumeCode({
+            ...input,
+            recipeImplementation: recipe.recipeImpl,
         });
     }
 

--- a/lib/ts/recipe/passwordless/utils.ts
+++ b/lib/ts/recipe/passwordless/utils.ts
@@ -24,13 +24,15 @@ import {
     NormalisedConfig,
     SignInUpFeatureConfigInput,
 } from "./types";
-import { RecipeInterface } from "supertokens-web-js/recipe/passwordless";
+import { RecipeFunctionOptions, RecipeInterface } from "supertokens-web-js/recipe/passwordless";
 import {
     defaultPhoneNumberValidator,
     defaultPhoneNumberValidatorForCombinedInput,
     defaultEmailValidator,
     defaultEmailValidatorForCombinedInput,
 } from "./validators";
+import { PasswordlessFlowType, PasswordlessUser } from "supertokens-web-js/lib/build/recipe/passwordless/types";
+import { getNormalisedUserContext } from "../../utils";
 
 export function normalisePasswordlessConfig(config: Config): NormalisedConfig {
     if (!["EMAIL", "PHONE", "EMAIL_OR_PHONE"].includes(config.contactMethod)) {
@@ -182,5 +184,148 @@ export async function setLoginAttemptInfo(input: {
     return await input.recipeImplementation.setLoginAttemptInfo<AdditionalLoginAttemptInfoProperties>({
         userContext: input.userContext,
         attemptInfo: input.attemptInfo,
+    });
+}
+
+export async function createCode(
+    input:
+        | { email: string; userContext?: any; options?: RecipeFunctionOptions; recipeImplementation: RecipeInterface }
+        | {
+              phoneNumber: string;
+              userContext?: any;
+              options?: RecipeFunctionOptions;
+              recipeImplementation: RecipeInterface;
+          }
+): Promise<{
+    status: "OK";
+    deviceId: string;
+    preAuthSessionId: string;
+    flowType: PasswordlessFlowType;
+    fetchResponse: Response;
+}> {
+    const normalisedUserContext = getNormalisedUserContext(input.userContext);
+
+    const createCodeResponse = await input.recipeImplementation.createCode({
+        ...input,
+        userContext: normalisedUserContext,
+    });
+
+    await input.recipeImplementation.setLoginAttemptInfo({
+        attemptInfo: {
+            deviceId: createCodeResponse.deviceId,
+            preAuthSessionId: createCodeResponse.preAuthSessionId,
+            flowType: createCodeResponse.flowType,
+        },
+        userContext: normalisedUserContext,
+    });
+
+    return createCodeResponse;
+}
+
+export async function resendCode(input: {
+    userContext?: any;
+    options?: RecipeFunctionOptions;
+    recipeImplementation: RecipeInterface;
+}): Promise<{
+    status: "OK" | "RESTART_FLOW_ERROR";
+    fetchResponse: Response;
+}> {
+    const normalisedUserContext = getNormalisedUserContext(input.userContext);
+
+    const previousAttemptInfo = await input.recipeImplementation.getLoginAttemptInfo({
+        userContext: normalisedUserContext,
+    });
+
+    /**
+     * If previousAttemptInfo is undefined then local storage was probably cleared by another tab.
+     * In this case we use empty strings when calling the API because we want to
+     * return "RESTART_FLOW_ERROR"
+     */
+    return input.recipeImplementation.resendCode({
+        ...input,
+        userContext: normalisedUserContext,
+        deviceId: previousAttemptInfo === undefined ? "" : previousAttemptInfo.deviceId,
+        preAuthSessionId: previousAttemptInfo === undefined ? "" : previousAttemptInfo.preAuthSessionId,
+    });
+}
+
+export async function consumeCode(
+    input:
+        | {
+              userInputCode: string;
+              userContext?: any;
+              options?: RecipeFunctionOptions;
+              recipeImplementation: RecipeInterface;
+          }
+        | {
+              userContext?: any;
+              options?: RecipeFunctionOptions;
+              recipeImplementation: RecipeInterface;
+          }
+): Promise<
+    | {
+          status: "OK";
+          createdUser: boolean;
+          user: PasswordlessUser;
+          fetchResponse: Response;
+      }
+    | {
+          status: "INCORRECT_USER_INPUT_CODE_ERROR" | "EXPIRED_USER_INPUT_CODE_ERROR";
+          failedCodeInputAttemptCount: number;
+          maximumCodeInputAttempts: number;
+          fetchResponse: Response;
+      }
+    | { status: "RESTART_FLOW_ERROR"; fetchResponse: Response }
+> {
+    const normalisedUserContext = getNormalisedUserContext(input.userContext);
+
+    let additionalParams:
+        | {
+              userInputCode: string;
+              deviceId: string;
+              preAuthSessionId: string;
+          }
+        | {
+              linkCode: string;
+              preAuthSessionId: string;
+          };
+
+    if ("userInputCode" in input) {
+        const attemptInfoFromStorage = await input.recipeImplementation.getLoginAttemptInfo({
+            userContext: normalisedUserContext,
+        });
+
+        /**
+         * If attemptInfoFromStorage is undefined then local storage was probably cleared by another tab.
+         * In this case we use empty strings when calling the API because we want to
+         * return "RESTART_FLOW_ERROR"
+         *
+         * Note: We dont do this for the linkCode flow because that does not depend on local storage.
+         */
+
+        additionalParams = {
+            userInputCode: input.userInputCode,
+            deviceId: attemptInfoFromStorage === undefined ? "" : attemptInfoFromStorage.deviceId,
+            preAuthSessionId: attemptInfoFromStorage === undefined ? "" : attemptInfoFromStorage.preAuthSessionId,
+        };
+    } else {
+        const linkCode = input.recipeImplementation.getLinkCodeFromURL({
+            userContext: input.userContext,
+        });
+
+        const preAuthSessionId = input.recipeImplementation.getPreAuthSessionIdFromURL({
+            userContext: input.userContext,
+        });
+
+        additionalParams = {
+            linkCode,
+            preAuthSessionId,
+        };
+    }
+
+    return input.recipeImplementation.consumeCode({
+        userContext: normalisedUserContext,
+        options: input.options,
+        ...additionalParams,
     });
 }

--- a/lib/ts/recipe/passwordless/utils.ts
+++ b/lib/ts/recipe/passwordless/utils.ts
@@ -187,6 +187,11 @@ export async function setLoginAttemptInfo(input: {
     });
 }
 
+/**
+ * These functions are helper functions so that the logic can be exposed from both
+ * passwordless and thirdpartypasswordless recipes without having to duplicate code
+ */
+
 export async function createCode(
     input:
         | { email: string; userContext?: any; options?: RecipeFunctionOptions; recipeImplementation: RecipeInterface }

--- a/lib/ts/recipe/thirdparty/recipeImplementation.ts
+++ b/lib/ts/recipe/thirdparty/recipeImplementation.ts
@@ -87,8 +87,8 @@ export default function getRecipeImplementation(recipeInput: {
             });
         },
 
-        getAuthorizationURLWithQueryParamsAndSetState: async function (input) {
-            return webJsImplementation.getAuthorizationURLWithQueryParamsAndSetState.bind(this)({
+        getAuthorisationURLWithQueryParamsAndSetState: async function (input) {
+            return webJsImplementation.getAuthorisationURLWithQueryParamsAndSetState.bind(this)({
                 ...input,
             });
         },

--- a/lib/ts/recipe/thirdparty/utils.ts
+++ b/lib/ts/recipe/thirdparty/utils.ts
@@ -126,7 +126,7 @@ export async function redirectToThirdPartyLogin(input: {
         return { status: "ERROR" };
     }
 
-    const response = await input.recipeImplementation.getAuthorizationURLWithQueryParamsAndSetState({
+    const response = await input.recipeImplementation.getAuthorisationURLWithQueryParamsAndSetState({
         providerId: input.thirdPartyId,
         authorisationURL: provider.getRedirectURL(),
         providerClientId: provider.clientId,

--- a/lib/ts/recipe/thirdpartyemailpassword/recipeImplementation/index.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/recipeImplementation/index.ts
@@ -47,8 +47,8 @@ export default function getRecipeImplementation(recipeInput: {
         getAuthorisationURLFromBackend: async function (input) {
             return thirdPartyImpl.getAuthorisationURLFromBackend.bind(DerivedTP(this))(input);
         },
-        getAuthorizationURLWithQueryParamsAndSetState: async function (input) {
-            return thirdPartyImpl.getAuthorizationURLWithQueryParamsAndSetState.bind(DerivedTP(this))(input);
+        getAuthorisationURLWithQueryParamsAndSetState: async function (input) {
+            return thirdPartyImpl.getAuthorisationURLWithQueryParamsAndSetState.bind(DerivedTP(this))(input);
         },
         thirdPartySignInAndUp: async function (input) {
             return await thirdPartyImpl.signInAndUp.bind(DerivedTP(this))(input);

--- a/lib/ts/recipe/thirdpartyemailpassword/recipeImplementation/thirdPartyImplementation.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/recipeImplementation/thirdPartyImplementation.ts
@@ -27,8 +27,8 @@ export default function getRecipeImplementation(
         getAuthStateFromURL: originalImplementation.getAuthStateFromURL.bind(originalImplementation),
         getAuthorisationURLFromBackend:
             originalImplementation.getAuthorisationURLFromBackend.bind(originalImplementation),
-        getAuthorizationURLWithQueryParamsAndSetState:
-            originalImplementation.getAuthorizationURLWithQueryParamsAndSetState.bind(originalImplementation),
+        getAuthorisationURLWithQueryParamsAndSetState:
+            originalImplementation.getAuthorisationURLWithQueryParamsAndSetState.bind(originalImplementation),
         getStateAndOtherInfoFromStorage:
             originalImplementation.getStateAndOtherInfoFromStorage.bind(originalImplementation),
         setStateAndOtherInfoToStorage:

--- a/lib/ts/recipe/thirdpartypasswordless/index.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/index.ts
@@ -112,7 +112,7 @@ export default class Wrapper {
         });
     }
 
-    static async createCode(
+    static async createPasswordlessCode(
         input:
             | { email: string; userContext?: any; options?: RecipeFunctionOptions }
             | { phoneNumber: string; userContext?: any; options?: RecipeFunctionOptions }
@@ -137,7 +137,7 @@ export default class Wrapper {
         });
     }
 
-    static async resendCode(input: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static async resendPasswordlessCode(input: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
         status: "OK" | "RESTART_FLOW_ERROR";
         fetchResponse: Response;
     }> {
@@ -155,7 +155,7 @@ export default class Wrapper {
         });
     }
 
-    static async consumeCode(
+    static async consumePasswordlessCode(
         input:
             | {
                   userInputCode: string;
@@ -271,9 +271,9 @@ const sendVerificationEmail = Wrapper.sendVerificationEmail;
 const verifyEmail = Wrapper.verifyEmail;
 const redirectToThirdPartyLogin = Wrapper.redirectToThirdPartyLogin;
 const thirdPartySignInAndUp = Wrapper.thirdPartySignInAndUp;
-const createCode = Wrapper.createCode;
-const resendCode = Wrapper.resendCode;
-const consumeCode = Wrapper.consumeCode;
+const createPasswordlessCode = Wrapper.createPasswordlessCode;
+const resendPasswordlessCode = Wrapper.resendPasswordlessCode;
+const consumePasswordlessCode = Wrapper.consumePasswordlessCode;
 const doesPasswordlessUserEmailExist = Wrapper.doesPasswordlessUserEmailExist;
 const doesPasswordlessUserPhoneNumberExist = Wrapper.doesPasswordlessUserPhoneNumberExist;
 const redirectToAuth = Wrapper.redirectToAuth;
@@ -294,9 +294,9 @@ export {
     verifyEmail,
     redirectToThirdPartyLogin,
     thirdPartySignInAndUp,
-    createCode,
-    resendCode,
-    consumeCode,
+    createPasswordlessCode,
+    resendPasswordlessCode,
+    consumePasswordlessCode,
     doesPasswordlessUserEmailExist,
     doesPasswordlessUserPhoneNumberExist,
     SignInAndUp,

--- a/lib/ts/recipe/thirdpartypasswordless/index.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/index.ts
@@ -15,18 +15,13 @@
 import ThirdPartyPasswordless from "./recipe";
 import EmailVerificationTheme from "../emailverification/components/themes/emailVerification";
 
-import {
-    UserInput,
-    GetRedirectionURLContext,
-    PreAPIHookContext,
-    OnHandleEventContext,
-    TPPWlessRecipeInterface as RecipeInterface,
-} from "./types";
+import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 import ThirdPartyPasswordlessAuth from "./thirdpartyPasswordlessAuth";
 import SignInUpTheme from "./components/themes/signInUp";
 import { Apple, Google, Facebook, Github } from "../thirdparty/";
 import { LinkClickedScreen } from "../passwordless/components/themes/linkClickedScreen";
 import { getNormalisedUserContext } from "../../utils";
+import { RecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 
 export default class Wrapper {
     static init(config: UserInput) {

--- a/lib/ts/recipe/thirdpartypasswordless/recipe.tsx
+++ b/lib/ts/recipe/thirdpartypasswordless/recipe.tsx
@@ -26,7 +26,6 @@ import {
     NormalisedConfig,
     OnHandleEventContext,
     UserInput,
-    TPPWlessRecipeInterface,
     PreAndPostAPIHookAction,
 } from "./types";
 import { isTest, matchRecipeIdUsingQueryParams } from "../../utils";
@@ -43,6 +42,7 @@ import getThirdPartyImpl from "./recipeImplementation/thirdPartyImplementation";
 import EmailVerification from "../emailverification/recipe";
 import AuthWidgetWrapper from "../authRecipe/authWidgetWrapper";
 import OverrideableBuilder from "supertokens-js-override";
+import { RecipeInterface as TPPWlessRecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 
 export default class ThirdPartyPasswordless extends AuthRecipeWithEmailVerification<
     GetRedirectionURLContext,

--- a/lib/ts/recipe/thirdpartypasswordless/recipeImplementation/index.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/recipeImplementation/index.ts
@@ -26,10 +26,10 @@ export default function getRecipeImplementation(recipeInput: {
     });
 
     return {
-        consumeCode(input) {
+        consumePasswordlessCode(input) {
             return passwordlessImpl.consumeCode.bind(DerivedPwless(this))(input);
         },
-        createCode(input) {
+        createPasswordlessCode(input) {
             return passwordlessImpl.createCode.bind(DerivedPwless(this))(input);
         },
         doesPasswordlessUserPhoneNumberExist(input) {
@@ -38,7 +38,7 @@ export default function getRecipeImplementation(recipeInput: {
         doesPasswordlessUserEmailExist: async function (input) {
             return passwordlessImpl.doesEmailExist.bind(DerivedPwless(this))(input);
         },
-        resendCode(input) {
+        resendPasswordlessCode(input) {
             return passwordlessImpl.resendCode.bind(DerivedPwless(this))(input);
         },
         clearPasswordlessLoginAttemptInfo(input) {
@@ -62,28 +62,28 @@ export default function getRecipeImplementation(recipeInput: {
         thirdPartySignInAndUp: async function (input) {
             return thirdPartyImpl.signInAndUp.bind(DerivedTP(this))(input);
         },
-        getStateAndOtherInfoFromStorage: function (input) {
+        getThirdPartyStateAndOtherInfoFromStorage: function (input) {
             return thirdPartyImpl.getStateAndOtherInfoFromStorage.bind(DerivedTP(this))(input);
         },
-        setStateAndOtherInfoToStorage: function (input) {
+        setThirdPartyStateAndOtherInfoToStorage: function (input) {
             return thirdPartyImpl.setStateAndOtherInfoToStorage.bind(DerivedTP(this))(input);
         },
-        getAuthorizationURLWithQueryParamsAndSetState: function (input) {
-            return thirdPartyImpl.getAuthorizationURLWithQueryParamsAndSetState.bind(DerivedTP(this))(input);
+        getThirdPartyAuthorisationURLWithQueryParamsAndSetState: function (input) {
+            return thirdPartyImpl.getAuthorisationURLWithQueryParamsAndSetState.bind(DerivedTP(this))(input);
         },
-        generateStateToSendToOAuthProvider: function (input) {
+        generateThirdPartyStateToSendToOAuthProvider: function (input) {
             return thirdPartyImpl.generateStateToSendToOAuthProvider.bind(DerivedTP(this))(input);
         },
-        verifyAndGetStateOrThrowError: function (input) {
+        verifyAndGetThirdPartyStateOrThrowError: function (input) {
             return thirdPartyImpl.verifyAndGetStateOrThrowError.bind(DerivedTP(this))(input);
         },
-        getAuthCodeFromURL: function (input) {
+        getThirdPartyAuthCodeFromURL: function (input) {
             return thirdPartyImpl.getAuthCodeFromURL.bind(DerivedTP(this))(input);
         },
-        getAuthErrorFromURL: function (input) {
+        getThirdPartyAuthErrorFromURL: function (input) {
             return thirdPartyImpl.getAuthErrorFromURL.bind(DerivedTP(this))(input);
         },
-        getAuthStateFromURL: function (input) {
+        getThirdPartyAuthStateFromURL: function (input) {
             return thirdPartyImpl.getAuthStateFromURL.bind(DerivedTP(this))(input);
         },
     };

--- a/lib/ts/recipe/thirdpartypasswordless/recipeImplementation/index.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/recipeImplementation/index.ts
@@ -1,4 +1,4 @@
-import { TPPWlessRecipeInterface, PreAndPostAPIHookAction, OnHandleEventContext } from "../types";
+import { PreAndPostAPIHookAction, OnHandleEventContext } from "../types";
 import { NormalisedAppInfo } from "../../../types";
 import PasswordlessRecipeImplementation from "../../passwordless/recipeImplementation";
 import ThirdPartyRecipeImplementation from "../../thirdparty/recipeImplementation";
@@ -9,6 +9,7 @@ import {
     RecipePostAPIHookFunction,
     RecipePreAPIHookFunction,
 } from "../../recipeModule/types";
+import { RecipeInterface as TPPWlessRecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 
 export default function getRecipeImplementation(recipeInput: {
     recipeId: string;

--- a/lib/ts/recipe/thirdpartypasswordless/recipeImplementation/passwordlessImplementation.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/recipeImplementation/passwordlessImplementation.ts
@@ -6,12 +6,12 @@ export default function getRecipeImplementation(
 ): WebJSPasswordlessRecipeInterface {
     return {
         clearLoginAttemptInfo: originalImplementation.clearPasswordlessLoginAttemptInfo.bind(originalImplementation),
-        consumeCode: originalImplementation.consumeCode.bind(originalImplementation),
-        createCode: originalImplementation.createCode.bind(originalImplementation),
+        consumeCode: originalImplementation.consumePasswordlessCode.bind(originalImplementation),
+        createCode: originalImplementation.createPasswordlessCode.bind(originalImplementation),
         doesEmailExist: originalImplementation.doesPasswordlessUserEmailExist.bind(originalImplementation),
         doesPhoneNumberExist: originalImplementation.doesPasswordlessUserPhoneNumberExist.bind(originalImplementation),
         getLoginAttemptInfo: originalImplementation.getPasswordlessLoginAttemptInfo.bind(originalImplementation),
-        resendCode: originalImplementation.resendCode.bind(originalImplementation),
+        resendCode: originalImplementation.resendPasswordlessCode.bind(originalImplementation),
         setLoginAttemptInfo: originalImplementation.setPasswordlessLoginAttemptInfo.bind(originalImplementation),
         getLinkCodeFromURL: originalImplementation.getPasswordlessLinkCodeFromURL.bind(originalImplementation),
         getPreAuthSessionIdFromURL:

--- a/lib/ts/recipe/thirdpartypasswordless/recipeImplementation/passwordlessImplementation.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/recipeImplementation/passwordlessImplementation.ts
@@ -1,5 +1,5 @@
 import { RecipeInterface as WebJSPasswordlessRecipeInterface } from "supertokens-web-js/recipe/passwordless";
-import { TPPWlessRecipeInterface } from "../types";
+import { RecipeInterface as TPPWlessRecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 
 export default function getRecipeImplementation(
     originalImplementation: TPPWlessRecipeInterface

--- a/lib/ts/recipe/thirdpartypasswordless/recipeImplementation/thirdPartyImplementation.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/recipeImplementation/thirdPartyImplementation.ts
@@ -1,5 +1,5 @@
 import { RecipeInterface as WebJSThirdPartyRecipeInterface } from "supertokens-web-js/recipe/thirdparty";
-import { TPPWlessRecipeInterface } from "../types";
+import { RecipeInterface as TPPWlessRecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 
 export default function getRecipeImplementation(
     originalImplementation: TPPWlessRecipeInterface

--- a/lib/ts/recipe/thirdpartypasswordless/recipeImplementation/thirdPartyImplementation.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/recipeImplementation/thirdPartyImplementation.ts
@@ -6,20 +6,20 @@ export default function getRecipeImplementation(
 ): WebJSThirdPartyRecipeInterface {
     return {
         generateStateToSendToOAuthProvider:
-            originalImplementation.generateStateToSendToOAuthProvider.bind(originalImplementation),
-        getAuthCodeFromURL: originalImplementation.getAuthCodeFromURL.bind(originalImplementation),
-        getAuthErrorFromURL: originalImplementation.getAuthErrorFromURL.bind(originalImplementation),
-        getAuthStateFromURL: originalImplementation.getAuthStateFromURL.bind(originalImplementation),
+            originalImplementation.generateThirdPartyStateToSendToOAuthProvider.bind(originalImplementation),
+        getAuthCodeFromURL: originalImplementation.getThirdPartyAuthCodeFromURL.bind(originalImplementation),
+        getAuthErrorFromURL: originalImplementation.getThirdPartyAuthErrorFromURL.bind(originalImplementation),
+        getAuthStateFromURL: originalImplementation.getThirdPartyAuthStateFromURL.bind(originalImplementation),
         getAuthorisationURLFromBackend:
             originalImplementation.getAuthorisationURLFromBackend.bind(originalImplementation),
-        getAuthorizationURLWithQueryParamsAndSetState:
-            originalImplementation.getAuthorizationURLWithQueryParamsAndSetState.bind(originalImplementation),
+        getAuthorisationURLWithQueryParamsAndSetState:
+            originalImplementation.getThirdPartyAuthorisationURLWithQueryParamsAndSetState.bind(originalImplementation),
         getStateAndOtherInfoFromStorage:
-            originalImplementation.getStateAndOtherInfoFromStorage.bind(originalImplementation),
+            originalImplementation.getThirdPartyStateAndOtherInfoFromStorage.bind(originalImplementation),
         setStateAndOtherInfoToStorage:
-            originalImplementation.setStateAndOtherInfoToStorage.bind(originalImplementation),
+            originalImplementation.setThirdPartyStateAndOtherInfoToStorage.bind(originalImplementation),
         signInAndUp: originalImplementation.thirdPartySignInAndUp.bind(originalImplementation),
         verifyAndGetStateOrThrowError:
-            originalImplementation.verifyAndGetStateOrThrowError.bind(originalImplementation),
+            originalImplementation.verifyAndGetThirdPartyStateOrThrowError.bind(originalImplementation),
     };
 }

--- a/lib/ts/recipe/thirdpartypasswordless/types.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/types.ts
@@ -37,7 +37,6 @@ import {
     PreAPIHookContext as ThirdPartyPreAPIHookContext,
 } from "../thirdparty";
 import {
-    StateObject,
     ThirdPartySignInAndUpState,
     ThirdPartySignInUpActions,
     ThirdPartySignInUpChildProps,
@@ -63,9 +62,7 @@ import { Header } from "./components/themes/signInUp/header";
 import { CountryCode } from "libphonenumber-js";
 import { Dispatch } from "react";
 import { SignInUpScreens } from "../passwordless/components/themes/signInUp";
-import { PasswordlessUser, RecipeFunctionOptions } from "supertokens-web-js/recipe/passwordless";
-import { PasswordlessFlowType } from "supertokens-web-js/lib/build/recipe/passwordless/types";
-import { UserType } from "supertokens-web-js/lib/build/recipe/authRecipeWithEmailVerification/types";
+import { RecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 
 // This defines a new type by renaming a single K property to L and as optional
 // If we upgrade to typescript 4.1> this could just keep the optionality of the original (with the as keyword)
@@ -123,9 +120,9 @@ export type UserInput = (
 ) & {
     override?: {
         functions?: (
-            originalImplementation: TPPWlessRecipeInterface,
-            builder?: OverrideableBuilder<TPPWlessRecipeInterface>
-        ) => TPPWlessRecipeInterface;
+            originalImplementation: RecipeInterface,
+            builder?: OverrideableBuilder<RecipeInterface>
+        ) => RecipeInterface;
         components?: ComponentOverrideMap;
     } & AuthRecipeUserInputOverride;
     linkClickedScreenFeature?: PasswordlessFeatureBaseConfig;
@@ -144,9 +141,9 @@ export type NormalisedConfig = {
 
     override: {
         functions: (
-            originalImplementation: TPPWlessRecipeInterface,
-            builder?: OverrideableBuilder<TPPWlessRecipeInterface>
-        ) => TPPWlessRecipeInterface;
+            originalImplementation: RecipeInterface,
+            builder?: OverrideableBuilder<RecipeInterface>
+        ) => RecipeInterface;
         components: ComponentOverrideMap;
     };
 } & NormalisedAuthRecipeModuleConfig<GetRedirectionURLContext, PreAndPostAPIHookAction, OnHandleEventContext>;
@@ -203,197 +200,3 @@ export type ThirdPartyPasswordlessSignInAndUpThemePropsWithActiveScreen = {
           pwlessChildProps: PwlessChildProps;
       }
 );
-
-export type TPPWlessRecipeInterface = {
-    createCode: (
-        input:
-            | { email: string; userContext: any; options?: RecipeFunctionOptions }
-            | { phoneNumber: string; userContext: any; options?: RecipeFunctionOptions }
-    ) => Promise<{
-        status: "OK";
-        deviceId: string;
-        preAuthSessionId: string;
-        flowType: PasswordlessFlowType;
-        fetchResponse: Response;
-    }>;
-
-    resendCode: (input: {
-        userContext: any;
-        deviceId: string;
-        preAuthSessionId: string;
-        options?: RecipeFunctionOptions;
-    }) => Promise<{
-        status: "OK" | "RESTART_FLOW_ERROR";
-        fetchResponse: Response;
-    }>;
-
-    consumeCode: (
-        input:
-            | {
-                  userInputCode: string;
-                  deviceId: string;
-                  preAuthSessionId: string;
-                  userContext: any;
-                  options?: RecipeFunctionOptions;
-              }
-            | {
-                  preAuthSessionId: string;
-                  linkCode: string;
-                  userContext: any;
-                  options?: RecipeFunctionOptions;
-              }
-    ) => Promise<
-        | {
-              status: "OK";
-              createdUser: boolean;
-              user: PasswordlessUser;
-              fetchResponse: Response;
-          }
-        | {
-              status: "INCORRECT_USER_INPUT_CODE_ERROR" | "EXPIRED_USER_INPUT_CODE_ERROR";
-              failedCodeInputAttemptCount: number;
-              maximumCodeInputAttempts: number;
-              fetchResponse: Response;
-          }
-        | { status: "RESTART_FLOW_ERROR"; fetchResponse: Response }
-    >;
-
-    getPasswordlessLinkCodeFromURL: (input: { userContext: any }) => string;
-
-    getPasswordlessPreAuthSessionIdFromURL: (input: { userContext: any }) => string;
-
-    doesPasswordlessUserEmailExist: (input: {
-        email: string;
-        userContext: any;
-        options?: RecipeFunctionOptions;
-    }) => Promise<{
-        status: "OK";
-        doesExist: boolean;
-        fetchResponse: Response;
-    }>;
-
-    doesPasswordlessUserPhoneNumberExist: (input: {
-        phoneNumber: string;
-        userContext: any;
-        options?: RecipeFunctionOptions;
-    }) => Promise<{
-        status: "OK";
-        doesExist: boolean;
-        fetchResponse: Response;
-    }>;
-
-    // getPasswordlessLoginAttemptInfo: () =>
-    //     | Promise<
-    //           | undefined
-    //           | {
-    //                 deviceId: string;
-    //                 preAuthSessionId: string;
-    //                 contactInfo: string;
-    //                 contactMethod: "EMAIL" | "PHONE";
-    //                 flowType: "USER_INPUT_CODE" | "MAGIC_LINK" | "USER_INPUT_CODE_AND_MAGIC_LINK";
-    //                 lastResend: number;
-    //                 redirectToPath?: string;
-    //             }
-    //       >
-    //     | {
-    //           deviceId: string;
-    //           preAuthSessionId: string;
-    //           contactInfo: string;
-    //           contactMethod: "EMAIL" | "PHONE";
-    //           flowType: "USER_INPUT_CODE" | "MAGIC_LINK" | "USER_INPUT_CODE_AND_MAGIC_LINK";
-    //           lastResend: number;
-    //           redirectToPath?: string;
-    //       }
-    //     | undefined;
-
-    getPasswordlessLoginAttemptInfo: <CustomLoginAttemptInfoProperties>(input: { userContext: any }) =>
-        | Promise<
-              | undefined
-              | ({
-                    deviceId: string;
-                    preAuthSessionId: string;
-                    flowType: PasswordlessFlowType;
-                } & CustomLoginAttemptInfoProperties)
-          >
-        | ({
-              deviceId: string;
-              preAuthSessionId: string;
-              flowType: PasswordlessFlowType;
-          } & CustomLoginAttemptInfoProperties)
-        | undefined;
-
-    // setPasswordlessLoginAttemptInfo: (input: {
-    //     deviceId: string;
-    //     preAuthSessionId: string;
-    //     contactInfo: string;
-    //     contactMethod: "EMAIL" | "PHONE";
-    //     flowType: "USER_INPUT_CODE" | "MAGIC_LINK" | "USER_INPUT_CODE_AND_MAGIC_LINK";
-    //     lastResend: number;
-    //     redirectToPath?: string;
-    // }) => Promise<void> | void;
-
-    setPasswordlessLoginAttemptInfo: <CustomStateProperties>(input: {
-        attemptInfo: {
-            deviceId: string;
-            preAuthSessionId: string;
-            flowType: PasswordlessFlowType;
-        } & CustomStateProperties;
-        userContext: any;
-    }) => Promise<void> | void;
-
-    clearPasswordlessLoginAttemptInfo: (input: { userContext: any }) => Promise<void> | void;
-
-    getAuthorisationURLFromBackend: (input: {
-        providerId: string;
-        userContext: any;
-        options?: RecipeFunctionOptions;
-    }) => Promise<{
-        status: "OK";
-        url: string;
-        fetchResponse: Response;
-    }>;
-
-    thirdPartySignInAndUp: (input: { userContext: any; options?: RecipeFunctionOptions }) => Promise<
-        | {
-              status: "OK";
-              user: UserType;
-              createdNewUser: boolean;
-              fetchResponse: Response;
-          }
-        | {
-              status: "NO_EMAIL_GIVEN_BY_PROVIDER";
-              fetchResponse: Response;
-          }
-    >;
-
-    getStateAndOtherInfoFromStorage: <CustomStateProperties>(input: {
-        userContext: any;
-    }) => (StateObject & CustomStateProperties) | undefined;
-
-    setStateAndOtherInfoToStorage: <CustomStateProperties>(input: {
-        state: StateObject & CustomStateProperties;
-        userContext: any;
-    }) => void;
-
-    getAuthorizationURLWithQueryParamsAndSetState: (input: {
-        providerId: string;
-        authorisationURL: string;
-        userContext: any;
-        providerClientId?: string;
-        options?: RecipeFunctionOptions;
-    }) => Promise<string>;
-
-    generateStateToSendToOAuthProvider: (input: { userContext: any }) => string;
-
-    verifyAndGetStateOrThrowError: <CustomStateProperties>(input: {
-        stateFromAuthProvider: string | undefined;
-        stateObjectFromStorage: (StateObject & CustomStateProperties) | undefined;
-        userContext: any;
-    }) => Promise<StateObject & CustomStateProperties>;
-
-    getAuthCodeFromURL: (input: { userContext: any }) => string;
-
-    getAuthErrorFromURL: (input: { userContext: any }) => string | undefined;
-
-    getAuthStateFromURL: (input: { userContext: any }) => string;
-};

--- a/lib/ts/recipe/thirdpartypasswordless/utils.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/utils.ts
@@ -16,9 +16,9 @@
 /*
  * Imports.
  */
-import { Config, NormalisedConfig, TPPWlessRecipeInterface } from "./types";
-
+import { Config, NormalisedConfig } from "./types";
 import { normaliseAuthRecipeWithEmailVerificationConfig } from "../authRecipeWithEmailVerification/utils";
+import { RecipeInterface as TPPWlessRecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 
 export function normaliseThirdPartyPasswordlessConfig(config: Config): NormalisedConfig {
     const disablePasswordless = config.disablePasswordless === true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15236,7 +15236,7 @@
         },
         "node_modules/supertokens-web-js": {
             "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#bc9e540657795f660edf5bcf0bab95e474240f71",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#fb74d21aaedaaea7da45c443c953b511b4d9f9fa",
             "license": "Apache-2.0",
             "dependencies": {
                 "supertokens-js-override": "0.0.4",
@@ -26611,7 +26611,7 @@
             "version": "0.0.4"
         },
         "supertokens-web-js": {
-            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#bc9e540657795f660edf5bcf0bab95e474240f71",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#fb74d21aaedaaea7da45c443c953b511b4d9f9fa",
             "from": "supertokens-web-js@github:supertokens/supertokens-web-js#thirdparty-passwordless",
             "requires": {
                 "supertokens-js-override": "0.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15236,7 +15236,7 @@
         },
         "node_modules/supertokens-web-js": {
             "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#fb74d21aaedaaea7da45c443c953b511b4d9f9fa",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#8460f8dc8794c342a46d16d154d94c4297f66aee",
             "license": "Apache-2.0",
             "dependencies": {
                 "supertokens-js-override": "0.0.4",
@@ -26611,7 +26611,7 @@
             "version": "0.0.4"
         },
         "supertokens-web-js": {
-            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#fb74d21aaedaaea7da45c443c953b511b4d9f9fa",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#8460f8dc8794c342a46d16d154d94c4297f66aee",
             "from": "supertokens-web-js@github:supertokens/supertokens-web-js#thirdparty-passwordless",
             "requires": {
                 "supertokens-js-override": "0.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "react-select": "^5.2.1",
                 "react-shadow": "^19.0.2",
                 "supertokens-js-override": "^0.0.4",
-                "supertokens-web-js": "github:supertokens/supertokens-web-js#thirdparty-passwordless"
+                "supertokens-web-js": "github:supertokens/supertokens-web-js#0.0"
             },
             "devDependencies": {
                 "@babel/core": "7.12.1",
@@ -15236,7 +15236,7 @@
         },
         "node_modules/supertokens-web-js": {
             "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#8460f8dc8794c342a46d16d154d94c4297f66aee",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#c73aaceb1fbfa9ed308b7273b7fe45975c7fa2d9",
             "license": "Apache-2.0",
             "dependencies": {
                 "supertokens-js-override": "0.0.4",
@@ -26611,8 +26611,8 @@
             "version": "0.0.4"
         },
         "supertokens-web-js": {
-            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#8460f8dc8794c342a46d16d154d94c4297f66aee",
-            "from": "supertokens-web-js@github:supertokens/supertokens-web-js#thirdparty-passwordless",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#c73aaceb1fbfa9ed308b7273b7fe45975c7fa2d9",
+            "from": "supertokens-web-js@github:supertokens/supertokens-web-js#0.0",
             "requires": {
                 "supertokens-js-override": "0.0.4",
                 "supertokens-website": "github:supertokens/supertokens-website#user-context-changes"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "react-select": "^5.2.1",
                 "react-shadow": "^19.0.2",
                 "supertokens-js-override": "^0.0.4",
-                "supertokens-web-js": "github:supertokens/supertokens-web-js#0.0"
+                "supertokens-web-js": "github:supertokens/supertokens-web-js#thirdparty-passwordless"
             },
             "devDependencies": {
                 "@babel/core": "7.12.1",
@@ -15236,7 +15236,7 @@
         },
         "node_modules/supertokens-web-js": {
             "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#70b3f5b79d732dcd5145966394bbc08b7c2c0de3",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#bc9e540657795f660edf5bcf0bab95e474240f71",
             "license": "Apache-2.0",
             "dependencies": {
                 "supertokens-js-override": "0.0.4",
@@ -26611,8 +26611,8 @@
             "version": "0.0.4"
         },
         "supertokens-web-js": {
-            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#70b3f5b79d732dcd5145966394bbc08b7c2c0de3",
-            "from": "supertokens-web-js@github:supertokens/supertokens-web-js#0.0",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#bc9e540657795f660edf5bcf0bab95e474240f71",
+            "from": "supertokens-web-js@github:supertokens/supertokens-web-js#thirdparty-passwordless",
             "requires": {
                 "supertokens-js-override": "0.0.4",
                 "supertokens-website": "github:supertokens/supertokens-website#user-context-changes"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "react-select": "^5.2.1",
         "react-shadow": "^19.0.2",
         "supertokens-js-override": "^0.0.4",
-        "supertokens-web-js": "github:supertokens/supertokens-web-js#thirdparty-passwordless"
+        "supertokens-web-js": "github:supertokens/supertokens-web-js#0.0"
     },
     "peerDependencies": {
         "react": ">=16.8.0"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "react-select": "^5.2.1",
         "react-shadow": "^19.0.2",
         "supertokens-js-override": "^0.0.4",
-        "supertokens-web-js": "github:supertokens/supertokens-web-js#0.0"
+        "supertokens-web-js": "github:supertokens/supertokens-web-js#thirdparty-passwordless"
     },
     "peerDependencies": {
         "react": ">=16.8.0"

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
         },
         {
             "path": "recipe/thirdpartypasswordless/index.js",
-            "limit": "210kb"
+            "limit": "215kb"
         }
     ],
     "repository": {


### PR DESCRIPTION
## Summary of change

- Refactors thirdpartypasswordless recipe to use Recipe interface from web-js SDK

## Related issues

-   https://github.com/supertokens/for-zenhub/issues/28

## Test Plan

All existing test cases pass: https://github.com/supertokens/supertokens-auth-react/runs/5867190737?check_suite_focus=true

## Documentation changes

WIP

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] ~~`frontendDriverInterfaceSupported.json` file has been updated (if needed)~~
    -   ~~Along with the associated array in `lib/ts/version.ts`~~
-   [ ] ~~Changes to the version if needed~~
    -   ~~In `package.json`~~
    -   ~~In `package-lock.json`~~
    -   ~~In `lib/ts/version.ts`~~
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] ~~Issue this PR against the latest non released version branch.~~
    -   ~~To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.~~
    -   ~~If no such branch exists, then create one from the latest released branch.~~
-   [ ] ~~If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).~~
-   [ ] ~~If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.~~

## Remaining TODOs for this PR

-   [ ] Update CHANGELOG
-   [ ] Verify size limit
-   [ ] Export recipe functions from thirdpartypasswordless/index