### PR TITLE
fix: remove accidental import

### DIFF
--- a/lib/build/recipe/session/sessionAuth.js
+++ b/lib/build/recipe/session/sessionAuth.js
@@ -177,7 +177,6 @@ var react_1 = __importStar(require("react"));
 var sessionContext_1 = __importStar(require("./sessionContext"));
 var recipe_1 = __importDefault(require("./recipe"));
 var utils_1 = require("../../utils");
-var path_1 = require("path");
 // if it's not the default context, it means SessionAuth from top has
 // given us a sessionContext.
 var hasParentProvider = function (ctx) {
@@ -257,7 +256,7 @@ var SessionAuth = function (_a) {
                 });
             });
         },
-        [path_1.toNamespacedPath, props]
+        [props]
     );
     utils_1.useOnMountAPICall(buildContext, setInitialContextAndMaybeRedirect);
     // subscribe to events on mount

--- a/lib/ts/recipe/session/sessionAuth.tsx
+++ b/lib/ts/recipe/session/sessionAuth.tsx
@@ -21,7 +21,6 @@ import SessionContext, { isDefaultContext } from "./sessionContext";
 import Session from "./recipe";
 import { RecipeEventWithSessionContext, SessionContextType } from "./types";
 import { useOnMountAPICall } from "../../utils";
-import { toNamespacedPath } from "path";
 
 // if it's not the default context, it means SessionAuth from top has
 // given us a sessionContext.
@@ -100,7 +99,7 @@ const SessionAuth: React.FC<PropsWithChildren<Props>> = ({ children, ...props })
                 }
             }
         },
-        [toNamespacedPath, props]
+        [props]
     );
 
     useOnMountAPICall(buildContext, setInitialContextAndMaybeRedirect);


### PR DESCRIPTION
## Summary of change

Remove an import I added by mistake

## Related issues


## Test Plan

N/A

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
