### PR TITLE
refactor: Use web-js input type for session recipe

### DIFF
--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="react" />
 /// <reference types="@emotion/react/types/css-prop" />
-import { RecipeInterface } from "supertokens-website";
+import { RecipeInterface } from "supertokens-web-js/recipe/session";
 import { InputType, SessionContextType } from "./types";
 import SessionContext from "./sessionContext";
 export default class SessionAPIWrapper {

--- a/lib/build/recipe/session/recipe.d.ts
+++ b/lib/build/recipe/session/recipe.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 import RecipeModule from "../recipeModule";
 import { CreateRecipeFunction, NormalisedAppInfo } from "../../types";
-import { InputType, RecipeEventWithSessionContext } from "./types";
+import { RecipeEventWithSessionContext, InputType } from "./types";
 import WebJSSessionRecipe from "supertokens-web-js/lib/build/recipe/session/recipe";
 declare type ConfigType = InputType & {
     recipeId: string;

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -341,7 +341,11 @@ var Session = /** @class */ (function (_super) {
     Session.init = function (config) {
         return function (appInfo) {
             Session.instance = new Session(
-                __assign(__assign({}, config), { appInfo: appInfo, recipeId: Session.RECIPE_ID })
+                __assign(__assign({}, config), {
+                    appInfo: appInfo,
+                    recipeId: Session.RECIPE_ID,
+                    apiDomain: appInfo.apiDomain.getAsStringDangerous(),
+                })
             );
             return Session.instance;
         };

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -1,5 +1,4 @@
-import { RecipeInterface } from "supertokens-website";
-import OverrideableBuilder from "supertokens-js-override";
+import { UserInput as WebJSInputType } from "supertokens-web-js/lib/build/recipe/session/types";
 export declare type RecipeEvent =
     | {
           action: "SIGN_OUT" | "REFRESH_SESSION" | "SESSION_CREATED";
@@ -13,29 +12,8 @@ export declare type RecipeEvent =
 export declare type RecipeEventWithSessionContext = RecipeEvent & {
     sessionContext: SessionContextType;
 };
-export declare type InputType = {
-    apiDomain?: string;
-    apiBasePath?: string;
-    sessionScope?: string;
-    sessionExpiredStatusCode?: number;
-    autoAddCredentials?: boolean;
-    isInIframe?: boolean;
-    cookieDomain?: string;
-    preAPIHook?: (context: {
-        action: "SIGN_OUT" | "REFRESH_SESSION";
-        requestInit: RequestInit;
-        url: string;
-    }) => Promise<{
-        url: string;
-        requestInit: RequestInit;
-    }>;
-    onHandleEvent?: (event: RecipeEvent) => void;
-    override?: {
-        functions?: (
-            originalImplementation: RecipeInterface,
-            builder?: OverrideableBuilder<RecipeInterface>
-        ) => RecipeInterface;
-    };
+export declare type InputType = WebJSInputType & {
+    onHandleEvent?: (event: RecipeEventWithSessionContext) => void;
 };
 export declare type SessionContextType = {
     doesSessionExist: boolean;

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -14,7 +14,7 @@
  */
 
 import Session from "./recipe";
-import { RecipeInterface } from "supertokens-website";
+import { RecipeInterface } from "supertokens-web-js/recipe/session";
 import SessionAuthWrapper from "./sessionAuth";
 import useSessionContextFunc from "./useSessionContext";
 import { InputType, SessionContextType } from "./types";

--- a/lib/ts/recipe/session/recipe.ts
+++ b/lib/ts/recipe/session/recipe.ts
@@ -19,8 +19,9 @@
 import RecipeModule from "../recipeModule";
 import { CreateRecipeFunction, NormalisedAppInfo, RecipeFeatureComponentMap } from "../../types";
 import { isTest } from "../../utils";
-import { InputType, RecipeEvent, RecipeEventWithSessionContext, SessionContextType } from "./types";
+import { RecipeEventWithSessionContext, SessionContextType, InputType } from "./types";
 import WebJSSessionRecipe from "supertokens-web-js/lib/build/recipe/session/recipe";
+import { RecipeEvent } from "supertokens-web-js/lib/build/recipe/session/types";
 
 type ConfigType = InputType & { recipeId: string; appInfo: NormalisedAppInfo };
 
@@ -155,6 +156,7 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, any
                 ...config,
                 appInfo,
                 recipeId: Session.RECIPE_ID,
+                apiDomain: appInfo.apiDomain.getAsStringDangerous(),
             });
             return Session.instance;
         };

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -13,8 +13,7 @@
  * under the License.
  */
 
-import { RecipeInterface } from "supertokens-website";
-import OverrideableBuilder from "supertokens-js-override";
+import { UserInput as WebJSInputType } from "supertokens-web-js/lib/build/recipe/session/types";
 
 export type RecipeEvent =
     | {
@@ -29,26 +28,8 @@ export type RecipeEvent =
 
 export type RecipeEventWithSessionContext = RecipeEvent & { sessionContext: SessionContextType };
 
-export type InputType = {
-    apiDomain?: string;
-    apiBasePath?: string;
-    sessionScope?: string;
-    sessionExpiredStatusCode?: number;
-    autoAddCredentials?: boolean;
-    isInIframe?: boolean;
-    cookieDomain?: string;
-    preAPIHook?: (context: {
-        action: "SIGN_OUT" | "REFRESH_SESSION";
-        requestInit: RequestInit;
-        url: string;
-    }) => Promise<{ url: string; requestInit: RequestInit }>;
-    onHandleEvent?: (event: RecipeEvent) => void;
-    override?: {
-        functions?: (
-            originalImplementation: RecipeInterface,
-            builder?: OverrideableBuilder<RecipeInterface>
-        ) => RecipeInterface;
-    };
+export type InputType = WebJSInputType & {
+    onHandleEvent?: (event: RecipeEventWithSessionContext) => void;
 };
 
 export type SessionContextType = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "react-select": "^5.2.1",
                 "react-shadow": "^19.0.2",
                 "supertokens-js-override": "^0.0.4",
-                "supertokens-web-js": "github:supertokens/supertokens-web-js#0.0"
+                "supertokens-web-js": "github:supertokens/supertokens-web-js#session-types-fix"
             },
             "devDependencies": {
                 "@babel/core": "7.12.1",
@@ -15236,7 +15236,7 @@
         },
         "node_modules/supertokens-web-js": {
             "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#b7a64c6aeb0945c7bbb7a961f771c749fbdaea47",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#3e1982732fbbb9eb70928eee55d9e8fedd1674af",
             "license": "Apache-2.0",
             "dependencies": {
                 "supertokens-js-override": "0.0.4",
@@ -15245,7 +15245,7 @@
         },
         "node_modules/supertokens-website": {
             "version": "11.0.0",
-            "resolved": "git+ssh://git@github.com/supertokens/supertokens-website.git#9d94f8af9a75c03741696a958a1f78d9e1851505",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-website.git#bc67889e33859dc1396d71ed7c2542bd50545558",
             "license": "Apache-2.0",
             "dependencies": {
                 "browser-tabs-lock": "^1.2.14",
@@ -26611,15 +26611,15 @@
             "version": "0.0.4"
         },
         "supertokens-web-js": {
-            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#b7a64c6aeb0945c7bbb7a961f771c749fbdaea47",
-            "from": "supertokens-web-js@github:supertokens/supertokens-web-js#0.0",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#3e1982732fbbb9eb70928eee55d9e8fedd1674af",
+            "from": "supertokens-web-js@github:supertokens/supertokens-web-js#session-types-fix",
             "requires": {
                 "supertokens-js-override": "0.0.4",
                 "supertokens-website": "github:supertokens/supertokens-website#user-context-changes"
             }
         },
         "supertokens-website": {
-            "version": "git+ssh://git@github.com/supertokens/supertokens-website.git#9d94f8af9a75c03741696a958a1f78d9e1851505",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-website.git#bc67889e33859dc1396d71ed7c2542bd50545558",
             "from": "supertokens-website@github:supertokens/supertokens-website#user-context-changes",
             "requires": {
                 "browser-tabs-lock": "^1.2.14",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         },
         {
             "path": "recipe/session/index.js",
-            "limit": "15kb"
+            "limit": "16kb"
         },
         {
             "path": "recipe/thirdpartyemailpassword/index.js",
@@ -117,7 +117,7 @@
         },
         {
             "path": "recipe/emailpassword/index.js",
-            "limit": "105kb"
+            "limit": "106kb"
         },
         {
             "path": "recipe/passwordless/index.js",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "react-select": "^5.2.1",
         "react-shadow": "^19.0.2",
         "supertokens-js-override": "^0.0.4",
-        "supertokens-web-js": "github:supertokens/supertokens-web-js#0.0"
+        "supertokens-web-js": "github:supertokens/supertokens-web-js#session-types-fix"
     },
     "peerDependencies": {
         "react": ">=16.8.0"


### PR DESCRIPTION
## Summary of change
- Uses input types for session recipe from supertokens-web-js instead of redeclaring them

## Related issues
-   https://github.com/supertokens/for-zenhub/issues/28

## Related PRs (These should be merged before this one)
- https://github.com/supertokens/supertokens-web-js/pull/24

## Test Plan

Tests from Github actions should pass

## Documentation changes

None

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Remaining TODOs for this PR

-   [ ] Verify Size Limit
