### PR TITLE
Adds a back button to reset password form in emailpassword and thirdpartyemailpassword recipes

### DIFF
--- a/lib/ts/components/assets/heavyArrowLeftIcon.tsx
+++ b/lib/ts/components/assets/heavyArrowLeftIcon.tsx
@@ -1,0 +1,36 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Imports.
+ */
+
+/** @jsx jsx */
+import { jsx } from "@emotion/react";
+
+/*
+ * Component.
+ */
+
+export default function HeavyArrowLeftIcon({ color }: { color: string }): JSX.Element {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="15.743" height="13.076" viewBox="0 0 15.743 13.076">
+            <path
+                fill={color}
+                d="m14.858 7.773.025-.005H4.348l3.312 3.318a.87.87 0 0 1 0 1.223l-.515.516a.862.862 0 0 1-1.217 0L.251 7.149a.868.868 0 0 1 0-1.221L5.928.251a.863.863 0 0 1 1.217 0l.515.516a.853.853 0 0 1 .251.608.827.827 0 0 1-.251.6L4.311 5.309H14.87a.892.892 0 0 1 .873.883v.729a.875.875 0 0 1-.885.852z"
+            />
+        </svg>
+    );
+}

--- a/lib/ts/recipe/emailpassword/components/features/resetPasswordUsingToken/index.tsx
+++ b/lib/ts/recipe/emailpassword/components/features/resetPasswordUsingToken/index.tsx
@@ -79,7 +79,12 @@ class ResetPasswordUsingToken extends PureComponent<
                       token: this.state.token,
                   };
 
+        const handleBackButtonClick = (): void => {
+            void this.props.recipe.redirectToAuthWithoutRedirectToPath("signin", this.props.history);
+        };
+
         const enterEmailForm = {
+            handleBackButtonClick,
             error: this.state.error,
             onError: (error: string) => this.setState((os) => ({ ...os, error })),
             clearError: () => this.setState((os) => ({ ...os, error: undefined })),

--- a/lib/ts/recipe/emailpassword/components/library/backButton.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/backButton.tsx
@@ -1,0 +1,47 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Imports.
+ */
+
+/** @jsx jsx */
+import { jsx } from "@emotion/react";
+
+import { useContext } from "react";
+import StyleContext from "../../../../styles/styleContext";
+import HeavyArrowLeftIcon from "../../../../components/assets/heavyArrowLeftIcon";
+
+/*
+ * Props.
+ */
+
+type ButtonProps = {
+    onClick?: () => void;
+};
+
+/*
+ * Component.
+ */
+
+export default function BackButton({ onClick }: ButtonProps): JSX.Element {
+    const styles = useContext(StyleContext);
+
+    return (
+        <button onClick={onClick} css={styles.backButton} data-supertokens="backButton">
+            <HeavyArrowLeftIcon color={styles.palette.colors.textTitle} />
+        </button>
+    );
+}

--- a/lib/ts/recipe/emailpassword/components/themes/resetPasswordUsingToken/resetPasswordEmail.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/resetPasswordUsingToken/resetPasswordEmail.tsx
@@ -23,6 +23,7 @@ import FormBase from "../../library/formBase";
 import { withOverride } from "../../../../../components/componentOverride/withOverride";
 import { useTranslation } from "../../../../../translation/translationContext";
 import GeneralError from "../../library/generalError";
+import BackButton from "../../library/backButton";
 
 const EmailPasswordResetPasswordEmail: React.FC<EnterEmailProps> = (props) => {
     const styles = useContext(StyleContext);
@@ -60,6 +61,7 @@ const EmailPasswordResetPasswordEmail: React.FC<EnterEmailProps> = (props) => {
         <div data-supertokens="container" css={styles.container}>
             <div data-supertokens="row" css={styles.row}>
                 <div data-supertokens="headerTitle" css={styles.headerTitle}>
+                    <BackButton onClick={props.handleBackButtonClick} />
                     {t("EMAIL_PASSWORD_RESET_HEADER_TITLE")}
                 </div>
                 <div data-supertokens="headerSubtitle" css={styles.headerSubtitle}>

--- a/lib/ts/recipe/emailpassword/components/themes/styles/styles.ts
+++ b/lib/ts/recipe/emailpassword/components/themes/styles/styles.ts
@@ -181,6 +181,25 @@ export function getStyles(palette: NormalisedPalette): NormalisedDefaultStyles {
             maxWidth: "96px",
             margin: "0 auto",
         },
+
+        headerTitle: {
+            position: "relative",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+        },
+
+        backButton: {
+            cursor: "pointer",
+            display: "inline-block",
+            border: "none",
+            backgroundColor: "transparent",
+            width: "15.7px",
+            height: "13.1px",
+            padding: "0px",
+            position: "absolute",
+            left: "0px",
+        },
     } as NormalisedDefaultStyles;
     return getMergedStyles(baseStyles, recipeStyles);
 }

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -363,6 +363,7 @@ export type EnterEmailProps = FormThemeBaseProps & {
     onError: (error: string) => void;
     recipeImplementation: RecipeInterface;
     config: NormalisedConfig;
+    handleBackButtonClick: () => void;
 };
 
 export type SubmitNewPasswordProps = FormThemeBaseProps & {

--- a/test/end-to-end/emailpassword.test.js
+++ b/test/end-to-end/emailpassword.test.js
@@ -1,0 +1,130 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Imports
+ */
+
+/* https://github.com/babel/babel/issues/9849#issuecomment-487040428 */
+import regeneratorRuntime from "regenerator-runtime";
+import assert from "assert";
+import fetch from "isomorphic-fetch";
+import puppeteer from "puppeteer";
+import {
+    clearBrowserCookiesWithoutAffectingConsole,
+    assertProviders,
+    clickOnProviderButton,
+    defaultSignUp,
+    getUserIdWithFetch,
+    getLogoutButton,
+    signUp,
+    toggleSignInSignUp,
+    loginWithAuth0,
+    getLoginWithRedirectToSignIn,
+    getLoginWithRedirectToSignUp,
+    getAuthPageHeaderText,
+    screenshotOnFailure,
+    clickForgotPasswordLink,
+    getResetPasswordFormBackButton,
+    getResetPasswordFormBackButtonDelete,
+    waitForSTElement,
+} from "../helpers";
+import { TEST_CLIENT_BASE_URL, TEST_SERVER_BASE_URL, SIGN_IN_UP_API } from "../constants";
+
+// Run the tests in a DOM environment.
+require("jsdom-global")();
+
+/*
+ * Tests.
+ */
+describe("SuperTokens Email Password", function () {
+    let browser;
+    let page;
+    let consoleLogs;
+
+    before(async function () {
+        await fetch(`${TEST_SERVER_BASE_URL}/beforeeach`, {
+            method: "POST",
+        }).catch(console.error);
+
+        await fetch(`${TEST_SERVER_BASE_URL}/startst`, {
+            method: "POST",
+        }).catch(console.error);
+
+        browser = await puppeteer.launch({
+            args: ["--no-sandbox", "--disable-setuid-sandbox"],
+            headless: true,
+        });
+        page = await browser.newPage();
+        page.on("console", (consoleObj) => {
+            const log = consoleObj.text();
+            if (log.startsWith("ST_LOGS")) {
+                consoleLogs.push(log);
+            }
+        });
+    });
+
+    after(async function () {
+        await browser.close();
+        await fetch(`${TEST_SERVER_BASE_URL}/after`, {
+            method: "POST",
+        }).catch(console.error);
+
+        await fetch(`${TEST_SERVER_BASE_URL}/stop`, {
+            method: "POST",
+        }).catch(console.error);
+    });
+
+    afterEach(function () {
+        return screenshotOnFailure(this, browser);
+    });
+
+    beforeEach(async function () {
+        consoleLogs = [];
+        consoleLogs = await clearBrowserCookiesWithoutAffectingConsole(page, consoleLogs);
+        await Promise.all([
+            page.goto(`${TEST_CLIENT_BASE_URL}/auth?authRecipe=emailpassword`),
+            page.waitForNavigation({ waitUntil: "networkidle0" }),
+        ]);
+    });
+
+    describe("Email Password Reset Password form back button tests", function () {
+        it("successfully redirects to Sign In screen when back button is clicked", async function () {
+            await clickForgotPasswordLink(page);
+
+            await waitForSTElement(page);
+            const pathBeforeBackButtonClick = await page.evaluate(() => window.location.pathname);
+
+            assert.equal(pathBeforeBackButtonClick, "/auth/reset-password");
+
+            const backButton = await getResetPasswordFormBackButton(page);
+
+            // assert that the back button exists
+            assert.notEqual(backButton, null);
+            assert.notEqual(backButton, undefined);
+
+            await backButton.click();
+
+            await waitForSTElement(page);
+            const pathAfterBackButtonClick = await page.evaluate(() => window.location.pathname);
+
+            assert.equal(pathAfterBackButtonClick, "/auth");
+
+            const pageTitle = await getAuthPageHeaderText(page);
+
+            assert.equal(pageTitle, "Sign In");
+        });
+    });
+});

--- a/test/end-to-end/emailpassword.test.js
+++ b/test/end-to-end/emailpassword.test.js
@@ -24,24 +24,13 @@ import fetch from "isomorphic-fetch";
 import puppeteer from "puppeteer";
 import {
     clearBrowserCookiesWithoutAffectingConsole,
-    assertProviders,
-    clickOnProviderButton,
-    defaultSignUp,
-    getUserIdWithFetch,
-    getLogoutButton,
-    signUp,
-    toggleSignInSignUp,
-    loginWithAuth0,
-    getLoginWithRedirectToSignIn,
-    getLoginWithRedirectToSignUp,
     getAuthPageHeaderText,
     screenshotOnFailure,
     clickForgotPasswordLink,
     getResetPasswordFormBackButton,
-    getResetPasswordFormBackButtonDelete,
     waitForSTElement,
 } from "../helpers";
-import { TEST_CLIENT_BASE_URL, TEST_SERVER_BASE_URL, SIGN_IN_UP_API } from "../constants";
+import { TEST_CLIENT_BASE_URL, TEST_SERVER_BASE_URL } from "../constants";
 
 // Run the tests in a DOM environment.
 require("jsdom-global")();
@@ -100,8 +89,8 @@ describe("SuperTokens Email Password", function () {
         ]);
     });
 
-    describe("Email Password Reset Password form back button tests", function () {
-        it("successfully redirects to Sign In screen when back button is clicked", async function () {
+    describe("Reset Password form back button", function () {
+        it("Successfully redirects to Sign In screen when back button is clicked", async function () {
             await clickForgotPasswordLink(page);
 
             await waitForSTElement(page);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -690,3 +690,9 @@ export function setPasswordlessFlowType(contactMethod, flowType) {
 export function isReact16() {
     return process.env.IS_REACT_16 === "true";
 }
+
+export async function getResetPasswordFormBackButton(page) {
+    const backButtonSelector = "[data-supertokens='headerTitle'] > [data-supertokens='backButton']";
+
+    return await waitForSTElement(page, backButtonSelector);
+}


### PR DESCRIPTION
## Summary of change
- This PR adds a back button to the reset password form, which takes the user to sign in screen when clicked.

## Related issues
- #480

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
