### PR TITLE
ci: adds new e2e test for resend code in passwordless recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.22.1] - 2022-06-11
+
 -   Updates the example app for ThirdPartyEmailPassword + Passwordless login with SuperTokens
+-   Adds new tests for testing resend code button in passwordless recipe
 
 ### CI changes
 

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.22.0";
+export declare const package_version = "0.22.1";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -14,4 +14,4 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.package_version = "0.22.0";
+exports.package_version = "0.22.1";

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.22.0";
+export const package_version = "0.22.1";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.22.0",
+    "version": "0.22.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.22.0",
+            "version": "0.22.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@emotion/react": "^11.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.22.0",
+    "version": "0.22.1",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -147,6 +147,11 @@ export async function submitForm(page) {
     await submitButton.click();
 }
 
+export async function clickOnPasswordlessResendButton(page) {
+    const resendButton = await waitForSTElement(page, "[data-supertokens='link linkButton resendCodeBtn']");
+    resendButton.click();
+}
+
 export async function getLogoutButton(page) {
     return await page.waitForSelector(".logoutButton");
 }


### PR DESCRIPTION
## Summary of change

See title

## Related issues

-   https://github.com/supertokens/supertokens-auth-react/issues/490

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
