### PR TITLE
feat: update session context on ACCESS_TOKEN_PAYLOAD_UPDATED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## [unreleased]
+## [0.21.0] - 2022-05-11
+
+### Changes
+
+-   Now updating the session context when the access token payload is updated
+-   Updated supertokens-webiste dependency to ^11.0.0
+
+### Added
 
 ## [0.20.5] - 2022-05-10
 

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -295,7 +295,14 @@ var Session = /** @class */ (function (_super) {
             return __generator(this, function (_c) {
                 switch (_c.label) {
                     case 0:
-                        if (!(action === "SESSION_CREATED" || action === "REFRESH_SESSION")) return [3 /*break*/, 2];
+                        if (
+                            !(
+                                action === "SESSION_CREATED" ||
+                                action === "REFRESH_SESSION" ||
+                                action === "ACCESS_TOKEN_PAYLOAD_UPDATED"
+                            )
+                        )
+                            return [3 /*break*/, 2];
                         return [4 /*yield*/, Promise.all([this.getUserId(), this.getAccessTokenPayloadSecurely()])];
                     case 1:
                         (_b = _c.sent()), (userId = _b[0]), (accessTokenPayload = _b[1]);

--- a/lib/build/recipe/session/sessionAuth.js
+++ b/lib/build/recipe/session/sessionAuth.js
@@ -287,6 +287,9 @@ var SessionAuth = function (_a) {
                     case "REFRESH_SESSION":
                         setContext(event.sessionContext);
                         return;
+                    case "ACCESS_TOKEN_PAYLOAD_UPDATED":
+                        setContext(event.sessionContext);
+                        return;
                     case "SIGN_OUT":
                         if (props.requireAuth !== true) {
                             setContext(event.sessionContext);

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -2,7 +2,7 @@ import { RecipeInterface } from "supertokens-website";
 import OverrideableBuilder from "supertokens-js-override";
 export declare type RecipeEvent =
     | {
-          action: "SIGN_OUT" | "REFRESH_SESSION" | "SESSION_CREATED";
+          action: "SIGN_OUT" | "REFRESH_SESSION" | "SESSION_CREATED" | "ACCESS_TOKEN_PAYLOAD_UPDATED";
       }
     | {
           action: "UNAUTHORISED";

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,2 +1,2 @@
-export declare const package_version = "0.20.5";
+export declare const package_version = "0.21.0";
 export declare const supported_fdi: string[];

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,5 +14,5 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.package_version = "0.20.5";
+exports.package_version = "0.21.0";
 exports.supported_fdi = ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13"];

--- a/lib/ts/recipe/session/recipe.ts
+++ b/lib/ts/recipe/session/recipe.ts
@@ -114,7 +114,7 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, any
     };
 
     private async getSessionContext({ action }: RecipeEvent): Promise<SessionContextType> {
-        if (action === "SESSION_CREATED" || action === "REFRESH_SESSION") {
+        if (action === "SESSION_CREATED" || action === "REFRESH_SESSION" || action === "ACCESS_TOKEN_PAYLOAD_UPDATED") {
             const [userId, accessTokenPayload] = await Promise.all([
                 this.getUserId(),
                 this.getAccessTokenPayloadSecurely(),

--- a/lib/ts/recipe/session/sessionAuth.tsx
+++ b/lib/ts/recipe/session/sessionAuth.tsx
@@ -126,6 +126,9 @@ const SessionAuth: React.FC<PropsWithChildren<Props>> = ({ children, ...props })
                 case "REFRESH_SESSION":
                     setContext(event.sessionContext);
                     return;
+                case "ACCESS_TOKEN_PAYLOAD_UPDATED":
+                    setContext(event.sessionContext);
+                    return;
                 case "SIGN_OUT":
                     if (props.requireAuth !== true) {
                         setContext(event.sessionContext);

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -18,7 +18,7 @@ import OverrideableBuilder from "supertokens-js-override";
 
 export type RecipeEvent =
     | {
-          action: "SIGN_OUT" | "REFRESH_SESSION" | "SESSION_CREATED";
+          action: "SIGN_OUT" | "REFRESH_SESSION" | "SESSION_CREATED" | "ACCESS_TOKEN_PAYLOAD_UPDATED";
       }
     | {
           action: "UNAUTHORISED";

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,5 +12,5 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.20.5";
+export const package_version = "0.21.0";
 export const supported_fdi = ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.20.5",
+    "version": "0.21.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.20.5",
+            "version": "0.21.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@emotion/react": "^11.4.1",
@@ -18,7 +18,7 @@
                 "react-select": "5.2.1",
                 "react-shadow": "19.0.2",
                 "supertokens-js-override": "^0.0.4",
-                "supertokens-website": "^10.1.0"
+                "supertokens-website": "^11.0.0"
             },
             "devDependencies": {
                 "@babel/core": "7.12.1",
@@ -15235,9 +15235,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/supertokens-website": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-10.1.0.tgz",
-            "integrity": "sha512-otLABiurUiR+inYBj43s3Kn87+EeEMz+OsNYYVWRr5YbgqrsMzxwEuG6+V5NPGUFfe72W6VybKqoeW0EUaUYPA==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-11.0.0.tgz",
+            "integrity": "sha512-DzuPGQuw34/8iZtk8P6D8HTeTeoAFBQ4IV4iJvpzgIbbxHmSPE+rDV6smyhzdgI1Z9BoQkBHTYvOSDGJrIQfAg==",
             "dependencies": {
                 "browser-tabs-lock": "^1.2.14",
                 "supertokens-js-override": "^0.0.4"
@@ -26602,9 +26602,9 @@
             "version": "0.0.4"
         },
         "supertokens-website": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-10.1.0.tgz",
-            "integrity": "sha512-otLABiurUiR+inYBj43s3Kn87+EeEMz+OsNYYVWRr5YbgqrsMzxwEuG6+V5NPGUFfe72W6VybKqoeW0EUaUYPA==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-11.0.0.tgz",
+            "integrity": "sha512-DzuPGQuw34/8iZtk8P6D8HTeTeoAFBQ4IV4iJvpzgIbbxHmSPE+rDV6smyhzdgI1Z9BoQkBHTYvOSDGJrIQfAg==",
             "requires": {
                 "browser-tabs-lock": "^1.2.14",
                 "supertokens-js-override": "^0.0.4"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         },
         {
             "path": "recipe/session/index.js",
-            "limit": "15kb"
+            "limit": "17kb"
         },
         {
             "path": "recipe/thirdpartyemailpassword/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.20.5",
+    "version": "0.21.0",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {
@@ -68,7 +68,7 @@
         "react-select": "5.2.1",
         "react-shadow": "19.0.2",
         "supertokens-js-override": "^0.0.4",
-        "supertokens-website": "^10.1.0"
+        "supertokens-website": "^11.0.0"
     },
     "peerDependencies": {
         "react": ">=16.8.0"

--- a/test/unit/recipe/session/sessionAuth.test.tsx
+++ b/test/unit/recipe/session/sessionAuth.test.tsx
@@ -247,6 +247,46 @@ describe("SessionAuth", () => {
         });
     });
 
+    test("update context on ACCESS_TOKEN_PAYLOAD_UPDATED", async () => {
+        // given
+        let listenerFn: (event: any) => void;
+        MockSession.addEventListener.mockImplementationOnce((fn) => {
+            listenerFn = fn;
+
+            return () => {};
+        });
+
+        const result = render(
+            <SessionAuth>
+                <MockSessionConsumer />
+            </SessionAuth>
+        );
+
+        expect(await result.findByText(/^accessTokenPayload:/)).toHaveTextContent(
+            `accessTokenPayload: ${JSON.stringify({})}`
+        );
+
+        const mockAccessTokenPayload = {
+            afterRefreshKey: "afterRefreshValue",
+        };
+
+        // when
+        act(() =>
+            listenerFn({
+                action: "ACCESS_TOKEN_PAYLOAD_UPDATED",
+                sessionContext: {
+                    doesSessionExist: true,
+                    userId: "mock-user-id",
+                    accessTokenPayload: mockAccessTokenPayload,
+                },
+            })
+        );
+        // then
+        expect(await result.findByText(/^accessTokenPayload:/)).toHaveTextContent(
+            `accessTokenPayload: ${JSON.stringify(mockAccessTokenPayload)}`
+        );
+    });
+
     describe("onSessionExpired", () => {
         test("not update context when prop is passed", async () => {
             // given

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -166,6 +166,7 @@ function getRecipeList() {
                 } else if (context.action === "UNAUTHORISED") {
                     if (context.sessionExpiredOrRevoked) {
                     }
+                } else if (context.action === "ACCESS_TOKEN_PAYLOAD_UPDATED") {
                 }
             },
             preAPIHook: async (context) => {


### PR DESCRIPTION
## Summary of change

Update session context when getting an `ACCESS_TOKEN_PAYLOAD_UPDATED` event

## Related issues

-   #397 
-   supertokens/supertokens-website#121 

## Test Plan

Added unit test

## Documentation changes

supertokens/docs#324

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Remaining TODOs for this PR

-   [ ] Docs
