### PR TITLE
fix(examples, with-localstorage): update headers on the response obje…

### DIFF
--- a/examples/with-localstorage/api-server.js
+++ b/examples/with-localstorage/api-server.js
@@ -56,7 +56,7 @@ supertokens.init({
                             const session = await origImpl.createNewSession(input);
 
                             // We need to copy the Set-Cookies header into the custom header in the response.
-                            updateHeaders(session.res);
+                            updateHeaders(input.res);
 
                             return session;
                         },

--- a/examples/with-localstorage/api-server.js
+++ b/examples/with-localstorage/api-server.js
@@ -75,7 +75,7 @@ supertokens.init({
                             const session = await origImpl.refreshSession(input);
 
                             // We need to copy the Set-Cookies header into the custom header in the response.
-                            updateHeaders(session.res);
+                            updateHeaders(input.res);
 
                             return session;
                         },


### PR DESCRIPTION
## Summary of change

The `getSession` overwrite errors out as the input parameter for updating the headers is wrong.

This PR fixes this by passing the response object as the parameter instead of the session.

## Related issues

![image](https://user-images.githubusercontent.com/18185649/169548555-74c4395d-a07a-496b-8d51-1cc3962e8062.png)

## Test Plan

This seems to be untested