### PR TITLE
ci: fix continuation for tag builds

### DIFF
--- a/.circleci/config_continue.yml
+++ b/.circleci/config_continue.yml
@@ -62,10 +62,20 @@ workflows:
             - build:
                   context:
                       - slack-notification
+                  filters:
+                      tags:
+                          only: /dev-v[0-9]+(\.[0-9]+)*/
+                      branches:
+                          ignore: /.*/
 
             - test:
                   requires:
                       - build
+                  filters:
+                      tags:
+                          only: /dev-v[0-9]+(\.[0-9]+)*/
+                      branches:
+                          ignore: /.*/
                   matrix:
                       parameters:
                           fdi-version: placeholder
@@ -73,5 +83,10 @@ workflows:
             - mark-passed:
                   context:
                       - slack-notification
+                  filters:
+                      tags:
+                          only: /dev-v[0-9]+(\.[0-9]+)*/
+                      branches:
+                          ignore: /.*/
                   requires:
                       - test


### PR DESCRIPTION
## Summary of change

Added filters to the continuation jobs as well. Tags do not trigger the jobs if not explicitly stated in the filters unlike branches.

## Related issues


## Test Plan

N/A ci only fix

## Documentation changes

N/A ci only fix

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
