### PR TITLE
refactor: Rename disableDefaultImplementation to disableDefaultUI in the query params in the testing environment and example apps

### DIFF
--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -221,7 +221,7 @@ let recipeList = [
 ];
 
 const testContext = {
-    disableDefaultUI: getQueryParams("disableDefaultImplementation") === "true",
+    disableDefaultUI: getQueryParams("disableDefaultUI") === "true",
 };
 
 if (authRecipe === "thirdparty") {

--- a/examples/with-sign-in-up-split-emailpassword/src/App.js
+++ b/examples/with-sign-in-up-split-emailpassword/src/App.js
@@ -29,7 +29,7 @@ SuperTokens.init({
     recipeList: [
         EmailPassword.init({
             signInAndUpFeature: {
-                disableDefaultImplementation: true, // this disables showing the default sign in + sign up component
+                disableDefaultUI: true, // this disables showing the default sign in + sign up component
 
                 signInForm: {
                     style: {

--- a/examples/with-thirdparty-2fa-passwordless/README.md
+++ b/examples/with-thirdparty-2fa-passwordless/README.md
@@ -10,7 +10,7 @@ This demo app demonstrates how we can implement sign in with google workspaces a
 -   We initialise Passwordless recipe on the frontend and backend as per its quick setup
 -   To disable sign ups via google workspaces login, we override the `signInUpPOST` API call as shown in `api-server/customSignInUpPOST.js` file.
 -   We override the implementation of `doesSessionExist` on the frontend to return `false` in case the user has not completed both the auth factors. This prevents the user from accessing any protected routes.
--   We disable the UI for passwordless sign up and show it in "/second-factor" route by using the disableDefaultImplementation flag in the Passwordless config
+-   We disable the UI for passwordless sign up and show it in "/second-factor" route by using the disableDefaultUI flag in the Passwordless config
 -   We change the redirection logic for ThirdParty auth to take the user to the /second-factor route after completing sign in with google workspaces. If the user has already completed the second factor too, then we take them to the home page. We do this by providing the getRedirectionURL callback to the ThirdParty recipe on the frontend.
 -   We override the consume code API for passwordless to not create a new session, but instead modify the existing session to add the second factor to it. This will then indicate to the application APIs and routes that the session exists and the user can then use the app.
 -   We change the APIs to use a custom middleware which will check that the access token has both the auth factors in it. If it doesn't then we return a 401, else we allow the API call.

--- a/examples/with-thirdparty-2fa-passwordless/src/App.js
+++ b/examples/with-thirdparty-2fa-passwordless/src/App.js
@@ -54,7 +54,7 @@ SuperTokens.init({
         }),
         Passwordless.init({
             signInUpFeature: {
-                disableDefaultImplementation: true,
+                disableDefaultUI: true,
                 emailOrPhoneFormStyle: {
                     headerTitle: {
                         display: "none",

--- a/test/end-to-end/embed.test.js
+++ b/test/end-to-end/embed.test.js
@@ -59,10 +59,10 @@ describe("Embed components", async () => {
             assert.strictEqual(isFeatureMounted, true);
         });
 
-        it("don't mount SignInAndUp on /auth route if disableDefaultImplementation = true", async () => {
+        it("don't mount SignInAndUp on /auth route if disableDefaultUI = true", async () => {
             const authPage = await AuthPage.navigate(page, {
                 ...testContext,
-                disableDefaultImplementation: true,
+                disableDefaultUI: true,
             });
 
             const isFeatureMounted = await authPage.isFeatureMounted();
@@ -82,10 +82,10 @@ describe("Embed components", async () => {
             assert.strictEqual(isFeatureMounted, true);
         });
 
-        it("don't mount ResetPassword on /auth/reset-password if disableDefaultImplementation = true", async () => {
+        it("don't mount ResetPassword on /auth/reset-password if disableDefaultUI = true", async () => {
             const resetPasswordPage = await ResetPasswordPage.navigate(page, {
                 ...testContext,
-                disableDefaultImplementation: true,
+                disableDefaultUI: true,
             });
 
             const isFeatureMounted = await resetPasswordPage.isFeatureMounted();
@@ -111,7 +111,7 @@ describe("Embed components", async () => {
             assert.strictEqual(isFeatureMounted, true);
         });
 
-        it("don't mount EmailVerification on /auth/verify-email if disableDefaultImplementation = true", async () => {
+        it("don't mount EmailVerification on /auth/verify-email if disableDefaultUI = true", async () => {
             // First, sign in, as we signed up previously
             const authPage = await AuthPage.navigate(page, {
                 ...testContext,
@@ -121,7 +121,7 @@ describe("Embed components", async () => {
 
             const emailVerificationPage = await EmailVerificationPage.navigate(page, {
                 ...testContext,
-                disableDefaultImplementation: true,
+                disableDefaultUI: true,
             });
 
             const isFeatureMounted = await emailVerificationPage.isFeatureMounted();
@@ -143,10 +143,10 @@ describe("Embed components", async () => {
             assert.strictEqual(isFeatureMounted, true);
         });
 
-        it("don't mount supertokens on /auth route if disableDefaultImplementation = true", async () => {
+        it("don't mount supertokens on /auth route if disableDefaultUI = true", async () => {
             const authPage = await AuthPage.navigate(page, {
                 ...testContext,
-                disableDefaultImplementation: true,
+                disableDefaultUI: true,
             });
 
             const isFeatureMounted = await authPage.isFeatureMounted();
@@ -168,10 +168,10 @@ describe("Embed components", async () => {
             assert.strictEqual(isFeatureMounted, true);
         });
 
-        it("don't mount supertokens on /auth route if disableDefaultImplementation = true", async () => {
+        it("don't mount supertokens on /auth route if disableDefaultUI = true", async () => {
             const authPage = await AuthPage.navigate(page, {
                 ...testContext,
-                disableDefaultImplementation: true,
+                disableDefaultUI: true,
             });
 
             const isFeatureMounted = await authPage.isFeatureMounted();

--- a/test/end-to-end/userContext.test.js
+++ b/test/end-to-end/userContext.test.js
@@ -94,15 +94,13 @@ describe("SuperTokens userContext with UI components test", function () {
         await toggleSignInSignUp(page);
         await defaultSignUp(page, "thirdpartyemailpassword");
 
-        await page.goto(
-            `${TEST_CLIENT_BASE_URL}/auth/reset-password?disableDefaultImplementation=true&forUserContext=true`
-        );
+        await page.goto(`${TEST_CLIENT_BASE_URL}/auth/reset-password?disableDefaultUI=true&forUserContext=true`);
 
         await setInputValues(page, [{ name: "email", value: "john.doe@supertokens.io" }]);
         await submitFormReturnRequestAndResponse(page, RESET_PASSWORD_TOKEN_API);
 
         const latestURLWithToken = await getLatestURLWithToken();
-        await page.goto(latestURLWithToken + "&disableDefaultImplementation=true&forUserContext=true");
+        await page.goto(latestURLWithToken + "&disableDefaultUI=true&forUserContext=true");
 
         await setInputValues(page, [
             { name: "password", value: "NEW_Str0ngP@ssw0rd" },
@@ -149,7 +147,7 @@ describe("SuperTokens userContext with UI components test", function () {
         });
 
         await Promise.all([
-            page.goto(`${TEST_CLIENT_BASE_URL}/auth?disableDefaultImplementation=true&forUserContext=true`),
+            page.goto(`${TEST_CLIENT_BASE_URL}/auth?disableDefaultUI=true&forUserContext=true`),
             page.waitForNavigation({ waitUntil: "networkidle0" }),
         ]);
 


### PR DESCRIPTION
## Summary of change
- Use disableDefaultUI in query params during testing
- Use disableDefaultUI in the example apps

## Related issues

-   https://github.com/supertokens/for-zenhub/issues/28

## Test Plan

All existing test cases should pass

## Documentation changes

WIP

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Remaining TODOs for this PR

-   [ ] ...
