### PR TITLE
feat: added loading to session state + made auth wrapper to be SSR compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
-### Changes
+### Added
 
--   Added `loading` to the session context
 -   Added `SuperTokensWrapper` intended to wrap around whole applications, providing a session context
+
+### Changed
+
 -   Made auth wrappers SSR compatible
+
+### Breaking changes
+
+-   Added `loading` to the session context. Please check if the session context is still loading before using other props. `loading` is always true inside components wrapped by `AuthWrapper`s with `requireAuth=true`
+-   Rendering components wrapped by `AuthWrappers` while loading if `requireAuth` is set to false.
 
 ## [0.23.1] - 2022-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changes
+
+-   Added `loading` to the session context
+-   Added `SuperTokensWrapper` intended to wrap around whole applications, providing a session context
+-   Made auth wrappers SSR compatible
+
 ## [0.23.1] - 2022-06-25
 
 -   [CI]: Changes dependency for node SDK in integration tests so that tests pass when using node 14

--- a/lib/build/components/supertokensWrapper.d.ts
+++ b/lib/build/components/supertokensWrapper.d.ts
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from "react";
-import { SessionAuthProps } from "./sessionAuth";
+import { SessionAuthProps } from "../recipe/session/sessionAuth";
 export declare const SuperTokensWrapper: React.FC<
     PropsWithChildren<
         SessionAuthProps & {

--- a/lib/build/components/supertokensWrapper.js
+++ b/lib/build/components/supertokensWrapper.js
@@ -21,8 +21,8 @@ var __importDefault =
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SuperTokensWrapper = void 0;
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
-var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
-var sessionAuth_1 = __importDefault(require("./sessionAuth"));
+var userContextWrapper_1 = __importDefault(require("../usercontext/userContextWrapper"));
+var sessionAuth_1 = __importDefault(require("../recipe/session/sessionAuth"));
 var SuperTokensWrapper = function (props) {
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,

--- a/lib/build/index.d.ts
+++ b/lib/build/index.d.ts
@@ -3,6 +3,13 @@ import SuperTokens from "./superTokens";
 import { TranslationStore } from "./translation/translationHelpers";
 import { SuperTokensConfig } from "./types";
 export default class SuperTokensAPIWrapper {
+    static SuperTokensWrapper: import("react").FC<
+        import("react").PropsWithChildren<
+            import("./recipe/session/sessionAuth").SessionAuthProps & {
+                userContext?: any;
+            }
+        >
+    >;
     static init(config: SuperTokensConfig): void;
     static canHandleRoute(): boolean;
     static getRoutingComponent(): JSX.Element | null;
@@ -18,5 +25,6 @@ export declare const changeLanguage: typeof SuperTokensAPIWrapper.changeLanguage
 export declare const loadTranslation: typeof SuperTokensAPIWrapper.loadTranslation;
 export declare const getRoutingComponent: typeof SuperTokensAPIWrapper.getRoutingComponent;
 export declare const getSuperTokensRoutesForReactRouterDom: typeof SuperTokens.getSuperTokensRoutesForReactRouterDom;
+export { SuperTokensWrapper } from "./components/supertokensWrapper";
 export { useTranslation } from "./translation/translationContext";
 export { useUserContext } from "./usercontext";

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -21,6 +21,7 @@ var __importDefault =
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.useUserContext =
     exports.useTranslation =
+    exports.SuperTokensWrapper =
     exports.getSuperTokensRoutesForReactRouterDom =
     exports.getRoutingComponent =
     exports.loadTranslation =
@@ -34,6 +35,7 @@ exports.useUserContext =
 var translationContext_1 = require("./translation/translationContext");
 var superTokens_1 = __importDefault(require("./superTokens"));
 var usercontext_1 = require("./usercontext");
+var supertokensWrapper_1 = require("./components/supertokensWrapper");
 /*
  * API Wrapper exposed to user.
  */
@@ -57,6 +59,7 @@ var SuperTokensAPIWrapper = /** @class */ (function () {
     SuperTokensAPIWrapper.getSuperTokensRoutesForReactRouterDom = function (reactRouterDom) {
         return superTokens_1.default.getSuperTokensRoutesForReactRouterDom(reactRouterDom);
     };
+    SuperTokensAPIWrapper.SuperTokensWrapper = supertokensWrapper_1.SuperTokensWrapper;
     SuperTokensAPIWrapper.useTranslation = translationContext_1.useTranslation;
     SuperTokensAPIWrapper.useUserContext = usercontext_1.useUserContext;
     return SuperTokensAPIWrapper;
@@ -68,6 +71,13 @@ exports.changeLanguage = SuperTokensAPIWrapper.changeLanguage;
 exports.loadTranslation = SuperTokensAPIWrapper.loadTranslation;
 exports.getRoutingComponent = SuperTokensAPIWrapper.getRoutingComponent;
 exports.getSuperTokensRoutesForReactRouterDom = superTokens_1.default.getSuperTokensRoutesForReactRouterDom;
+var supertokensWrapper_2 = require("./components/supertokensWrapper");
+Object.defineProperty(exports, "SuperTokensWrapper", {
+    enumerable: true,
+    get: function () {
+        return supertokensWrapper_2.SuperTokensWrapper;
+    },
+});
 var translationContext_2 = require("./translation/translationContext");
 Object.defineProperty(exports, "useTranslation", {
     enumerable: true,

--- a/lib/build/recipe/authRecipe/authWidgetWrapper.js
+++ b/lib/build/recipe/authRecipe/authWidgetWrapper.js
@@ -50,34 +50,36 @@ var Redirector = function (props) {
     var _a = (0, react_1.useState)(false),
         alwaysShow = _a[0],
         updateAlwaysShow = _a[1];
-    (0, react_1.useEffect)(function () {
-        // we want to do this just once, so we supply it an empty array.
-        // if we supply it with props, sessionContext,
-        // then once the user signs in, then this will route the
-        // user to the dashboard, as opposed to the sign up / sign in functions.
-        if (sessionContext.doesSessionExist) {
-            if (props.onSessionAlreadyExists !== undefined) {
-                props.onSessionAlreadyExists();
+    (0, react_1.useEffect)(
+        function () {
+            // we want to do this just once, so we supply it with only the loading statet.
+            // if we supply it with props, sessionContext, then once the user signs in, then this will route the
+            // user to the dashboard, as opposed to the sign up / sign in functions.
+            if (sessionContext.loading === false && sessionContext.doesSessionExist) {
+                if (props.onSessionAlreadyExists !== undefined) {
+                    props.onSessionAlreadyExists();
+                } else {
+                    props.authRecipe.config.onHandleEvent({
+                        action: "SESSION_ALREADY_EXISTS",
+                    });
+                    void props.authRecipe.redirect(
+                        {
+                            action: "SUCCESS",
+                            isNewUser: false,
+                            redirectToPath: (0, utils_1.getRedirectToPathFromURL)(),
+                        },
+                        props.history
+                    );
+                }
             } else {
-                props.authRecipe.config.onHandleEvent({
-                    action: "SESSION_ALREADY_EXISTS",
-                });
-                void props.authRecipe.redirect(
-                    {
-                        action: "SUCCESS",
-                        isNewUser: false,
-                        redirectToPath: (0, utils_1.getRedirectToPathFromURL)(),
-                    },
-                    props.history
-                );
+                // this means even if a session exists, we will still show the children
+                // cause the child component will take care of redirecting etc..
+                updateAlwaysShow(true);
             }
-        } else {
-            // this means even if a session exists, we will still show the children
-            // cause the child component will take care of redirecting etc..
-            updateAlwaysShow(true);
-        }
-    }, []);
-    if (sessionContext.doesSessionExist && !alwaysShow) {
+        },
+        [sessionContext.loading]
+    );
+    if ((sessionContext.loading === true || sessionContext.doesSessionExist) && !alwaysShow) {
         return null;
     } else {
         return (0, jsx_runtime_1.jsx)(jsx_runtime_1.Fragment, { children: props.children });

--- a/lib/build/recipe/authRecipe/authWidgetWrapper.js
+++ b/lib/build/recipe/authRecipe/authWidgetWrapper.js
@@ -52,29 +52,31 @@ var Redirector = function (props) {
         updateAlwaysShow = _a[1];
     (0, react_1.useEffect)(
         function () {
-            // we want to do this just once, so we supply it with only the loading statet.
+            // we want to do this just once, so we supply it with only the loading state.
             // if we supply it with props, sessionContext, then once the user signs in, then this will route the
             // user to the dashboard, as opposed to the sign up / sign in functions.
-            if (sessionContext.loading === false && sessionContext.doesSessionExist) {
-                if (props.onSessionAlreadyExists !== undefined) {
-                    props.onSessionAlreadyExists();
+            if (sessionContext.loading === false) {
+                if (sessionContext.doesSessionExist) {
+                    if (props.onSessionAlreadyExists !== undefined) {
+                        props.onSessionAlreadyExists();
+                    } else {
+                        props.authRecipe.config.onHandleEvent({
+                            action: "SESSION_ALREADY_EXISTS",
+                        });
+                        void props.authRecipe.redirect(
+                            {
+                                action: "SUCCESS",
+                                isNewUser: false,
+                                redirectToPath: (0, utils_1.getRedirectToPathFromURL)(),
+                            },
+                            props.history
+                        );
+                    }
                 } else {
-                    props.authRecipe.config.onHandleEvent({
-                        action: "SESSION_ALREADY_EXISTS",
-                    });
-                    void props.authRecipe.redirect(
-                        {
-                            action: "SUCCESS",
-                            isNewUser: false,
-                            redirectToPath: (0, utils_1.getRedirectToPathFromURL)(),
-                        },
-                        props.history
-                    );
+                    // this means even if a session exists, we will still show the children
+                    // cause the child component will take care of redirecting etc..
+                    updateAlwaysShow(true);
                 }
-            } else {
-                // this means even if a session exists, we will still show the children
-                // cause the child component will take care of redirecting etc..
-                updateAlwaysShow(true);
             }
         },
         [sessionContext.loading]

--- a/lib/build/recipe/emailpassword/emailPasswordAuth.js
+++ b/lib/build/recipe/emailpassword/emailPasswordAuth.js
@@ -29,7 +29,15 @@ var userContextWrapper_1 = __importDefault(require("../../usercontext/userContex
 function EmailPasswordAuth(props) {
     var emailVerification = (0, jsx_runtime_1.jsx)(
         emailVerificationAuth_1.default,
-        __assign({ recipe: props.recipe.emailVerification, history: props.history }, { children: props.children })
+        __assign(
+            {
+                getRecipe: function () {
+                    return recipe_1.default.getInstanceOrThrow().emailVerification;
+                },
+                history: props.history,
+            },
+            { children: props.children }
+        )
     );
     if (props.requireAuth === false) {
         return (0, jsx_runtime_1.jsx)(
@@ -59,7 +67,7 @@ var EmailPasswordAuthWrapper = function (_a) {
         requireAuth = _a.requireAuth,
         onSessionExpired = _a.onSessionExpired,
         userContext = _a.userContext;
-    var routerInfo = superTokens_1.default.getInstanceOrThrow().getReactRouterDomWithCustomHistory();
+    var routerInfo = superTokens_1.default.getReactRouterDomWithCustomHistory();
     var history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
@@ -69,12 +77,7 @@ var EmailPasswordAuthWrapper = function (_a) {
                 children: (0, jsx_runtime_1.jsx)(
                     EmailPasswordAuthMemo,
                     __assign(
-                        {
-                            history: history,
-                            onSessionExpired: onSessionExpired,
-                            requireAuth: requireAuth,
-                            recipe: recipe_1.default.getInstanceOrThrow(),
-                        },
+                        { history: history, onSessionExpired: onSessionExpired, requireAuth: requireAuth },
                         { children: children }
                     )
                 ),

--- a/lib/build/recipe/emailverification/components/features/emailVerification/index.js
+++ b/lib/build/recipe/emailverification/components/features/emailVerification/index.js
@@ -258,7 +258,7 @@ var EmailVerification = function (props) {
                             token =
                                 (_a = (0, utils_1.getQueryParams)("token")) !== null && _a !== void 0 ? _a : undefined;
                             if (!(token === undefined)) return [3 /*break*/, 4];
-                            if (!(sessionContext.loading === true || !sessionContext.doesSessionExist))
+                            if (!(sessionContext.loading === false && !sessionContext.doesSessionExist))
                                 return [3 /*break*/, 2];
                             return [4 /*yield*/, props.recipe.config.redirectToSignIn(props.history)];
                         case 1:
@@ -275,7 +275,7 @@ var EmailVerification = function (props) {
                 });
             });
         },
-        [props.recipe]
+        [props.recipe, sessionContext]
     );
     var checkIsEmailVerified = (0, react_1.useCallback)(
         function (isVerified) {
@@ -291,7 +291,12 @@ var EmailVerification = function (props) {
         },
         [props.recipe, setStatus]
     );
-    (0, utils_1.useOnMountAPICall)(fetchIsEmailVerified, checkIsEmailVerified);
+    (0, utils_1.useOnMountAPICall)(
+        fetchIsEmailVerified,
+        checkIsEmailVerified,
+        undefined,
+        sessionContext.loading === false
+    );
     var signOut = (0, react_1.useCallback)(
         function () {
             return __awaiter(void 0, void 0, void 0, function () {

--- a/lib/build/recipe/emailverification/components/features/emailVerification/index.js
+++ b/lib/build/recipe/emailverification/components/features/emailVerification/index.js
@@ -258,7 +258,8 @@ var EmailVerification = function (props) {
                             token =
                                 (_a = (0, utils_1.getQueryParams)("token")) !== null && _a !== void 0 ? _a : undefined;
                             if (!(token === undefined)) return [3 /*break*/, 4];
-                            if (!!sessionContext.doesSessionExist) return [3 /*break*/, 2];
+                            if (!(sessionContext.loading === true || !sessionContext.doesSessionExist))
+                                return [3 /*break*/, 2];
                             return [4 /*yield*/, props.recipe.config.redirectToSignIn(props.history)];
                         case 1:
                             _b.sent();

--- a/lib/build/recipe/emailverification/components/features/emailVerification/index.js
+++ b/lib/build/recipe/emailverification/components/features/emailVerification/index.js
@@ -255,11 +255,14 @@ var EmailVerification = function (props) {
                 return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
+                            if (sessionContext.loading === true) {
+                                // This callback should only be called if
+                                throw new Error("Should never come here");
+                            }
                             token =
                                 (_a = (0, utils_1.getQueryParams)("token")) !== null && _a !== void 0 ? _a : undefined;
                             if (!(token === undefined)) return [3 /*break*/, 4];
-                            if (!(sessionContext.loading === false && !sessionContext.doesSessionExist))
-                                return [3 /*break*/, 2];
+                            if (!!sessionContext.doesSessionExist) return [3 /*break*/, 2];
                             return [4 /*yield*/, props.recipe.config.redirectToSignIn(props.history)];
                         case 1:
                             _b.sent();

--- a/lib/build/recipe/emailverification/components/features/emailVerification/index.js
+++ b/lib/build/recipe/emailverification/components/features/emailVerification/index.js
@@ -256,7 +256,7 @@ var EmailVerification = function (props) {
                     switch (_b.label) {
                         case 0:
                             if (sessionContext.loading === true) {
-                                // This callback should only be called if
+                                // This callback should only be called if the session is already loaded
                                 throw new Error("Should never come here");
                             }
                             token =

--- a/lib/build/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.js
+++ b/lib/build/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.js
@@ -185,7 +185,7 @@ var useSessionContext_1 = __importDefault(require("../../../../session/useSessio
 var EmailVerificationVerifyEmailLinkClicked = function (props) {
     var styles = (0, react_1.useContext)(styleContext_1.default);
     var t = (0, translationContext_1.useTranslation)();
-    var doesSessionExist = (0, useSessionContext_1.default)().doesSessionExist;
+    var sessionContext = (0, useSessionContext_1.default)();
     var userContext = (0, usercontext_1.useUserContext)();
     var _a = (0, react_1.useState)("LOADING"),
         status = _a[0],
@@ -203,7 +203,7 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
                     // If there is no active session we know that the verification was started elsewhere, since it requires a session
                     // otherwise we assume it's the same session. The main purpose of this is to prevent mail scanners
                     // from accidentally validating an email address
-                    if (!doesSessionExist) {
+                    if (sessionContext.loading === false && sessionContext.doesSessionExist) {
                         return [2 /*return*/, "INTERACTION_REQUIRED"];
                     }
                     return [

--- a/lib/build/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.js
+++ b/lib/build/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.js
@@ -203,7 +203,7 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
                     // If there is no active session we know that the verification was started elsewhere, since it requires a session
                     // otherwise we assume it's the same session. The main purpose of this is to prevent mail scanners
                     // from accidentally validating an email address
-                    if (sessionContext.loading === false && sessionContext.doesSessionExist) {
+                    if (sessionContext.loading === false && !sessionContext.doesSessionExist) {
                         return [2 /*return*/, "INTERACTION_REQUIRED"];
                     }
                     return [
@@ -215,7 +215,7 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
                 });
             });
         },
-        [props.recipeImplementation]
+        [props.recipeImplementation, sessionContext]
     );
     var handleVerifyResp = (0, react_1.useCallback)(
         function (response) {
@@ -243,7 +243,7 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
         },
         [setStatus, setErrorMessage]
     );
-    (0, utils_1.useOnMountAPICall)(verifyEmailOnMount, handleVerifyResp, handleError);
+    (0, utils_1.useOnMountAPICall)(verifyEmailOnMount, handleVerifyResp, handleError, sessionContext.loading === false);
     var onTokenInvalidRedirect = props.onTokenInvalidRedirect,
         onSuccess = props.onSuccess;
     if (status === "LOADING") {

--- a/lib/build/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.js
+++ b/lib/build/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.js
@@ -200,10 +200,14 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
         function () {
             return __awaiter(void 0, void 0, void 0, function () {
                 return __generator(this, function (_a) {
+                    if (sessionContext.loading === true) {
+                        // This callback should only be called if the session is already loaded
+                        throw new Error("Should never come here");
+                    }
                     // If there is no active session we know that the verification was started elsewhere, since it requires a session
                     // otherwise we assume it's the same session. The main purpose of this is to prevent mail scanners
                     // from accidentally validating an email address
-                    if (sessionContext.loading === false && !sessionContext.doesSessionExist) {
+                    if (!sessionContext.doesSessionExist) {
                         return [2 /*return*/, "INTERACTION_REQUIRED"];
                     }
                     return [

--- a/lib/build/recipe/emailverification/emailVerificationAuth.d.ts
+++ b/lib/build/recipe/emailverification/emailVerificationAuth.d.ts
@@ -2,7 +2,7 @@ import React from "react";
 import { FeatureBaseProps } from "../../types";
 import Recipe from "./recipe";
 declare type Props = FeatureBaseProps & {
-    recipe: Recipe;
+    getRecipe: () => Recipe;
 };
 declare const EmailVerificationAuthWrapper: React.FC<
     Props & {

--- a/lib/build/recipe/emailverification/emailVerificationAuth.js
+++ b/lib/build/recipe/emailverification/emailVerificationAuth.js
@@ -291,7 +291,12 @@ var EmailVerificationAuth = function (_a) {
         undefined,
         sessionContext.loading === false
     );
-    if (props.recipe.config.mode !== "REQUIRED" || isEmailVerified) {
+    if (
+        sessionContext.loading === true ||
+        sessionContext.doesSessionExist === false ||
+        props.recipe.config.mode !== "REQUIRED" ||
+        isEmailVerified
+    ) {
         return (0, jsx_runtime_1.jsx)(jsx_runtime_1.Fragment, { children: children });
     }
     return null;

--- a/lib/build/recipe/emailverification/emailVerificationAuth.js
+++ b/lib/build/recipe/emailverification/emailVerificationAuth.js
@@ -228,9 +228,17 @@ var EmailVerificationAuth = function (_a) {
     var _b = (0, react_1.useState)(false),
         isEmailVerified = _b[0],
         setIsEmailVerified = _b[1];
-    var emailVerificationMode = props.recipe.config.mode;
+    var recipe = react_1.default.useRef();
     var propsRef = react_1.default.useRef(props);
     var userContext = (0, usercontext_1.useUserContext)();
+    if (recipe.current === undefined) {
+        try {
+            recipe.current = propsRef.current.getRecipe();
+        } catch (_c) {
+            // We are in either an SSR environment or the user forgot to initialize the recipe
+            // We are ignoring this exception here, because in SSR we don't want to throw and the callback below will throw in a browser
+        }
+    }
     var checkIsEmailVerified = (0, react_1.useCallback)(
         function () {
             return __awaiter(void 0, void 0, void 0, function () {
@@ -241,9 +249,13 @@ var EmailVerificationAuth = function (_a) {
                                 // This callback should only be called if the session is already loaded
                                 throw new Error("Should never come here");
                             }
-                            if (!(sessionContext.doesSessionExist && emailVerificationMode === "REQUIRED"))
+                            if (!recipe.current) {
+                                // If the recipe.current isn't initialized here, this will likely throw and produce a user friendly error
+                                recipe.current = propsRef.current.getRecipe();
+                            }
+                            if (!(sessionContext.doesSessionExist && recipe.current.config.mode === "REQUIRED"))
                                 return [3 /*break*/, 2];
-                            return [4 /*yield*/, propsRef.current.recipe.isEmailVerified(userContext)];
+                            return [4 /*yield*/, recipe.current.isEmailVerified(userContext)];
                         case 1:
                             return [2 /*return*/, _a.sent().isVerified];
                         case 2:
@@ -252,7 +264,7 @@ var EmailVerificationAuth = function (_a) {
                 });
             });
         },
-        [sessionContext, emailVerificationMode]
+        [sessionContext]
     );
     var useIsEmailVerified = (0, react_1.useCallback)(
         function (isEmailVerified) {
@@ -264,12 +276,12 @@ var EmailVerificationAuth = function (_a) {
                                 // This callback should only be called if the session is already loaded
                                 throw new Error("Should never come here");
                             }
-                            if (!(sessionContext.doesSessionExist && emailVerificationMode === "REQUIRED"))
+                            if (!(sessionContext.doesSessionExist && recipe.current.config.mode === "REQUIRED"))
                                 return [3 /*break*/, 3];
                             if (!(isEmailVerified === false)) return [3 /*break*/, 2];
                             return [
                                 4 /*yield*/,
-                                propsRef.current.recipe.redirect({ action: "VERIFY_EMAIL" }, propsRef.current.history),
+                                recipe.current.redirect({ action: "VERIFY_EMAIL" }, propsRef.current.history),
                             ];
                         case 1:
                             _a.sent();
@@ -283,7 +295,7 @@ var EmailVerificationAuth = function (_a) {
                 });
             });
         },
-        [sessionContext.loading, emailVerificationMode]
+        [sessionContext.loading]
     );
     (0, utils_1.useOnMountAPICall)(
         checkIsEmailVerified,
@@ -291,11 +303,11 @@ var EmailVerificationAuth = function (_a) {
         undefined,
         sessionContext.loading === false
     );
+    var isNotRequired = recipe.current !== undefined && recipe.current.config.mode !== "REQUIRED";
     if (
-        sessionContext.loading === true ||
-        sessionContext.doesSessionExist === false ||
-        props.recipe.config.mode !== "REQUIRED" ||
-        isEmailVerified
+        // We only render after loading has finished to eliminate flicker
+        sessionContext.loading === false &&
+        (isNotRequired || sessionContext.doesSessionExist === false || isEmailVerified)
     ) {
         return (0, jsx_runtime_1.jsx)(jsx_runtime_1.Fragment, { children: children });
     }

--- a/lib/build/recipe/emailverification/emailVerificationAuth.js
+++ b/lib/build/recipe/emailverification/emailVerificationAuth.js
@@ -228,11 +228,6 @@ var EmailVerificationAuth = function (_a) {
     var _b = (0, react_1.useState)(false),
         isEmailVerified = _b[0],
         setIsEmailVerified = _b[1];
-    // we extract these three this way so that the useEffect below
-    // doesn't rerun just because the sessionContext or props objects
-    // have changed, even though the doesSessionExist & emailVerificationMode
-    // have not.
-    var doesSessionExist = sessionContext.loading === false && sessionContext.doesSessionExist;
     var emailVerificationMode = props.recipe.config.mode;
     var propsRef = react_1.default.useRef(props);
     var userContext = (0, usercontext_1.useUserContext)();
@@ -242,7 +237,12 @@ var EmailVerificationAuth = function (_a) {
                 return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
-                            if (!(doesSessionExist && emailVerificationMode === "REQUIRED")) return [3 /*break*/, 2];
+                            if (sessionContext.loading === true) {
+                                // This callback should only be called if the session is already loaded
+                                throw new Error("Should never come here");
+                            }
+                            if (!(sessionContext.doesSessionExist && emailVerificationMode === "REQUIRED"))
+                                return [3 /*break*/, 2];
                             return [4 /*yield*/, propsRef.current.recipe.isEmailVerified(userContext)];
                         case 1:
                             return [2 /*return*/, _a.sent().isVerified];
@@ -252,7 +252,7 @@ var EmailVerificationAuth = function (_a) {
                 });
             });
         },
-        [doesSessionExist, emailVerificationMode]
+        [sessionContext, emailVerificationMode]
     );
     var useIsEmailVerified = (0, react_1.useCallback)(
         function (isEmailVerified) {
@@ -260,7 +260,12 @@ var EmailVerificationAuth = function (_a) {
                 return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
-                            if (!(doesSessionExist && emailVerificationMode === "REQUIRED")) return [3 /*break*/, 3];
+                            if (sessionContext.loading === true) {
+                                // This callback should only be called if the session is already loaded
+                                throw new Error("Should never come here");
+                            }
+                            if (!(sessionContext.doesSessionExist && emailVerificationMode === "REQUIRED"))
+                                return [3 /*break*/, 3];
                             if (!(isEmailVerified === false)) return [3 /*break*/, 2];
                             return [
                                 4 /*yield*/,
@@ -278,7 +283,7 @@ var EmailVerificationAuth = function (_a) {
                 });
             });
         },
-        [doesSessionExist, emailVerificationMode]
+        [sessionContext.loading, emailVerificationMode]
     );
     (0, utils_1.useOnMountAPICall)(
         checkIsEmailVerified,
@@ -286,13 +291,10 @@ var EmailVerificationAuth = function (_a) {
         undefined,
         sessionContext.loading === false
     );
-    if (doesSessionExist === false) {
+    if (props.recipe.config.mode !== "REQUIRED" || isEmailVerified) {
         return (0, jsx_runtime_1.jsx)(jsx_runtime_1.Fragment, { children: children });
     }
-    if (props.recipe.config.mode !== "REQUIRED") {
-        return (0, jsx_runtime_1.jsx)(jsx_runtime_1.Fragment, { children: children });
-    }
-    return isEmailVerified ? (0, jsx_runtime_1.jsx)(jsx_runtime_1.Fragment, { children: children }) : null;
+    return null;
 };
 var EmailVerificationAuthWrapper = function (props) {
     return (0, jsx_runtime_1.jsx)(

--- a/lib/build/recipe/emailverification/emailVerificationAuth.js
+++ b/lib/build/recipe/emailverification/emailVerificationAuth.js
@@ -280,7 +280,12 @@ var EmailVerificationAuth = function (_a) {
         },
         [doesSessionExist, emailVerificationMode]
     );
-    (0, utils_1.useOnMountAPICall)(checkIsEmailVerified, useIsEmailVerified);
+    (0, utils_1.useOnMountAPICall)(
+        checkIsEmailVerified,
+        useIsEmailVerified,
+        undefined,
+        sessionContext.loading === false
+    );
     if (doesSessionExist === false) {
         return (0, jsx_runtime_1.jsx)(jsx_runtime_1.Fragment, { children: children });
     }

--- a/lib/build/recipe/emailverification/emailVerificationAuth.js
+++ b/lib/build/recipe/emailverification/emailVerificationAuth.js
@@ -303,12 +303,12 @@ var EmailVerificationAuth = function (_a) {
         undefined,
         sessionContext.loading === false
     );
-    var isNotRequired = recipe.current !== undefined && recipe.current.config.mode !== "REQUIRED";
-    if (
-        // We only render after loading has finished to eliminate flicker
-        sessionContext.loading === false &&
-        (isNotRequired || sessionContext.doesSessionExist === false || isEmailVerified)
-    ) {
+    // We only render after loading has finished to eliminate flicker
+    // recipe.current should only be undefined during SSR but this makes the type system happy
+    if (sessionContext.loading === true || recipe.current === undefined) {
+        return null;
+    }
+    if (recipe.current.config.mode !== "REQUIRED" || sessionContext.doesSessionExist === false || isEmailVerified) {
         return (0, jsx_runtime_1.jsx)(jsx_runtime_1.Fragment, { children: children });
     }
     return null;

--- a/lib/build/recipe/emailverification/emailVerificationAuth.js
+++ b/lib/build/recipe/emailverification/emailVerificationAuth.js
@@ -232,7 +232,7 @@ var EmailVerificationAuth = function (_a) {
     // doesn't rerun just because the sessionContext or props objects
     // have changed, even though the doesSessionExist & emailVerificationMode
     // have not.
-    var doesSessionExist = sessionContext.doesSessionExist;
+    var doesSessionExist = sessionContext.loading === false && sessionContext.doesSessionExist;
     var emailVerificationMode = props.recipe.config.mode;
     var propsRef = react_1.default.useRef(props);
     var userContext = (0, usercontext_1.useUserContext)();
@@ -281,7 +281,7 @@ var EmailVerificationAuth = function (_a) {
         [doesSessionExist, emailVerificationMode]
     );
     (0, utils_1.useOnMountAPICall)(checkIsEmailVerified, useIsEmailVerified);
-    if (sessionContext.doesSessionExist === false) {
+    if (doesSessionExist === false) {
         return (0, jsx_runtime_1.jsx)(jsx_runtime_1.Fragment, { children: children });
     }
     if (props.recipe.config.mode !== "REQUIRED") {

--- a/lib/build/recipe/passwordless/passwordlessAuth.js
+++ b/lib/build/recipe/passwordless/passwordlessAuth.js
@@ -54,7 +54,7 @@ function PasswordlessAuthWrapper(_a) {
         requireAuth = _a.requireAuth,
         onSessionExpired = _a.onSessionExpired,
         userContext = _a.userContext;
-    var routerInfo = superTokens_1.default.getInstanceOrThrow().getReactRouterDomWithCustomHistory();
+    var routerInfo = superTokens_1.default.getReactRouterDomWithCustomHistory();
     var history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
@@ -64,12 +64,7 @@ function PasswordlessAuthWrapper(_a) {
                 children: (0, jsx_runtime_1.jsx)(
                     PasswordlessAuthMemo,
                     __assign(
-                        {
-                            history: history,
-                            onSessionExpired: onSessionExpired,
-                            requireAuth: requireAuth,
-                            recipe: recipe_1.default.getInstanceOrThrow(),
-                        },
+                        { history: history, onSessionExpired: onSessionExpired, requireAuth: requireAuth },
                         { children: children }
                     )
                 ),

--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -2,21 +2,19 @@
 import { RecipeInterface } from "supertokens-web-js/recipe/session";
 import { InputType, SessionContextType } from "./types";
 import SessionContext from "./sessionContext";
+import { SuperTokensWrapper } from "./supertokensWrapper";
 export default class SessionAPIWrapper {
     static useSessionContext: () => SessionContextType;
     static SessionAuth: import("react").FC<
         import("react").PropsWithChildren<
-            ((
-                | {
-                      requireAuth?: false | undefined;
-                  }
-                | {
-                      requireAuth: true;
-                      redirectToLogin: () => void;
-                  }
-            ) & {
-                onSessionExpired?: (() => void) | undefined;
-            }) & {
+            import("./sessionAuth").SessionAuthProps & {
+                userContext?: any;
+            }
+        >
+    >;
+    static SuperTokensWrapper: import("react").FC<
+        import("react").PropsWithChildren<
+            import("./sessionAuth").SessionAuthProps & {
                 userContext?: any;
             }
         >
@@ -32,17 +30,7 @@ export default class SessionAPIWrapper {
 declare const useSessionContext: () => SessionContextType;
 declare const SessionAuth: import("react").FC<
     import("react").PropsWithChildren<
-        ((
-            | {
-                  requireAuth?: false | undefined;
-              }
-            | {
-                  requireAuth: true;
-                  redirectToLogin: () => void;
-              }
-        ) & {
-            onSessionExpired?: (() => void) | undefined;
-        }) & {
+        import("./sessionAuth").SessionAuthProps & {
             userContext?: any;
         }
     >
@@ -57,6 +45,7 @@ declare const signOut: typeof SessionAPIWrapper.signOut;
 export {
     useSessionContext,
     SessionAuth,
+    SuperTokensWrapper,
     init,
     getUserId,
     getAccessTokenPayloadSecurely,

--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -2,17 +2,9 @@
 import { RecipeInterface } from "supertokens-web-js/recipe/session";
 import { InputType, SessionContextType } from "./types";
 import SessionContext from "./sessionContext";
-import { SuperTokensWrapper } from "./supertokensWrapper";
 export default class SessionAPIWrapper {
     static useSessionContext: () => SessionContextType;
     static SessionAuth: import("react").FC<
-        import("react").PropsWithChildren<
-            import("./sessionAuth").SessionAuthProps & {
-                userContext?: any;
-            }
-        >
-    >;
-    static SuperTokensWrapper: import("react").FC<
         import("react").PropsWithChildren<
             import("./sessionAuth").SessionAuthProps & {
                 userContext?: any;
@@ -45,7 +37,6 @@ declare const signOut: typeof SessionAPIWrapper.signOut;
 export {
     useSessionContext,
     SessionAuth,
-    SuperTokensWrapper,
     init,
     getUserId,
     getAccessTokenPayloadSecurely,

--- a/lib/build/recipe/session/index.js
+++ b/lib/build/recipe/session/index.js
@@ -158,7 +158,6 @@ exports.SessionContext =
     exports.getAccessTokenPayloadSecurely =
     exports.getUserId =
     exports.init =
-    exports.SuperTokensWrapper =
     exports.SessionAuth =
     exports.useSessionContext =
         void 0;
@@ -168,13 +167,6 @@ var useSessionContext_1 = __importDefault(require("./useSessionContext"));
 var sessionContext_1 = __importDefault(require("./sessionContext"));
 exports.SessionContext = sessionContext_1.default;
 var utils_1 = require("../../utils");
-var supertokensWrapper_1 = require("./supertokensWrapper");
-Object.defineProperty(exports, "SuperTokensWrapper", {
-    enumerable: true,
-    get: function () {
-        return supertokensWrapper_1.SuperTokensWrapper;
-    },
-});
 var SessionAPIWrapper = /** @class */ (function () {
     function SessionAPIWrapper() {}
     SessionAPIWrapper.init = function (config) {
@@ -248,7 +240,6 @@ var SessionAPIWrapper = /** @class */ (function () {
     };
     SessionAPIWrapper.useSessionContext = useSessionContext_1.default;
     SessionAPIWrapper.SessionAuth = sessionAuth_1.default;
-    SessionAPIWrapper.SuperTokensWrapper = supertokensWrapper_1.SuperTokensWrapper;
     return SessionAPIWrapper;
 })();
 exports.default = SessionAPIWrapper;

--- a/lib/build/recipe/session/index.js
+++ b/lib/build/recipe/session/index.js
@@ -158,6 +158,7 @@ exports.SessionContext =
     exports.getAccessTokenPayloadSecurely =
     exports.getUserId =
     exports.init =
+    exports.SuperTokensWrapper =
     exports.SessionAuth =
     exports.useSessionContext =
         void 0;
@@ -167,6 +168,13 @@ var useSessionContext_1 = __importDefault(require("./useSessionContext"));
 var sessionContext_1 = __importDefault(require("./sessionContext"));
 exports.SessionContext = sessionContext_1.default;
 var utils_1 = require("../../utils");
+var supertokensWrapper_1 = require("./supertokensWrapper");
+Object.defineProperty(exports, "SuperTokensWrapper", {
+    enumerable: true,
+    get: function () {
+        return supertokensWrapper_1.SuperTokensWrapper;
+    },
+});
 var SessionAPIWrapper = /** @class */ (function () {
     function SessionAPIWrapper() {}
     SessionAPIWrapper.init = function (config) {
@@ -240,6 +248,7 @@ var SessionAPIWrapper = /** @class */ (function () {
     };
     SessionAPIWrapper.useSessionContext = useSessionContext_1.default;
     SessionAPIWrapper.SessionAuth = sessionAuth_1.default;
+    SessionAPIWrapper.SuperTokensWrapper = supertokensWrapper_1.SuperTokensWrapper;
     return SessionAPIWrapper;
 })();
 exports.default = SessionAPIWrapper;

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -323,6 +323,7 @@ var Session = /** @class */ (function (_super) {
                                 doesSessionExist: true,
                                 accessTokenPayload: accessTokenPayload,
                                 userId: userId,
+                                loading: false,
                             },
                         ];
                     case 2:
@@ -333,6 +334,7 @@ var Session = /** @class */ (function (_super) {
                                     doesSessionExist: false,
                                     accessTokenPayload: {},
                                     userId: "",
+                                    loading: false,
                                 },
                             ];
                         }

--- a/lib/build/recipe/session/sessionAuth.d.ts
+++ b/lib/build/recipe/session/sessionAuth.d.ts
@@ -6,12 +6,12 @@ declare type PropsWithAuth = {
     requireAuth: true;
     redirectToLogin: () => void;
 };
-declare type Props = (PropsWithoutAuth | PropsWithAuth) & {
+export declare type SessionAuthProps = (PropsWithoutAuth | PropsWithAuth) & {
     onSessionExpired?: () => void;
 };
 declare const SessionAuthWrapper: React.FC<
     PropsWithChildren<
-        Props & {
+        SessionAuthProps & {
             userContext?: any;
         }
     >

--- a/lib/build/recipe/session/sessionAuth.js
+++ b/lib/build/recipe/session/sessionAuth.js
@@ -310,11 +310,7 @@ var SessionAuth = function (_a) {
                         // We should not be updating the context to loading
                         throw new Error("Should never come here");
                     }
-                    if (
-                        toSetContext.loading === false &&
-                        !toSetContext.doesSessionExist &&
-                        props.requireAuth === true
-                    ) {
+                    if (!toSetContext.doesSessionExist && props.requireAuth === true) {
                         props.redirectToLogin();
                     } else {
                         setContext(function (context) {

--- a/lib/build/recipe/session/sessionAuth.js
+++ b/lib/build/recipe/session/sessionAuth.js
@@ -241,7 +241,7 @@ var SessionAuth = function (_a) {
     var parentSessionContext = (0, react_1.useContext)(sessionContext_1.default);
     // assign the parent context here itself so that there is no flicker in the UI
     var _b = (0, react_1.useState)(
-            !(0, sessionContext_1.isDefaultContext)(parentSessionContext) ? parentSessionContext : undefined
+            !(0, sessionContext_1.isDefaultContext)(parentSessionContext) ? parentSessionContext : { loading: true }
         ),
         context = _b[0],
         setContext = _b[1];
@@ -376,9 +376,6 @@ var SessionAuth = function (_a) {
         },
         [props]
     );
-    if (context === undefined) {
-        return null;
-    }
     // this will display null only if initially the below condition is true.
     // cause if the session goes from existing to non existing, then
     // the context is not updated if props.requireAuth === true

--- a/lib/build/recipe/session/sessionAuth.js
+++ b/lib/build/recipe/session/sessionAuth.js
@@ -262,7 +262,7 @@ var SessionAuth = function (_a) {
                         if (!(0, sessionContext_1.isDefaultContext)(parentSessionContext)) {
                             return [2 /*return*/, parentSessionContext];
                         }
-                        if (context) {
+                        if (!context.loading) {
                             return [2 /*return*/, context];
                         }
                         return [
@@ -321,14 +321,14 @@ var SessionAuth = function (_a) {
                         props.redirectToLogin();
                     } else {
                         setContext(function (context) {
-                            return context !== undefined ? context : toSetContext;
+                            return !context.loading ? context : toSetContext;
                         });
                     }
                     return [2 /*return*/];
                 });
             });
         },
-        [props]
+        [props.requireAuth, props.requireAuth === true && props.redirectToLogin]
     );
     (0, utils_1.useOnMountAPICall)(buildContext, setInitialContextAndMaybeRedirect);
     // subscribe to events on mount
@@ -346,22 +346,14 @@ var SessionAuth = function (_a) {
                         setContext(event.sessionContext);
                         return;
                     case "SIGN_OUT":
-                        if (props.requireAuth !== true) {
-                            setContext(event.sessionContext);
-                        }
+                        setContext(event.sessionContext);
                         return;
                     case "UNAUTHORISED":
-                        if (props.requireAuth === true) {
-                            if (props.onSessionExpired !== undefined) {
-                                props.onSessionExpired();
-                            } else {
-                                props.redirectToLogin();
-                            }
-                        } else {
-                            setContext(event.sessionContext);
-                            if (props.onSessionExpired !== undefined) {
-                                props.onSessionExpired();
-                            }
+                        setContext(event.sessionContext);
+                        if (props.onSessionExpired !== undefined) {
+                            props.onSessionExpired();
+                        } else if (props.requireAuth === true) {
+                            props.redirectToLogin();
                         }
                         return;
                 }
@@ -376,15 +368,13 @@ var SessionAuth = function (_a) {
         },
         [props]
     );
-    // this will display null only if initially the below condition is true.
-    // cause if the session goes from existing to non existing, then
-    // the context is not updated if props.requireAuth === true
-    if (props.requireAuth === true && (context.loading || !context.doesSessionExist)) {
+    var actualContext = !(0, sessionContext_1.isDefaultContext)(parentSessionContext) ? parentSessionContext : context;
+    if (props.requireAuth === true && (actualContext.loading || !actualContext.doesSessionExist)) {
         return null;
     }
     return (0, jsx_runtime_1.jsx)(
         sessionContext_1.default.Provider,
-        __assign({ value: __assign(__assign({}, context), { isDefault: false }) }, { children: children })
+        __assign({ value: __assign(__assign({}, actualContext), { isDefault: false }) }, { children: children })
     );
 };
 var SessionAuthWrapper = function (props) {

--- a/lib/build/recipe/session/sessionAuth.js
+++ b/lib/build/recipe/session/sessionAuth.js
@@ -257,11 +257,6 @@ var SessionAuth = function (_a) {
                         if (session.current === undefined) {
                             session.current = recipe_1.default.getInstanceOrThrow();
                         }
-                        // if it's not the default context, it means SessionAuth from top has
-                        // given us a sessionContext.
-                        if (!(0, sessionContext_1.isDefaultContext)(parentSessionContext)) {
-                            return [2 /*return*/, parentSessionContext];
-                        }
                         if (!context.loading) {
                             return [2 /*return*/, context];
                         }
@@ -311,8 +306,10 @@ var SessionAuth = function (_a) {
         function (toSetContext) {
             return __awaiter(void 0, void 0, void 0, function () {
                 return __generator(this, function (_a) {
-                    // if this component is unmounting, or the context has already
-                    // been set, then we don't need to proceed...
+                    if (toSetContext.loading === true) {
+                        // We should not be updating the context to loading
+                        throw new Error("Should never come here");
+                    }
                     if (
                         toSetContext.loading === false &&
                         !toSetContext.doesSessionExist &&

--- a/lib/build/recipe/session/sessionAuth.js
+++ b/lib/build/recipe/session/sessionAuth.js
@@ -225,11 +225,6 @@ var recipe_1 = __importDefault(require("./recipe"));
 var usercontext_1 = require("../../usercontext");
 var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
 var utils_1 = require("../../utils");
-// if it's not the default context, it means SessionAuth from top has
-// given us a sessionContext.
-var hasParentProvider = function (ctx) {
-    return !(0, sessionContext_1.isDefaultContext)(ctx);
-};
 var SessionAuth = function (_a) {
     var children = _a.children,
         props = __rest(_a, ["children"]);
@@ -245,10 +240,12 @@ var SessionAuth = function (_a) {
     }
     var parentSessionContext = (0, react_1.useContext)(sessionContext_1.default);
     // assign the parent context here itself so that there is no flicker in the UI
-    var _b = (0, react_1.useState)(hasParentProvider(parentSessionContext) ? parentSessionContext : undefined),
+    var _b = (0, react_1.useState)(
+            !(0, sessionContext_1.isDefaultContext)(parentSessionContext) ? parentSessionContext : undefined
+        ),
         context = _b[0],
         setContext = _b[1];
-    var session = (0, react_1.useRef)(recipe_1.default.getInstanceOrThrow());
+    var session = (0, react_1.useRef)();
     var userContext = (0, usercontext_1.useUserContext)();
     var buildContext = (0, react_1.useCallback)(function () {
         return __awaiter(void 0, void 0, void 0, function () {
@@ -257,7 +254,12 @@ var SessionAuth = function (_a) {
             return __generator(this, function (_b) {
                 switch (_b.label) {
                     case 0:
-                        if (hasParentProvider(parentSessionContext)) {
+                        if (session.current === undefined) {
+                            session.current = recipe_1.default.getInstanceOrThrow();
+                        }
+                        // if it's not the default context, it means SessionAuth from top has
+                        // given us a sessionContext.
+                        if (!(0, sessionContext_1.isDefaultContext)(parentSessionContext)) {
                             return [2 /*return*/, parentSessionContext];
                         }
                         if (context) {
@@ -278,6 +280,7 @@ var SessionAuth = function (_a) {
                                     doesSessionExist: false,
                                     accessTokenPayload: {},
                                     userId: "",
+                                    loading: false,
                                 },
                             ];
                         }
@@ -299,7 +302,7 @@ var SessionAuth = function (_a) {
                             }),
                         ];
                     case 3:
-                        return [2 /*return*/, ((_a.userId = _b.sent()), _a)];
+                        return [2 /*return*/, ((_a.userId = _b.sent()), (_a.loading = false), _a)];
                 }
             });
         });
@@ -310,12 +313,16 @@ var SessionAuth = function (_a) {
                 return __generator(this, function (_a) {
                     // if this component is unmounting, or the context has already
                     // been set, then we don't need to proceed...
-                    if (!toSetContext.doesSessionExist && props.requireAuth === true) {
+                    if (
+                        toSetContext.loading === false &&
+                        !toSetContext.doesSessionExist &&
+                        props.requireAuth === true
+                    ) {
                         props.redirectToLogin();
                     } else {
-                        if (context === undefined) {
-                            setContext(toSetContext);
-                        }
+                        setContext(function (context) {
+                            return context !== undefined ? context : toSetContext;
+                        });
                     }
                     return [2 /*return*/];
                 });
@@ -359,6 +366,9 @@ var SessionAuth = function (_a) {
                         return;
                 }
             }
+            if (session.current === undefined) {
+                session.current = recipe_1.default.getInstanceOrThrow();
+            }
             // we return here cause addEventListener returns a function that removes
             // the listener, and this function will be called by useEffect when
             // onHandleEvent changes or if the component is unmounting.
@@ -372,12 +382,12 @@ var SessionAuth = function (_a) {
     // this will display null only if initially the below condition is true.
     // cause if the session goes from existing to non existing, then
     // the context is not updated if props.requireAuth === true
-    if (!context.doesSessionExist && props.requireAuth === true) {
+    if (props.requireAuth === true && (context.loading || !context.doesSessionExist)) {
         return null;
     }
     return (0, jsx_runtime_1.jsx)(
         sessionContext_1.default.Provider,
-        __assign({ value: context }, { children: children })
+        __assign({ value: __assign(__assign({}, context), { isDefault: false }) }, { children: children })
     );
 };
 var SessionAuthWrapper = function (props) {

--- a/lib/build/recipe/session/sessionContext.d.ts
+++ b/lib/build/recipe/session/sessionContext.d.ts
@@ -1,5 +1,13 @@
 import React from "react";
 import { SessionContextType } from "./types";
-declare const SessionContext: React.Context<SessionContextType>;
-export declare function isDefaultContext(sessionContext: SessionContextType): boolean;
+declare const SessionContext: React.Context<
+    SessionContextType & {
+        isDefault: boolean;
+    }
+>;
+export declare function isDefaultContext(
+    sessionContext: SessionContextType & {
+        isDefault: boolean;
+    }
+): boolean;
 export default SessionContext;

--- a/lib/build/recipe/session/sessionContext.js
+++ b/lib/build/recipe/session/sessionContext.js
@@ -8,12 +8,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.isDefaultContext = void 0;
 var react_1 = __importDefault(require("react"));
 var SessionContext = react_1.default.createContext({
-    doesSessionExist: false,
-    userId: "DEFAULT_USER_ID",
-    accessTokenPayload: {},
+    loading: true,
+    isDefault: true,
 });
 function isDefaultContext(sessionContext) {
-    return sessionContext.userId === "DEFAULT_USER_ID";
+    return sessionContext.isDefault;
 }
 exports.isDefaultContext = isDefaultContext;
 exports.default = SessionContext;

--- a/lib/build/recipe/session/supertokensWrapper.d.ts
+++ b/lib/build/recipe/session/supertokensWrapper.d.ts
@@ -1,0 +1,9 @@
+import { PropsWithChildren } from "react";
+import { SessionAuthProps } from "./sessionAuth";
+export declare const SuperTokensWrapper: React.FC<
+    PropsWithChildren<
+        SessionAuthProps & {
+            userContext?: any;
+        }
+    >
+>;

--- a/lib/build/recipe/session/supertokensWrapper.js
+++ b/lib/build/recipe/session/supertokensWrapper.js
@@ -1,0 +1,35 @@
+"use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.SuperTokensWrapper = void 0;
+var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
+var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
+var sessionAuth_1 = __importDefault(require("./sessionAuth"));
+var SuperTokensWrapper = function (props) {
+    return (0, jsx_runtime_1.jsx)(
+        userContextWrapper_1.default,
+        __assign(
+            { userContext: props.userContext },
+            { children: (0, jsx_runtime_1.jsx)(sessionAuth_1.default, __assign({}, props)) }
+        )
+    );
+};
+exports.SuperTokensWrapper = SuperTokensWrapper;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -5,8 +5,13 @@ export declare type RecipeEventWithSessionContext = RecipeEvent & {
 export declare type InputType = WebJSInputType & {
     onHandleEvent?: (event: RecipeEventWithSessionContext) => void;
 };
-export declare type SessionContextType = {
-    doesSessionExist: boolean;
-    userId: string;
-    accessTokenPayload: any;
-};
+export declare type SessionContextType =
+    | {
+          doesSessionExist: boolean;
+          userId: string;
+          accessTokenPayload: any;
+          loading: false;
+      }
+    | {
+          loading: true;
+      };

--- a/lib/build/recipe/session/useSessionContext.js
+++ b/lib/build/recipe/session/useSessionContext.js
@@ -8,6 +8,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var react_1 = __importDefault(require("react"));
 var sessionContext_1 = __importDefault(require("./sessionContext"));
 var useSessionContext = function () {
-    return react_1.default.useContext(sessionContext_1.default);
+    var ctx = react_1.default.useContext(sessionContext_1.default);
+    if (ctx.isDefault) {
+        throw new Error("Cannot use useSessionContext outside auth components.");
+    }
+    return ctx;
 };
 exports.default = useSessionContext;

--- a/lib/build/recipe/session/useSessionContext.js
+++ b/lib/build/recipe/session/useSessionContext.js
@@ -10,7 +10,7 @@ var sessionContext_1 = __importDefault(require("./sessionContext"));
 var useSessionContext = function () {
     var ctx = react_1.default.useContext(sessionContext_1.default);
     if (ctx.isDefault) {
-        throw new Error("Cannot use useSessionContext outside auth components.");
+        throw new Error("Cannot use useSessionContext outside auth wrapper components.");
     }
     return ctx;
 };

--- a/lib/build/recipe/thirdparty/thirdpartyAuth.js
+++ b/lib/build/recipe/thirdparty/thirdpartyAuth.js
@@ -29,7 +29,15 @@ var userContextWrapper_1 = __importDefault(require("../../usercontext/userContex
 function ThirdPartyAuth(props) {
     var emailVerification = (0, jsx_runtime_1.jsx)(
         emailVerificationAuth_1.default,
-        __assign({ recipe: props.recipe.emailVerification, history: props.history }, { children: props.children })
+        __assign(
+            {
+                getRecipe: function () {
+                    return recipe_1.default.getInstanceOrThrow().emailVerification;
+                },
+                history: props.history,
+            },
+            { children: props.children }
+        )
     );
     if (props.requireAuth === false) {
         return (0, jsx_runtime_1.jsx)(
@@ -59,7 +67,7 @@ var ThirdPartyAuthWrapper = function (_a) {
         requireAuth = _a.requireAuth,
         onSessionExpired = _a.onSessionExpired,
         userContext = _a.userContext;
-    var routerInfo = superTokens_1.default.getInstanceOrThrow().getReactRouterDomWithCustomHistory();
+    var routerInfo = superTokens_1.default.getReactRouterDomWithCustomHistory();
     var history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
@@ -69,12 +77,7 @@ var ThirdPartyAuthWrapper = function (_a) {
                 children: (0, jsx_runtime_1.jsx)(
                     ThirdPartyAuthMemo,
                     __assign(
-                        {
-                            history: history,
-                            onSessionExpired: onSessionExpired,
-                            requireAuth: requireAuth,
-                            recipe: recipe_1.default.getInstanceOrThrow(),
-                        },
+                        { history: history, onSessionExpired: onSessionExpired, requireAuth: requireAuth },
                         { children: children }
                     )
                 ),

--- a/lib/build/recipe/thirdpartyemailpassword/thirdpartyEmailpasswordAuth.js
+++ b/lib/build/recipe/thirdpartyemailpassword/thirdpartyEmailpasswordAuth.js
@@ -29,7 +29,15 @@ var userContextWrapper_1 = __importDefault(require("../../usercontext/userContex
 function ThirdPartyEmailPasswordAuth(props) {
     var emailVerification = (0, jsx_runtime_1.jsx)(
         emailVerificationAuth_1.default,
-        __assign({ recipe: props.recipe.emailVerification, history: props.history }, { children: props.children })
+        __assign(
+            {
+                getRecipe: function () {
+                    return recipe_1.default.getInstanceOrThrow().emailVerification;
+                },
+                history: props.history,
+            },
+            { children: props.children }
+        )
     );
     if (props.requireAuth === false) {
         return (0, jsx_runtime_1.jsx)(
@@ -59,7 +67,7 @@ var ThirdPartyEmailPasswordAuthWrapper = function (_a) {
         requireAuth = _a.requireAuth,
         onSessionExpired = _a.onSessionExpired,
         userContext = _a.userContext;
-    var routerInfo = superTokens_1.default.getInstanceOrThrow().getReactRouterDomWithCustomHistory();
+    var routerInfo = superTokens_1.default.getReactRouterDomWithCustomHistory();
     var history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
@@ -69,12 +77,7 @@ var ThirdPartyEmailPasswordAuthWrapper = function (_a) {
                 children: (0, jsx_runtime_1.jsx)(
                     ThirdPartyEmailPasswordAuthMemo,
                     __assign(
-                        {
-                            history: history,
-                            onSessionExpired: onSessionExpired,
-                            requireAuth: requireAuth,
-                            recipe: recipe_1.default.getInstanceOrThrow(),
-                        },
+                        { history: history, onSessionExpired: onSessionExpired, requireAuth: requireAuth },
                         { children: children }
                     )
                 ),

--- a/lib/build/recipe/thirdpartypasswordless/thirdpartyPasswordlessAuth.js
+++ b/lib/build/recipe/thirdpartypasswordless/thirdpartyPasswordlessAuth.js
@@ -29,7 +29,15 @@ var userContextWrapper_1 = __importDefault(require("../../usercontext/userContex
 function ThirdPartyPasswordlessAuth(props) {
     var emailVerification = (0, jsx_runtime_1.jsx)(
         emailVerificationAuth_1.default,
-        __assign({ recipe: props.recipe.emailVerification, history: props.history }, { children: props.children })
+        __assign(
+            {
+                getRecipe: function () {
+                    return recipe_1.default.getInstanceOrThrow().emailVerification;
+                },
+                history: props.history,
+            },
+            { children: props.children }
+        )
     );
     if (props.requireAuth === false) {
         return (0, jsx_runtime_1.jsx)(
@@ -59,7 +67,7 @@ var ThirdPartyPasswordlessAuthWrapper = function (_a) {
         requireAuth = _a.requireAuth,
         onSessionExpired = _a.onSessionExpired,
         userContext = _a.userContext;
-    var routerInfo = superTokens_1.default.getInstanceOrThrow().getReactRouterDomWithCustomHistory();
+    var routerInfo = superTokens_1.default.getReactRouterDomWithCustomHistory();
     var history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
@@ -69,12 +77,7 @@ var ThirdPartyPasswordlessAuthWrapper = function (_a) {
                 children: (0, jsx_runtime_1.jsx)(
                     ThirdPartyPasswordlessAuthMemo,
                     __assign(
-                        {
-                            history: history,
-                            onSessionExpired: onSessionExpired,
-                            requireAuth: requireAuth,
-                            recipe: recipe_1.default.getInstanceOrThrow(),
-                        },
+                        { history: history, onSessionExpired: onSessionExpired, requireAuth: requireAuth },
                         { children: children }
                     )
                 ),

--- a/lib/build/superTokens.d.ts
+++ b/lib/build/superTokens.d.ts
@@ -25,6 +25,14 @@ export default class SuperTokens {
     static canHandleRoute(): boolean;
     static getRoutingComponent(): JSX.Element | null;
     static getSuperTokensRoutesForReactRouterDom(reactRouterDom: any): JSX.Element[];
+    static getReactRouterDomWithCustomHistory():
+        | {
+              router: {
+                  Route: any;
+              };
+              useHistoryCustom: () => any;
+          }
+        | undefined;
     canHandleRoute: () => boolean;
     getRoutingComponent: () => JSX.Element | null;
     getPathsToFeatureComponentWithRecipeIdMap: () => BaseFeatureComponentMap;

--- a/lib/build/superTokens.js
+++ b/lib/build/superTokens.js
@@ -382,6 +382,9 @@ var SuperTokens = /** @class */ (function () {
         };
         return (0, superTokensRoute_1.getSuperTokensRoutesForReactRouterDom)(SuperTokens.getInstanceOrThrow());
     };
+    SuperTokens.getReactRouterDomWithCustomHistory = function () {
+        return this.instance !== undefined ? this.instance.getReactRouterDomWithCustomHistory() : undefined;
+    };
     SuperTokens.prototype.getRecipeOrThrow = function (recipeId) {
         var recipe = this.recipeList.find(function (recipe) {
             return recipe.config.recipeId === recipeId;

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -37,5 +37,6 @@ export declare function getNormalisedUserContext(userContext?: any): any;
 export declare const useOnMountAPICall: <T>(
     fetch: () => Promise<T>,
     handleResponse: (consumeResp: T) => Promise<void>,
-    handleError?: ((err: unknown, consumeResp: T | undefined) => void) | undefined
+    handleError?: ((err: unknown, consumeResp: T | undefined) => void) | undefined,
+    startLoading?: boolean
 ) => void;

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -34,6 +34,17 @@ export declare function setFrontendCookie(
     scope: string | undefined
 ): Promise<void>;
 export declare function getNormalisedUserContext(userContext?: any): any;
+/**
+ * This function handles calling APIs that should only be called once during mount (mostly on mount of a route/feature component).
+ * It's split into multiple callbacks (fetch + handleResponse/handleError) because we expect fetch to take longer and
+ * and the component may be unmounted during the first fetch, in which case we want to avoid updating state/redirecting.
+ * This is especially relevant for development in strict mode with React 18 (and in the future for concurrent rendering).
+ *
+ * @param fetch This is a callback that is only called once on mount. Mostly it's for consuming tokens/doing one time only API calls
+ * @param handleResponse This is called with the result of the first (fetch) call if it succeeds.
+ * @param handleError This is called with the error of the first (fetch) call if it rejects.
+ * @param startLoading Will start the whole process if this is set to true (or omitted). Mostly used to wait for session loading.
+ */
 export declare const useOnMountAPICall: <T>(
     fetch: () => Promise<T>,
     handleResponse: (consumeResp: T) => Promise<void>,

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -662,6 +662,17 @@ function getNormalisedUserContext(userContext) {
     return userContext === undefined ? {} : userContext;
 }
 exports.getNormalisedUserContext = getNormalisedUserContext;
+/**
+ * This function handles calling APIs that should only be called once during mount (mostly on mount of a route/feature component).
+ * It's split into multiple callbacks (fetch + handleResponse/handleError) because we expect fetch to take longer and
+ * and the component may be unmounted during the first fetch, in which case we want to avoid updating state/redirecting.
+ * This is especially relevant for development in strict mode with React 18 (and in the future for concurrent rendering).
+ *
+ * @param fetch This is a callback that is only called once on mount. Mostly it's for consuming tokens/doing one time only API calls
+ * @param handleResponse This is called with the result of the first (fetch) call if it succeeds.
+ * @param handleError This is called with the error of the first (fetch) call if it rejects.
+ * @param startLoading Will start the whole process if this is set to true (or omitted). Mostly used to wait for session loading.
+ */
 var useOnMountAPICall = function (fetch, handleResponse, handleError, startLoading) {
     if (startLoading === void 0) {
         startLoading = true;

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -662,7 +662,10 @@ function getNormalisedUserContext(userContext) {
     return userContext === undefined ? {} : userContext;
 }
 exports.getNormalisedUserContext = getNormalisedUserContext;
-var useOnMountAPICall = function (fetch, handleResponse, handleError) {
+var useOnMountAPICall = function (fetch, handleResponse, handleError, startLoading) {
+    if (startLoading === void 0) {
+        startLoading = true;
+    }
     var consumeReq = (0, react_1.useRef)();
     (0, react_1.useEffect)(
         function () {
@@ -695,13 +698,16 @@ var useOnMountAPICall = function (fetch, handleResponse, handleError) {
                     });
                 });
             };
-            var ctrl = new AbortController();
-            void effect(ctrl.signal);
-            return function () {
-                ctrl.abort();
-            };
+            if (startLoading) {
+                var ctrl_1 = new AbortController();
+                void effect(ctrl_1.signal);
+                return function () {
+                    ctrl_1.abort();
+                };
+            }
+            return;
         },
-        [consumeReq, fetch, handleResponse, handleError]
+        [consumeReq, fetch, handleResponse, handleError, startLoading]
     );
 };
 exports.useOnMountAPICall = useOnMountAPICall;

--- a/lib/ts/components/supertokensWrapper.tsx
+++ b/lib/ts/components/supertokensWrapper.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from "react";
-import UserContextWrapper from "../../usercontext/userContextWrapper";
-import SessionAuthWrapper, { SessionAuthProps } from "./sessionAuth";
+import UserContextWrapper from "../usercontext/userContextWrapper";
+import SessionAuthWrapper, { SessionAuthProps } from "../recipe/session/sessionAuth";
 
 export const SuperTokensWrapper: React.FC<
     PropsWithChildren<

--- a/lib/ts/index.ts
+++ b/lib/ts/index.ts
@@ -21,12 +21,15 @@ import SuperTokens from "./superTokens";
 import { TranslationStore } from "./translation/translationHelpers";
 import { SuperTokensConfig } from "./types";
 import { useUserContext } from "./usercontext";
+import { SuperTokensWrapper } from "./components/supertokensWrapper";
 
 /*
  * API Wrapper exposed to user.
  */
 
 export default class SuperTokensAPIWrapper {
+    static SuperTokensWrapper = SuperTokensWrapper;
+
     static init(config: SuperTokensConfig): void {
         SuperTokens.init(config);
     }
@@ -63,5 +66,6 @@ export const loadTranslation = SuperTokensAPIWrapper.loadTranslation;
 export const getRoutingComponent = SuperTokensAPIWrapper.getRoutingComponent;
 export const getSuperTokensRoutesForReactRouterDom = SuperTokens.getSuperTokensRoutesForReactRouterDom;
 
+export { SuperTokensWrapper } from "./components/supertokensWrapper";
 export { useTranslation } from "./translation/translationContext";
 export { useUserContext } from "./usercontext";

--- a/lib/ts/recipe/authRecipe/authWidgetWrapper.tsx
+++ b/lib/ts/recipe/authRecipe/authWidgetWrapper.tsx
@@ -55,11 +55,10 @@ const Redirector = <T, S, R, N extends NormalisedConfig<T | GetRedirectionURLCon
     const [alwaysShow, updateAlwaysShow] = useState(false);
 
     useEffect(() => {
-        // we want to do this just once, so we supply it an empty array.
-        // if we supply it with props, sessionContext,
-        // then once the user signs in, then this will route the
+        // we want to do this just once, so we supply it with only the loading statet.
+        // if we supply it with props, sessionContext, then once the user signs in, then this will route the
         // user to the dashboard, as opposed to the sign up / sign in functions.
-        if (sessionContext.doesSessionExist) {
+        if (sessionContext.loading === false && sessionContext.doesSessionExist) {
             if (props.onSessionAlreadyExists !== undefined) {
                 props.onSessionAlreadyExists();
             } else {
@@ -80,9 +79,9 @@ const Redirector = <T, S, R, N extends NormalisedConfig<T | GetRedirectionURLCon
             // cause the child component will take care of redirecting etc..
             updateAlwaysShow(true);
         }
-    }, []);
+    }, [sessionContext.loading]);
 
-    if (sessionContext.doesSessionExist && !alwaysShow) {
+    if ((sessionContext.loading === true || sessionContext.doesSessionExist) && !alwaysShow) {
         return null;
     } else {
         return <>{props.children}</>;

--- a/lib/ts/recipe/authRecipe/authWidgetWrapper.tsx
+++ b/lib/ts/recipe/authRecipe/authWidgetWrapper.tsx
@@ -55,29 +55,31 @@ const Redirector = <T, S, R, N extends NormalisedConfig<T | GetRedirectionURLCon
     const [alwaysShow, updateAlwaysShow] = useState(false);
 
     useEffect(() => {
-        // we want to do this just once, so we supply it with only the loading statet.
+        // we want to do this just once, so we supply it with only the loading state.
         // if we supply it with props, sessionContext, then once the user signs in, then this will route the
         // user to the dashboard, as opposed to the sign up / sign in functions.
-        if (sessionContext.loading === false && sessionContext.doesSessionExist) {
-            if (props.onSessionAlreadyExists !== undefined) {
-                props.onSessionAlreadyExists();
+        if (sessionContext.loading === false) {
+            if (sessionContext.doesSessionExist) {
+                if (props.onSessionAlreadyExists !== undefined) {
+                    props.onSessionAlreadyExists();
+                } else {
+                    props.authRecipe.config.onHandleEvent({
+                        action: "SESSION_ALREADY_EXISTS",
+                    });
+                    void props.authRecipe.redirect(
+                        {
+                            action: "SUCCESS",
+                            isNewUser: false,
+                            redirectToPath: getRedirectToPathFromURL(),
+                        },
+                        props.history
+                    );
+                }
             } else {
-                props.authRecipe.config.onHandleEvent({
-                    action: "SESSION_ALREADY_EXISTS",
-                });
-                void props.authRecipe.redirect(
-                    {
-                        action: "SUCCESS",
-                        isNewUser: false,
-                        redirectToPath: getRedirectToPathFromURL(),
-                    },
-                    props.history
-                );
+                // this means even if a session exists, we will still show the children
+                // cause the child component will take care of redirecting etc..
+                updateAlwaysShow(true);
             }
-        } else {
-            // this means even if a session exists, we will still show the children
-            // cause the child component will take care of redirecting etc..
-            updateAlwaysShow(true);
         }
     }, [sessionContext.loading]);
 

--- a/lib/ts/recipe/emailpassword/emailPasswordAuth.tsx
+++ b/lib/ts/recipe/emailpassword/emailPasswordAuth.tsx
@@ -24,19 +24,19 @@ import { FeatureBaseProps } from "../../types";
 import SessionAuthWrapper from "../session/sessionAuth";
 import EmailVerificationAuthWrapper from "../emailverification/emailVerificationAuth";
 import SuperTokens from "../../superTokens";
-import Recipe from "./recipe";
 import UserContextWrapper from "../../usercontext/userContextWrapper";
 import { PropsWithChildren } from "react";
 
 type Props = FeatureBaseProps & {
-    recipe: Recipe;
     requireAuth?: boolean;
     onSessionExpired?: () => void;
 };
 
 function EmailPasswordAuth(props: Props) {
     const emailVerification = (
-        <EmailVerificationAuthWrapper recipe={props.recipe.emailVerification} history={props.history}>
+        <EmailVerificationAuthWrapper
+            getRecipe={() => EmailPassword.getInstanceOrThrow().emailVerification}
+            history={props.history}>
             {props.children}
         </EmailVerificationAuthWrapper>
     );
@@ -66,16 +66,12 @@ const EmailPasswordAuthWrapper: React.FC<
         userContext?: any;
     }>
 > = ({ children, requireAuth, onSessionExpired, userContext }) => {
-    const routerInfo = SuperTokens.getInstanceOrThrow().getReactRouterDomWithCustomHistory();
+    const routerInfo = SuperTokens.getReactRouterDomWithCustomHistory();
     const history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
 
     return (
         <UserContextWrapper userContext={userContext}>
-            <EmailPasswordAuthMemo
-                history={history}
-                onSessionExpired={onSessionExpired}
-                requireAuth={requireAuth}
-                recipe={EmailPassword.getInstanceOrThrow()}>
+            <EmailPasswordAuthMemo history={history} onSessionExpired={onSessionExpired} requireAuth={requireAuth}>
                 {children}
             </EmailPasswordAuthMemo>
         </UserContextWrapper>

--- a/lib/ts/recipe/emailverification/components/features/emailVerification/index.tsx
+++ b/lib/ts/recipe/emailverification/components/features/emailVerification/index.tsx
@@ -51,7 +51,7 @@ export const EmailVerification: React.FC<Prop> = (props) => {
     const fetchIsEmailVerified = useCallback(async () => {
         const token = getQueryParams("token") ?? undefined;
         if (token === undefined) {
-            if (!sessionContext.doesSessionExist) {
+            if (sessionContext.loading === true || !sessionContext.doesSessionExist) {
                 await props.recipe.config.redirectToSignIn(props.history);
             } else {
                 // we check if the email is already verified, and if it is, then we redirect the user

--- a/lib/ts/recipe/emailverification/components/features/emailVerification/index.tsx
+++ b/lib/ts/recipe/emailverification/components/features/emailVerification/index.tsx
@@ -50,7 +50,7 @@ export const EmailVerification: React.FC<Prop> = (props) => {
 
     const fetchIsEmailVerified = useCallback(async () => {
         if (sessionContext.loading === true) {
-            // This callback should only be called if
+            // This callback should only be called if the session is already loaded
             throw new Error("Should never come here");
         }
         const token = getQueryParams("token") ?? undefined;

--- a/lib/ts/recipe/emailverification/components/features/emailVerification/index.tsx
+++ b/lib/ts/recipe/emailverification/components/features/emailVerification/index.tsx
@@ -51,7 +51,7 @@ export const EmailVerification: React.FC<Prop> = (props) => {
     const fetchIsEmailVerified = useCallback(async () => {
         const token = getQueryParams("token") ?? undefined;
         if (token === undefined) {
-            if (sessionContext.loading === true || !sessionContext.doesSessionExist) {
+            if (sessionContext.loading === false && !sessionContext.doesSessionExist) {
                 await props.recipe.config.redirectToSignIn(props.history);
             } else {
                 // we check if the email is already verified, and if it is, then we redirect the user
@@ -59,7 +59,7 @@ export const EmailVerification: React.FC<Prop> = (props) => {
             }
         }
         return false;
-    }, [props.recipe]);
+    }, [props.recipe, sessionContext]);
 
     const checkIsEmailVerified = useCallback(
         async (isVerified: boolean): Promise<void> => {
@@ -70,7 +70,7 @@ export const EmailVerification: React.FC<Prop> = (props) => {
         },
         [props.recipe, setStatus]
     );
-    useOnMountAPICall(fetchIsEmailVerified, checkIsEmailVerified);
+    useOnMountAPICall(fetchIsEmailVerified, checkIsEmailVerified, undefined, sessionContext.loading === false);
 
     const signOut = useCallback(async (): Promise<void> => {
         await props.recipe.config.signOut();

--- a/lib/ts/recipe/emailverification/components/features/emailVerification/index.tsx
+++ b/lib/ts/recipe/emailverification/components/features/emailVerification/index.tsx
@@ -49,9 +49,13 @@ export const EmailVerification: React.FC<Prop> = (props) => {
     );
 
     const fetchIsEmailVerified = useCallback(async () => {
+        if (sessionContext.loading === true) {
+            // This callback should only be called if
+            throw new Error("Should never come here");
+        }
         const token = getQueryParams("token") ?? undefined;
         if (token === undefined) {
-            if (sessionContext.loading === false && !sessionContext.doesSessionExist) {
+            if (!sessionContext.doesSessionExist) {
                 await props.recipe.config.redirectToSignIn(props.history);
             } else {
                 // we check if the email is already verified, and if it is, then we redirect the user

--- a/lib/ts/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.tsx
+++ b/lib/ts/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.tsx
@@ -37,7 +37,7 @@ import useSessionContext from "../../../../session/useSessionContext";
 export const EmailVerificationVerifyEmailLinkClicked: React.FC<VerifyEmailLinkClickedThemeProps> = (props) => {
     const styles = useContext(StyleContext);
     const t = useTranslation();
-    const { doesSessionExist } = useSessionContext();
+    const sessionContext = useSessionContext();
     const userContext = useUserContext();
     const [status, setStatus] = useState<
         "LOADING" | "INTERACTION_REQUIRED" | "INVALID" | "GENERAL_ERROR" | "SUCCESSFUL"
@@ -49,7 +49,7 @@ export const EmailVerificationVerifyEmailLinkClicked: React.FC<VerifyEmailLinkCl
         // If there is no active session we know that the verification was started elsewhere, since it requires a session
         // otherwise we assume it's the same session. The main purpose of this is to prevent mail scanners
         // from accidentally validating an email address
-        if (!doesSessionExist) {
+        if (sessionContext.loading === false && sessionContext.doesSessionExist) {
             return "INTERACTION_REQUIRED";
         }
 

--- a/lib/ts/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.tsx
+++ b/lib/ts/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.tsx
@@ -49,14 +49,14 @@ export const EmailVerificationVerifyEmailLinkClicked: React.FC<VerifyEmailLinkCl
         // If there is no active session we know that the verification was started elsewhere, since it requires a session
         // otherwise we assume it's the same session. The main purpose of this is to prevent mail scanners
         // from accidentally validating an email address
-        if (sessionContext.loading === false && sessionContext.doesSessionExist) {
+        if (sessionContext.loading === false && !sessionContext.doesSessionExist) {
             return "INTERACTION_REQUIRED";
         }
 
         return props.recipeImplementation.verifyEmail({
             userContext,
         });
-    }, [props.recipeImplementation]);
+    }, [props.recipeImplementation, sessionContext]);
 
     const handleVerifyResp = useCallback(
         async (response: Awaited<ReturnType<typeof verifyEmailOnMount>>): Promise<void> => {
@@ -80,7 +80,7 @@ export const EmailVerificationVerifyEmailLinkClicked: React.FC<VerifyEmailLinkCl
         },
         [setStatus, setErrorMessage]
     );
-    useOnMountAPICall(verifyEmailOnMount, handleVerifyResp, handleError);
+    useOnMountAPICall(verifyEmailOnMount, handleVerifyResp, handleError, sessionContext.loading === false);
 
     const { onTokenInvalidRedirect, onSuccess } = props;
 

--- a/lib/ts/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.tsx
+++ b/lib/ts/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.tsx
@@ -46,10 +46,14 @@ export const EmailVerificationVerifyEmailLinkClicked: React.FC<VerifyEmailLinkCl
     const [verifyLoading, setVerifyLoading] = useState(false);
 
     const verifyEmailOnMount = useCallback(async () => {
+        if (sessionContext.loading === true) {
+            // This callback should only be called if the session is already loaded
+            throw new Error("Should never come here");
+        }
         // If there is no active session we know that the verification was started elsewhere, since it requires a session
         // otherwise we assume it's the same session. The main purpose of this is to prevent mail scanners
         // from accidentally validating an email address
-        if (sessionContext.loading === false && !sessionContext.doesSessionExist) {
+        if (!sessionContext.doesSessionExist) {
             return "INTERACTION_REQUIRED";
         }
 

--- a/lib/ts/recipe/emailverification/emailVerificationAuth.tsx
+++ b/lib/ts/recipe/emailverification/emailVerificationAuth.tsx
@@ -33,7 +33,7 @@ const EmailVerificationAuth: React.FC<Props> = ({ children, ...props }) => {
     // doesn't rerun just because the sessionContext or props objects
     // have changed, even though the doesSessionExist & emailVerificationMode
     // have not.
-    const doesSessionExist = sessionContext.doesSessionExist;
+    const doesSessionExist = sessionContext.loading === false && sessionContext.doesSessionExist;
     const emailVerificationMode = props.recipe.config.mode;
     const propsRef = React.useRef(props);
     const userContext = useUserContext();
@@ -59,7 +59,7 @@ const EmailVerificationAuth: React.FC<Props> = ({ children, ...props }) => {
 
     useOnMountAPICall(checkIsEmailVerified, useIsEmailVerified);
 
-    if (sessionContext.doesSessionExist === false) {
+    if (doesSessionExist === false) {
         return <>{children}</>;
     }
 

--- a/lib/ts/recipe/emailverification/emailVerificationAuth.tsx
+++ b/lib/ts/recipe/emailverification/emailVerificationAuth.tsx
@@ -62,7 +62,12 @@ const EmailVerificationAuth: React.FC<Props> = ({ children, ...props }) => {
 
     useOnMountAPICall(checkIsEmailVerified, useIsEmailVerified, undefined, sessionContext.loading === false);
 
-    if (props.recipe.config.mode !== "REQUIRED" || isEmailVerified) {
+    if (
+        sessionContext.loading === true ||
+        sessionContext.doesSessionExist === false ||
+        props.recipe.config.mode !== "REQUIRED" ||
+        isEmailVerified
+    ) {
         return <>{children}</>;
     }
 

--- a/lib/ts/recipe/emailverification/emailVerificationAuth.tsx
+++ b/lib/ts/recipe/emailverification/emailVerificationAuth.tsx
@@ -57,6 +57,7 @@ const EmailVerificationAuth: React.FC<Props> = ({ children, ...props }) => {
         }
         return undefined;
     }, [sessionContext]);
+
     const useIsEmailVerified = useCallback(
         async (isEmailVerified: boolean | undefined) => {
             if (sessionContext.loading === true) {
@@ -76,12 +77,13 @@ const EmailVerificationAuth: React.FC<Props> = ({ children, ...props }) => {
 
     useOnMountAPICall(checkIsEmailVerified, useIsEmailVerified, undefined, sessionContext.loading === false);
 
-    const isNotRequired = recipe.current !== undefined && recipe.current.config.mode !== "REQUIRED";
-    if (
-        // We only render after loading has finished to eliminate flicker
-        sessionContext.loading === false &&
-        (isNotRequired || sessionContext.doesSessionExist === false || isEmailVerified)
-    ) {
+    // We only render after loading has finished to eliminate flicker
+    // recipe.current should only be undefined during SSR but this makes the type system happy
+    if (sessionContext.loading === true || recipe.current === undefined) {
+        return null;
+    }
+
+    if (recipe.current.config.mode !== "REQUIRED" || sessionContext.doesSessionExist === false || isEmailVerified) {
         return <>{children}</>;
     }
 

--- a/lib/ts/recipe/emailverification/emailVerificationAuth.tsx
+++ b/lib/ts/recipe/emailverification/emailVerificationAuth.tsx
@@ -57,7 +57,7 @@ const EmailVerificationAuth: React.FC<Props> = ({ children, ...props }) => {
         [doesSessionExist, emailVerificationMode]
     );
 
-    useOnMountAPICall(checkIsEmailVerified, useIsEmailVerified);
+    useOnMountAPICall(checkIsEmailVerified, useIsEmailVerified, undefined, sessionContext.loading === false);
 
     if (doesSessionExist === false) {
         return <>{children}</>;

--- a/lib/ts/recipe/passwordless/passwordlessAuth.tsx
+++ b/lib/ts/recipe/passwordless/passwordlessAuth.tsx
@@ -26,7 +26,6 @@ import SessionAuthWrapper from "../session/sessionAuth";
 import Passwordless from "./recipe";
 
 type Props = FeatureBaseProps & {
-    recipe: Passwordless;
     requireAuth?: boolean;
     onSessionExpired?: () => void;
 };
@@ -60,16 +59,12 @@ export default function PasswordlessAuthWrapper({
     onSessionExpired?: () => void;
     userContext?: any;
 }>) {
-    const routerInfo = SuperTokens.getInstanceOrThrow().getReactRouterDomWithCustomHistory();
+    const routerInfo = SuperTokens.getReactRouterDomWithCustomHistory();
     const history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
 
     return (
         <UserContextWrapper userContext={userContext}>
-            <PasswordlessAuthMemo
-                history={history}
-                onSessionExpired={onSessionExpired}
-                requireAuth={requireAuth}
-                recipe={Passwordless.getInstanceOrThrow()}>
+            <PasswordlessAuthMemo history={history} onSessionExpired={onSessionExpired} requireAuth={requireAuth}>
                 {children}
             </PasswordlessAuthMemo>
         </UserContextWrapper>

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -20,11 +20,13 @@ import useSessionContextFunc from "./useSessionContext";
 import { InputType, SessionContextType } from "./types";
 import SessionContext from "./sessionContext";
 import { getNormalisedUserContext } from "../../utils";
+import { SuperTokensWrapper } from "./supertokensWrapper";
 
 export default class SessionAPIWrapper {
     static useSessionContext = useSessionContextFunc;
 
     static SessionAuth = SessionAuthWrapper;
+    static SuperTokensWrapper = SuperTokensWrapper;
 
     static init(config?: InputType) {
         return Session.init(config);
@@ -76,6 +78,7 @@ const signOut = SessionAPIWrapper.signOut;
 export {
     useSessionContext,
     SessionAuth,
+    SuperTokensWrapper,
     init,
     getUserId,
     getAccessTokenPayloadSecurely,

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -20,13 +20,11 @@ import useSessionContextFunc from "./useSessionContext";
 import { InputType, SessionContextType } from "./types";
 import SessionContext from "./sessionContext";
 import { getNormalisedUserContext } from "../../utils";
-import { SuperTokensWrapper } from "./supertokensWrapper";
 
 export default class SessionAPIWrapper {
     static useSessionContext = useSessionContextFunc;
 
     static SessionAuth = SessionAuthWrapper;
-    static SuperTokensWrapper = SuperTokensWrapper;
 
     static init(config?: InputType) {
         return Session.init(config);
@@ -78,7 +76,6 @@ const signOut = SessionAPIWrapper.signOut;
 export {
     useSessionContext,
     SessionAuth,
-    SuperTokensWrapper,
     init,
     getUserId,
     getAccessTokenPayloadSecurely,

--- a/lib/ts/recipe/session/recipe.ts
+++ b/lib/ts/recipe/session/recipe.ts
@@ -129,6 +129,7 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, any
                 doesSessionExist: true,
                 accessTokenPayload,
                 userId,
+                loading: false,
             };
         }
 
@@ -137,6 +138,7 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, any
                 doesSessionExist: false,
                 accessTokenPayload: {},
                 userId: "",
+                loading: false,
             };
         }
 

--- a/lib/ts/recipe/session/sessionAuth.tsx
+++ b/lib/ts/recipe/session/sessionAuth.tsx
@@ -53,8 +53,8 @@ const SessionAuth: React.FC<PropsWithChildren<SessionAuthProps>> = ({ children, 
     const parentSessionContext = useContext(SessionContext);
 
     // assign the parent context here itself so that there is no flicker in the UI
-    const [context, setContext] = useState<SessionContextType | undefined>(
-        !isDefaultContext(parentSessionContext) ? parentSessionContext : undefined
+    const [context, setContext] = useState<SessionContextType>(
+        !isDefaultContext(parentSessionContext) ? parentSessionContext : { loading: true }
     );
 
     const session = useRef<Session>();
@@ -159,10 +159,6 @@ const SessionAuth: React.FC<PropsWithChildren<SessionAuthProps>> = ({ children, 
         // onHandleEvent changes or if the component is unmounting.
         return session.current!.addEventListener(onHandleEvent);
     }, [props]);
-
-    if (context === undefined) {
-        return null;
-    }
 
     // this will display null only if initially the below condition is true.
     // cause if the session goes from existing to non existing, then

--- a/lib/ts/recipe/session/sessionAuth.tsx
+++ b/lib/ts/recipe/session/sessionAuth.tsx
@@ -101,7 +101,7 @@ const SessionAuth: React.FC<PropsWithChildren<SessionAuthProps>> = ({ children, 
                 throw new Error("Should never come here");
             }
 
-            if (toSetContext.loading === false && !toSetContext.doesSessionExist && props.requireAuth === true) {
+            if (!toSetContext.doesSessionExist && props.requireAuth === true) {
                 props.redirectToLogin();
             } else {
                 setContext((context) => (!context.loading ? context : toSetContext));

--- a/lib/ts/recipe/session/sessionAuth.tsx
+++ b/lib/ts/recipe/session/sessionAuth.tsx
@@ -65,12 +65,6 @@ const SessionAuth: React.FC<PropsWithChildren<SessionAuthProps>> = ({ children, 
             session.current = Session.getInstanceOrThrow();
         }
 
-        // if it's not the default context, it means SessionAuth from top has
-        // given us a sessionContext.
-        if (!isDefaultContext(parentSessionContext)) {
-            return parentSessionContext;
-        }
-
         if (!context.loading) {
             return context;
         }
@@ -102,8 +96,11 @@ const SessionAuth: React.FC<PropsWithChildren<SessionAuthProps>> = ({ children, 
 
     const setInitialContextAndMaybeRedirect = useCallback(
         async (toSetContext: SessionContextType) => {
-            // if this component is unmounting, or the context has already
-            // been set, then we don't need to proceed...
+            if (toSetContext.loading === true) {
+                // We should not be updating the context to loading
+                throw new Error("Should never come here");
+            }
+
             if (toSetContext.loading === false && !toSetContext.doesSessionExist && props.requireAuth === true) {
                 props.redirectToLogin();
             } else {

--- a/lib/ts/recipe/session/sessionContext.ts
+++ b/lib/ts/recipe/session/sessionContext.ts
@@ -1,14 +1,13 @@
 import React from "react";
 import { SessionContextType } from "./types";
 
-const SessionContext = React.createContext<SessionContextType>({
-    doesSessionExist: false,
-    userId: "DEFAULT_USER_ID",
-    accessTokenPayload: {},
+const SessionContext = React.createContext<SessionContextType & { isDefault: boolean }>({
+    loading: true,
+    isDefault: true,
 });
 
-export function isDefaultContext(sessionContext: SessionContextType): boolean {
-    return sessionContext.userId === "DEFAULT_USER_ID";
+export function isDefaultContext(sessionContext: SessionContextType & { isDefault: boolean }): boolean {
+    return sessionContext.isDefault;
 }
 
 export default SessionContext;

--- a/lib/ts/recipe/session/supertokensWrapper.tsx
+++ b/lib/ts/recipe/session/supertokensWrapper.tsx
@@ -1,0 +1,17 @@
+import { PropsWithChildren } from "react";
+import UserContextWrapper from "../../usercontext/userContextWrapper";
+import SessionAuthWrapper, { SessionAuthProps } from "./sessionAuth";
+
+export const SuperTokensWrapper: React.FC<
+    PropsWithChildren<
+        SessionAuthProps & {
+            userContext?: any;
+        }
+    >
+> = (props) => {
+    return (
+        <UserContextWrapper userContext={props.userContext}>
+            <SessionAuthWrapper {...props} />
+        </UserContextWrapper>
+    );
+};

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -21,8 +21,13 @@ export type InputType = WebJSInputType & {
     onHandleEvent?: (event: RecipeEventWithSessionContext) => void;
 };
 
-export type SessionContextType = {
-    doesSessionExist: boolean;
-    userId: string;
-    accessTokenPayload: any;
-};
+export type SessionContextType =
+    | {
+          doesSessionExist: boolean;
+          userId: string;
+          accessTokenPayload: any;
+          loading: false;
+      }
+    | {
+          loading: true;
+      };

--- a/lib/ts/recipe/session/useSessionContext.ts
+++ b/lib/ts/recipe/session/useSessionContext.ts
@@ -3,6 +3,13 @@ import React from "react";
 import SessionContext from "./sessionContext";
 import { SessionContextType } from "./types";
 
-const useSessionContext = (): SessionContextType => React.useContext(SessionContext);
+const useSessionContext = (): SessionContextType => {
+    const ctx = React.useContext(SessionContext);
+
+    if (ctx.isDefault) {
+        throw new Error("Cannot use useSessionContext outside auth components.");
+    }
+    return ctx;
+};
 
 export default useSessionContext;

--- a/lib/ts/recipe/session/useSessionContext.ts
+++ b/lib/ts/recipe/session/useSessionContext.ts
@@ -7,7 +7,7 @@ const useSessionContext = (): SessionContextType => {
     const ctx = React.useContext(SessionContext);
 
     if (ctx.isDefault) {
-        throw new Error("Cannot use useSessionContext outside auth components.");
+        throw new Error("Cannot use useSessionContext outside auth wrapper components.");
     }
     return ctx;
 };

--- a/lib/ts/recipe/thirdparty/thirdpartyAuth.tsx
+++ b/lib/ts/recipe/thirdparty/thirdpartyAuth.tsx
@@ -24,19 +24,19 @@ import { FeatureBaseProps } from "../../types";
 import SessionAuthWrapper from "../session/sessionAuth";
 import EmailVerificationAuthWrapper from "../emailverification/emailVerificationAuth";
 import SuperTokens from "../../superTokens";
-import Recipe from "./recipe";
 import UserContextWrapper from "../../usercontext/userContextWrapper";
 import { PropsWithChildren } from "react";
 
 type Props = FeatureBaseProps & {
-    recipe: Recipe;
     requireAuth?: boolean;
     onSessionExpired?: () => void;
 };
 
 function ThirdPartyAuth(props: Props) {
     const emailVerification = (
-        <EmailVerificationAuthWrapper recipe={props.recipe.emailVerification} history={props.history}>
+        <EmailVerificationAuthWrapper
+            getRecipe={() => ThirdParty.getInstanceOrThrow().emailVerification}
+            history={props.history}>
             {props.children}
         </EmailVerificationAuthWrapper>
     );
@@ -66,15 +66,11 @@ const ThirdPartyAuthWrapper: React.FC<
         userContext?: any;
     }>
 > = ({ children, requireAuth, onSessionExpired, userContext }) => {
-    const routerInfo = SuperTokens.getInstanceOrThrow().getReactRouterDomWithCustomHistory();
+    const routerInfo = SuperTokens.getReactRouterDomWithCustomHistory();
     const history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
     return (
         <UserContextWrapper userContext={userContext}>
-            <ThirdPartyAuthMemo
-                history={history}
-                onSessionExpired={onSessionExpired}
-                requireAuth={requireAuth}
-                recipe={ThirdParty.getInstanceOrThrow()}>
+            <ThirdPartyAuthMemo history={history} onSessionExpired={onSessionExpired} requireAuth={requireAuth}>
                 {children}
             </ThirdPartyAuthMemo>
         </UserContextWrapper>

--- a/lib/ts/recipe/thirdpartyemailpassword/thirdpartyEmailpasswordAuth.tsx
+++ b/lib/ts/recipe/thirdpartyemailpassword/thirdpartyEmailpasswordAuth.tsx
@@ -24,19 +24,19 @@ import { FeatureBaseProps } from "../../types";
 import SessionAuthWrapper from "../session/sessionAuth";
 import EmailVerificationAuthWrapper from "../emailverification/emailVerificationAuth";
 import SuperTokens from "../../superTokens";
-import Recipe from "./recipe";
 import UserContextWrapper from "../../usercontext/userContextWrapper";
 import { PropsWithChildren } from "react";
 
 type Props = FeatureBaseProps & {
-    recipe: Recipe;
     requireAuth?: boolean;
     onSessionExpired?: () => void;
 };
 
 function ThirdPartyEmailPasswordAuth(props: Props) {
     const emailVerification = (
-        <EmailVerificationAuthWrapper recipe={props.recipe.emailVerification} history={props.history}>
+        <EmailVerificationAuthWrapper
+            getRecipe={() => ThirdPartyEmailPassword.getInstanceOrThrow().emailVerification}
+            history={props.history}>
             {props.children}
         </EmailVerificationAuthWrapper>
     );
@@ -69,15 +69,14 @@ const ThirdPartyEmailPasswordAuthWrapper: React.FC<
         userContext?: any;
     }>
 > = ({ children, requireAuth, onSessionExpired, userContext }) => {
-    const routerInfo = SuperTokens.getInstanceOrThrow().getReactRouterDomWithCustomHistory();
+    const routerInfo = SuperTokens.getReactRouterDomWithCustomHistory();
     const history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
     return (
         <UserContextWrapper userContext={userContext}>
             <ThirdPartyEmailPasswordAuthMemo
                 history={history}
                 onSessionExpired={onSessionExpired}
-                requireAuth={requireAuth}
-                recipe={ThirdPartyEmailPassword.getInstanceOrThrow()}>
+                requireAuth={requireAuth}>
                 {children}
             </ThirdPartyEmailPasswordAuthMemo>
         </UserContextWrapper>

--- a/lib/ts/recipe/thirdpartypasswordless/thirdpartyPasswordlessAuth.tsx
+++ b/lib/ts/recipe/thirdpartypasswordless/thirdpartyPasswordlessAuth.tsx
@@ -24,19 +24,19 @@ import { FeatureBaseProps } from "../../types";
 import SessionAuth from "../session/sessionAuth";
 import EmailVerificationAuth from "../emailverification/emailVerificationAuth";
 import SuperTokens from "../../superTokens";
-import Recipe from "./recipe";
 import { PropsWithChildren } from "react";
 import UserContextWrapper from "../../usercontext/userContextWrapper";
 
 type Props = FeatureBaseProps & {
-    recipe: Recipe;
     requireAuth?: boolean;
     onSessionExpired?: () => void;
 };
 
 function ThirdPartyPasswordlessAuth(props: Props) {
     const emailVerification = (
-        <EmailVerificationAuth recipe={props.recipe.emailVerification} history={props.history}>
+        <EmailVerificationAuth
+            getRecipe={() => ThirdPartyPasswordless.getInstanceOrThrow().emailVerification}
+            history={props.history}>
             {props.children}
         </EmailVerificationAuth>
     );
@@ -69,15 +69,14 @@ const ThirdPartyPasswordlessAuthWrapper: React.FC<
         userContext?: any;
     }>
 > = ({ children, requireAuth, onSessionExpired, userContext }) => {
-    const routerInfo = SuperTokens.getInstanceOrThrow().getReactRouterDomWithCustomHistory();
+    const routerInfo = SuperTokens.getReactRouterDomWithCustomHistory();
     const history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
     return (
         <UserContextWrapper userContext={userContext}>
             <ThirdPartyPasswordlessAuthMemo
                 history={history}
                 onSessionExpired={onSessionExpired}
-                requireAuth={requireAuth}
-                recipe={ThirdPartyPasswordless.getInstanceOrThrow()}>
+                requireAuth={requireAuth}>
                 {children}
             </ThirdPartyPasswordlessAuthMemo>
         </UserContextWrapper>

--- a/lib/ts/superTokens.tsx
+++ b/lib/ts/superTokens.tsx
@@ -182,6 +182,10 @@ export default class SuperTokens {
         return getSuperTokensRoutesForReactRouterDom(SuperTokens.getInstanceOrThrow());
     }
 
+    static getReactRouterDomWithCustomHistory(): { router: { Route: any }; useHistoryCustom: () => any } | undefined {
+        return this.instance !== undefined ? this.instance.getReactRouterDomWithCustomHistory() : undefined;
+    }
+
     /*
      * Instance Methods.
      */

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -390,6 +390,17 @@ export function getNormalisedUserContext(userContext?: any): any {
     return userContext === undefined ? {} : userContext;
 }
 
+/**
+ * This function handles calling APIs that should only be called once during mount (mostly on mount of a route/feature component).
+ * It's split into multiple callbacks (fetch + handleResponse/handleError) because we expect fetch to take longer and
+ * and the component may be unmounted during the first fetch, in which case we want to avoid updating state/redirecting.
+ * This is especially relevant for development in strict mode with React 18 (and in the future for concurrent rendering).
+ *
+ * @param fetch This is a callback that is only called once on mount. Mostly it's for consuming tokens/doing one time only API calls
+ * @param handleResponse This is called with the result of the first (fetch) call if it succeeds.
+ * @param handleError This is called with the error of the first (fetch) call if it rejects.
+ * @param startLoading Will start the whole process if this is set to true (or omitted). Mostly used to wait for session loading.
+ */
 export const useOnMountAPICall = <T>(
     fetch: () => Promise<T>,
     handleResponse: (consumeResp: T) => Promise<void>,

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -393,7 +393,8 @@ export function getNormalisedUserContext(userContext?: any): any {
 export const useOnMountAPICall = <T>(
     fetch: () => Promise<T>,
     handleResponse: (consumeResp: T) => Promise<void>,
-    handleError?: (err: unknown, consumeResp: T | undefined) => void
+    handleError?: (err: unknown, consumeResp: T | undefined) => void,
+    startLoading = true
 ) => {
     const consumeReq = useRef<Promise<T>>();
 
@@ -416,11 +417,14 @@ export const useOnMountAPICall = <T>(
                 }
             }
         };
-        const ctrl = new AbortController();
+        if (startLoading) {
+            const ctrl = new AbortController();
 
-        void effect(ctrl.signal);
-        return () => {
-            ctrl.abort();
-        };
-    }, [consumeReq, fetch, handleResponse, handleError]);
+            void effect(ctrl.signal);
+            return () => {
+                ctrl.abort();
+            };
+        }
+        return;
+    }, [consumeReq, fetch, handleResponse, handleError, startLoading]);
 };

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "size-limit": [
         {
             "path": "lib/build/index.js",
-            "limit": "16kb"
+            "limit": "28kb"
         },
         {
             "path": "recipe/session/index.js",

--- a/package.json
+++ b/package.json
@@ -105,11 +105,11 @@
     "size-limit": [
         {
             "path": "lib/build/index.js",
-            "limit": "28kb"
+            "limit": "30kb"
         },
         {
             "path": "recipe/session/index.js",
-            "limit": "28kb"
+            "limit": "30kb"
         },
         {
             "path": "recipe/thirdpartyemailpassword/index.js",

--- a/test/end-to-end/passwordless.test.js
+++ b/test/end-to-end/passwordless.test.js
@@ -1330,17 +1330,8 @@ export function getPasswordlessTestCases({ authRecipe, logId, generalErrorRecipe
                     "ST_LOGS SESSION OVERRIDE ADD_AXIOS_INTERCEPTORS",
                     "ST_LOGS SESSION OVERRIDE GET_JWT_PAYLOAD_SECURELY",
                     "ST_LOGS SESSION OVERRIDE GET_USER_ID",
-                    ...(isReact16()
-                        ? [
-                              `ST_LOGS ${logId} ON_HANDLE_EVENT SESSION_ALREADY_EXISTS`,
-                              `ST_LOGS ${logId} GET_REDIRECTION_URL SUCCESS`,
-                          ]
-                        : [
-                              `ST_LOGS ${logId} ON_HANDLE_EVENT SESSION_ALREADY_EXISTS`,
-                              `ST_LOGS ${logId} GET_REDIRECTION_URL SUCCESS`,
-                              `ST_LOGS ${logId} ON_HANDLE_EVENT SESSION_ALREADY_EXISTS`,
-                              `ST_LOGS ${logId} GET_REDIRECTION_URL SUCCESS`,
-                          ]),
+                    `ST_LOGS ${logId} ON_HANDLE_EVENT SESSION_ALREADY_EXISTS`,
+                    `ST_LOGS ${logId} GET_REDIRECTION_URL SUCCESS`,
                     "ST_LOGS SESSION OVERRIDE GET_JWT_PAYLOAD_SECURELY",
                     "ST_LOGS SESSION OVERRIDE GET_USER_ID",
                 ]);
@@ -1471,18 +1462,8 @@ export function getPasswordlessTestCases({ authRecipe, logId, generalErrorRecipe
                     "ST_LOGS SESSION OVERRIDE ADD_AXIOS_INTERCEPTORS",
                     "ST_LOGS SESSION OVERRIDE GET_JWT_PAYLOAD_SECURELY",
                     "ST_LOGS SESSION OVERRIDE GET_USER_ID",
-
-                    ...(isReact16()
-                        ? [
-                              `ST_LOGS ${logId} ON_HANDLE_EVENT SESSION_ALREADY_EXISTS`,
-                              `ST_LOGS ${logId} GET_REDIRECTION_URL SUCCESS`,
-                          ]
-                        : [
-                              `ST_LOGS ${logId} ON_HANDLE_EVENT SESSION_ALREADY_EXISTS`,
-                              `ST_LOGS ${logId} GET_REDIRECTION_URL SUCCESS`,
-                              `ST_LOGS ${logId} ON_HANDLE_EVENT SESSION_ALREADY_EXISTS`,
-                              `ST_LOGS ${logId} GET_REDIRECTION_URL SUCCESS`,
-                          ]),
+                    `ST_LOGS ${logId} ON_HANDLE_EVENT SESSION_ALREADY_EXISTS`,
+                    `ST_LOGS ${logId} GET_REDIRECTION_URL SUCCESS`,
                     "ST_LOGS SESSION OVERRIDE GET_JWT_PAYLOAD_SECURELY",
                     "ST_LOGS SESSION OVERRIDE GET_USER_ID",
                 ]);

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -38,7 +38,6 @@ import {
     getAuthPageHeaderText,
     getLoginWithRedirectToSignUp,
     screenshotOnFailure,
-    isReact16,
     getGeneralError,
     waitForSTElement,
 } from "../helpers";
@@ -263,17 +262,8 @@ describe("SuperTokens SignUp", function () {
                 "ST_LOGS SESSION OVERRIDE ADD_AXIOS_INTERCEPTORS",
                 "ST_LOGS SESSION OVERRIDE GET_JWT_PAYLOAD_SECURELY",
                 "ST_LOGS SESSION OVERRIDE GET_USER_ID",
-                ...(isReact16()
-                    ? [
-                          "ST_LOGS EMAIL_PASSWORD ON_HANDLE_EVENT SESSION_ALREADY_EXISTS",
-                          "ST_LOGS EMAIL_PASSWORD GET_REDIRECTION_URL SUCCESS",
-                      ]
-                    : [
-                          "ST_LOGS EMAIL_PASSWORD ON_HANDLE_EVENT SESSION_ALREADY_EXISTS",
-                          "ST_LOGS EMAIL_PASSWORD GET_REDIRECTION_URL SUCCESS",
-                          "ST_LOGS EMAIL_PASSWORD ON_HANDLE_EVENT SESSION_ALREADY_EXISTS",
-                          "ST_LOGS EMAIL_PASSWORD GET_REDIRECTION_URL SUCCESS",
-                      ]),
+                "ST_LOGS EMAIL_PASSWORD ON_HANDLE_EVENT SESSION_ALREADY_EXISTS",
+                "ST_LOGS EMAIL_PASSWORD GET_REDIRECTION_URL SUCCESS",
                 "ST_LOGS SESSION OVERRIDE GET_JWT_PAYLOAD_SECURELY",
                 "ST_LOGS SESSION OVERRIDE GET_USER_ID",
                 "ST_LOGS SESSION OVERRIDE ADD_FETCH_INTERCEPTORS_AND_RETURN_MODIFIED_FETCH",

--- a/test/unit/recipe/emailpassword/emailPasswordAuth.test.tsx
+++ b/test/unit/recipe/emailpassword/emailPasswordAuth.test.tsx
@@ -1,0 +1,302 @@
+import React, { useContext } from "react";
+import "@testing-library/jest-dom";
+import { render, waitFor, waitForElementToBeRemoved } from "@testing-library/react";
+import SuperTokens from "../../../../lib/ts/superTokens";
+import Session from "../../../../lib/ts/recipe/session/recipe";
+import EmailPasswordRecipe from "../../../../lib/ts/recipe/emailpassword/recipe";
+import { EmailPasswordAuth } from "../../../../lib/ts/recipe/emailpassword";
+import SessionContext from "../../../../lib/ts/recipe/session/sessionContext";
+import { SessionContextType } from "../../../../lib/ts/recipe/session";
+
+const MockSession = {
+    addEventListener: jest.fn(),
+    getUserId: jest.fn(),
+    getAccessTokenPayloadSecurely: jest.fn(),
+    doesSessionExist: jest.fn(),
+};
+
+const MockSessionConsumer = () => {
+    const session = useContext(SessionContext);
+
+    if (session.loading === true) {
+        return <h1>Loading</h1>;
+    }
+
+    if (!session.doesSessionExist) {
+        return <h1>Session doesn't exist</h1>;
+    }
+
+    return (
+        <>
+            <span>userId: {session.userId}</span>
+            <span>accessTokenPayload: {JSON.stringify(session.accessTokenPayload)}</span>
+        </>
+    );
+};
+
+const setMockResolvesSession = (ctx: SessionContextType) => {
+    if (ctx.loading === true) {
+        // We "simulate" loading by returning these promises that won't ever resolve
+        MockSession.getUserId.mockReturnValue(new Promise<any>(() => {}));
+        MockSession.getAccessTokenPayloadSecurely.mockReturnValue(new Promise<any>(() => {}));
+        MockSession.doesSessionExist.mockReturnValue(new Promise<any>(() => {}));
+    } else {
+        MockSession.getUserId.mockResolvedValue(ctx.userId);
+        MockSession.getAccessTokenPayloadSecurely.mockResolvedValue(ctx.accessTokenPayload);
+        MockSession.doesSessionExist.mockResolvedValue(ctx.doesSessionExist);
+    }
+};
+
+jest.spyOn(SuperTokens, "getInstanceOrThrow").mockImplementation(
+    () =>
+        ({
+            getReactRouterDomWithCustomHistory: jest.fn(),
+        } as any)
+);
+jest.spyOn(Session, "getInstanceOrThrow").mockImplementation(() => MockSession as any);
+
+const emailVerificationConfig = {
+    mode: "OFF",
+};
+const isEmailVerifiedMock = jest.fn();
+const MockEmailPassword = {
+    emailVerification: {
+        config: emailVerificationConfig,
+        isEmailVerified: isEmailVerifiedMock,
+        redirect: jest.fn(),
+    },
+    redirectToAuthWithRedirectToPath: jest.fn(),
+};
+jest.spyOn(EmailPasswordRecipe, "getInstanceOrThrow").mockImplementation(() => MockEmailPassword as any);
+
+describe("EmailPasswordAuth", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        setMockResolvesSession({
+            userId: "mock-user-id",
+            accessTokenPayload: {},
+            doesSessionExist: true,
+            loading: false,
+        });
+
+        emailVerificationConfig.mode = "OFF";
+        isEmailVerifiedMock.mockReset();
+    });
+
+    test("setup event listener when no parent provider", async () => {
+        // when
+        const result = render(<EmailPasswordAuth />);
+
+        // then
+        // This should be called twice with react 18 strict mode
+        await waitFor(() => expect(MockSession.addEventListener).toHaveBeenCalledTimes(2));
+    });
+
+    test("unsubscribe event listener on unmount", async () => {
+        // given
+        const mockUnsubscribe = jest.fn();
+        MockSession.addEventListener.mockImplementationOnce(() => mockUnsubscribe);
+
+        // when
+        const result = render(<EmailPasswordAuth>mockRenderedText</EmailPasswordAuth>);
+
+        expect(await result.findByText(`mockRenderedText`)).toBeInTheDocument();
+
+        result.unmount();
+
+        // then
+        expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    test("set initial context", async () => {
+        // when
+        const result = render(
+            <EmailPasswordAuth>
+                <MockSessionConsumer />
+            </EmailPasswordAuth>
+        );
+
+        // then
+        expect(await result.findByText(/^userId:/)).toHaveTextContent(`userId: mock-user-id`);
+        expect(await result.findByText(/^accessTokenPayload:/)).toHaveTextContent(
+            `accessTokenPayload: ${JSON.stringify({})}`
+        );
+    });
+
+    describe("children rendering", () => {
+        const testCases = [
+            // Even if email verification is required it should render if a session isn't required and doesn't exists
+            {
+                emailVerificationRequired: true,
+                isEmailVerified: false,
+                requireAuth: false,
+                doesSessionExist: false,
+                shouldRender: true,
+            },
+
+            // It should render only if email is verified if a session exists and verification is required
+            {
+                emailVerificationRequired: true,
+                isEmailVerified: false,
+                requireAuth: false,
+                doesSessionExist: true,
+                shouldRender: false,
+            },
+            {
+                emailVerificationRequired: true,
+                isEmailVerified: false,
+                requireAuth: true,
+                doesSessionExist: true,
+                shouldRender: false,
+            },
+            {
+                emailVerificationRequired: true,
+                isEmailVerified: true,
+                requireAuth: true,
+                doesSessionExist: true,
+                shouldRender: true,
+            },
+
+            // requireAuth should default to true
+            {
+                emailVerificationRequired: false,
+                isEmailVerified: false,
+                requireAuth: undefined,
+                doesSessionExist: false,
+                shouldRender: false,
+            },
+            {
+                emailVerificationRequired: false,
+                isEmailVerified: false,
+                requireAuth: undefined,
+                doesSessionExist: true,
+                shouldRender: true,
+            },
+            {
+                emailVerificationRequired: true,
+                requireAuth: undefined,
+                doesSessionExist: false,
+                shouldRender: false,
+            },
+            {
+                emailVerificationRequired: true,
+                isEmailVerified: false,
+                requireAuth: undefined,
+                doesSessionExist: true,
+                shouldRender: false,
+            },
+
+            // it should match sessionAuth behavior otherwise
+
+            {
+                emailVerificationRequired: false,
+                isEmailVerified: false,
+                requireAuth: false,
+                doesSessionExist: false,
+                shouldRender: true,
+            },
+            {
+                emailVerificationRequired: false,
+                isEmailVerified: false,
+                requireAuth: true,
+                doesSessionExist: false,
+                shouldRender: false,
+            },
+            {
+                emailVerificationRequired: false,
+                isEmailVerified: false,
+                requireAuth: false,
+                doesSessionExist: true,
+                shouldRender: true,
+            },
+            {
+                emailVerificationRequired: false,
+                isEmailVerified: false,
+                requireAuth: true,
+                doesSessionExist: true,
+                shouldRender: true,
+            },
+        ];
+
+        testCases.forEach(
+            ({ doesSessionExist, requireAuth, shouldRender, emailVerificationRequired, isEmailVerified }) => {
+                test(`${shouldRender ? "do" : "don't"} render when requireAuth=${requireAuth} and session ${
+                    doesSessionExist ? "exists" : "doesn't exist"
+                } w/ email verification mode ${
+                    emailVerificationRequired ? "required" : "off"
+                } and isEmailVerified: ${isEmailVerified}`, async () => {
+                    // given
+                    emailVerificationConfig.mode = emailVerificationRequired ? "REQUIRED" : "OFF";
+                    isEmailVerifiedMock.mockResolvedValue({ isVerified: isEmailVerified });
+                    setMockResolvesSession({
+                        doesSessionExist,
+                        accessTokenPayload: {},
+                        userId: "mock-id",
+                        loading: false,
+                    });
+
+                    // when
+                    const result = render(
+                        <EmailPasswordAuth requireAuth={requireAuth as any}>
+                            <MockSessionConsumer />
+                        </EmailPasswordAuth>
+                    );
+
+                    if (!requireAuth && result.queryByText("Loading")) {
+                        await waitForElementToBeRemoved(() => result.queryByText("Loading"));
+                    }
+
+                    const child = await result
+                        .findByText(doesSessionExist ? /userId:/i : "Session doesn't exist")
+                        .catch(() => null);
+
+                    // then
+                    if (shouldRender) {
+                        expect(child).toBeInTheDocument();
+                    } else {
+                        expect(child).not.toBeInTheDocument();
+                    }
+                });
+            }
+        );
+
+        test("don't render when requireAuth=true and session is loading", async () => {
+            // given
+            setMockResolvesSession({
+                loading: true,
+            });
+
+            // when
+            const result = render(
+                <EmailPasswordAuth requireAuth={true}>
+                    <h1>Children</h1>
+                </EmailPasswordAuth>
+            );
+
+            const child = await result.findByText(/Children/i).catch(() => null);
+
+            // then
+            expect(child).not.toBeInTheDocument();
+        });
+
+        test("do render when requireAuth=false and session is loading", async () => {
+            // given
+            setMockResolvesSession({
+                loading: true,
+            });
+
+            // when
+            const result = render(
+                <EmailPasswordAuth requireAuth={false}>
+                    <h1>Children</h1>
+                </EmailPasswordAuth>
+            );
+
+            const child = await result.findByText(/Children/i).catch(() => null);
+
+            // then
+            expect(child).toBeInTheDocument();
+        });
+    });
+});

--- a/test/unit/recipe/emailpassword/emailPasswordAuth.test.tsx
+++ b/test/unit/recipe/emailpassword/emailPasswordAuth.test.tsx
@@ -280,7 +280,7 @@ describe("EmailPasswordAuth", () => {
             expect(child).not.toBeInTheDocument();
         });
 
-        test("do render when requireAuth=false and session is loading", async () => {
+        test("don't render when requireAuth=false and session is loading", async () => {
             // given
             setMockResolvesSession({
                 loading: true,
@@ -296,7 +296,7 @@ describe("EmailPasswordAuth", () => {
             const child = await result.findByText(/Children/i).catch(() => null);
 
             // then
-            expect(child).toBeInTheDocument();
+            expect(child).not.toBeInTheDocument();
         });
     });
 });

--- a/test/unit/recipe/session/SessionContext.test.ts
+++ b/test/unit/recipe/session/SessionContext.test.ts
@@ -2,12 +2,11 @@ import { isDefaultContext } from "../../../../lib/ts/recipe/session/sessionConte
 import { SessionContextType } from "../../../../lib/ts/recipe/session";
 
 describe("SessionContext", () => {
-    test("return true if user id is DEFAULT_USER_ID", () => {
+    test("return true if isDefault is true", () => {
         // given
-        const mockSessionContext: SessionContextType = {
-            accessTokenPayload: {},
-            userId: "DEFAULT_USER_ID",
-            doesSessionExist: false,
+        const mockSessionContext: { loading: true; isDefault: true } = {
+            loading: true,
+            isDefault: true,
         };
 
         // when
@@ -17,12 +16,14 @@ describe("SessionContext", () => {
         expect(isDefault).toBe(true);
     });
 
-    test("return false if user id isn't DEFAULT_USER_ID", () => {
+    test("return false if user isDefault is false", () => {
         // given
-        const mockSessionContext: SessionContextType = {
+        const mockSessionContext = {
             accessTokenPayload: {},
             doesSessionExist: false,
             userId: "NOT_DEFAULT_USER_ID",
+            loading: false,
+            isDefault: false,
         };
 
         // when

--- a/test/unit/recipe/session/sessionAuth.test.tsx
+++ b/test/unit/recipe/session/sessionAuth.test.tsx
@@ -14,9 +14,9 @@ const MockSession = {
 };
 
 const MockSessionConsumer = () => {
-    const session = useContext<SessionContextType>(SessionContext);
+    const session = useContext(SessionContext);
 
-    if (!session.doesSessionExist) {
+    if (session.loading === true || !session.doesSessionExist) {
         return (
             <>
                 <h1>Session doesn't exist</h1>
@@ -33,6 +33,9 @@ const MockSessionConsumer = () => {
 };
 
 const setMockResolves = (ctx: SessionContextType) => {
+    if (ctx.loading === true) {
+        throw new Error();
+    }
     MockSession.getUserId.mockResolvedValue(ctx.userId);
     MockSession.getAccessTokenPayloadSecurely.mockResolvedValue(ctx.accessTokenPayload);
     MockSession.doesSessionExist.mockResolvedValue(ctx.doesSessionExist);
@@ -48,6 +51,7 @@ describe("SessionAuth", () => {
             userId: "mock-user-id",
             accessTokenPayload: {},
             doesSessionExist: true,
+            loading: false,
         });
     });
 
@@ -135,6 +139,7 @@ describe("SessionAuth", () => {
                     doesSessionExist,
                     accessTokenPayload: {},
                     userId: "mock-id",
+                    loading: false,
                 });
 
                 // when
@@ -307,6 +312,7 @@ describe("SessionAuth", () => {
                 doesSessionExist: true,
                 accessTokenPayload: { foo: "bar" },
                 userId: "before-id",
+                loading: false,
             });
 
             const result = render(

--- a/test/unit/recipe/session/sessionAuth.test.tsx
+++ b/test/unit/recipe/session/sessionAuth.test.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import "@testing-library/jest-dom";
-import { act, render, waitFor } from "@testing-library/react";
+import { act, render, waitFor, waitForElementToBeRemoved } from "@testing-library/react";
 import Session from "../../../../lib/ts/recipe/session/recipe";
 import SessionAuth from "../../../../lib/ts/recipe/session/sessionAuth";
 import SessionContext from "../../../../lib/ts/recipe/session/sessionContext";
@@ -15,13 +15,12 @@ const MockSession = {
 
 const MockSessionConsumer = () => {
     const session = useContext(SessionContext);
+    if (session.loading === true) {
+        return <h1>Loading</h1>;
+    }
 
-    if (session.loading === true || !session.doesSessionExist) {
-        return (
-            <>
-                <h1>Session doesn't exist</h1>
-            </>
-        );
+    if (!session.doesSessionExist) {
+        return <h1>Session doesn't exist</h1>;
     }
 
     return (
@@ -150,11 +149,17 @@ describe("SessionAuth", () => {
                 const result = render(
                     // We're passing redirectToLogin just to make sure it doesn't throw when requireAuth=true
                     <SessionAuth requireAuth={requireAuth as any} redirectToLogin={noop}>
-                        <h1>Children</h1>
+                        <MockSessionConsumer />
                     </SessionAuth>
                 );
 
-                const child = await result.findByText(/Children/i).catch(() => null);
+                if (!requireAuth) {
+                    await waitForElementToBeRemoved(() => result.queryByText("Loading"));
+                }
+
+                const child = await result
+                    .findByText(doesSessionExist ? /userId:/i : "Session doesn't exist")
+                    .catch(() => null);
 
                 // then
                 if (shouldRender) {
@@ -211,17 +216,67 @@ describe("SessionAuth", () => {
         test("call onSessionExpired on UNAUTHORISED", async () => {
             // given
             const mockOnSessionExpired = jest.fn();
-
-            MockSession.addEventListener.mockImplementationOnce((fn) => fn({ action: "UNAUTHORISED" }));
+            let listenerFn: (event: any) => void;
+            MockSession.addEventListener.mockImplementation((fn) => {
+                listenerFn = fn;
+            });
 
             // when
-            const result = render(<SessionAuth onSessionExpired={mockOnSessionExpired}>mockRenderedText</SessionAuth>);
+            const result = render(
+                <SessionAuth onSessionExpired={mockOnSessionExpired}>
+                    <MockSessionConsumer />
+                </SessionAuth>
+            );
 
             // Wait for full rendering
-            expect(await result.findByText(`mockRenderedText`)).toBeInTheDocument();
+            expect(await result.findByText(/^userId:/)).toBeInTheDocument();
+
+            act(() =>
+                listenerFn({
+                    action: "UNAUTHORISED",
+                    sessionContext: {
+                        doesSessionExist: false,
+                        accessTokenPayload: {},
+                        userId: "",
+                    },
+                })
+            );
 
             // then
             expect(mockOnSessionExpired).toHaveBeenCalledTimes(1);
+
+            await result.findByText("Session doesn't exist");
+        });
+
+        test("update context on SIGN_OUT", async () => {
+            // given
+            let listenerFn: (event: any) => void;
+            MockSession.addEventListener.mockImplementation((fn) => {
+                listenerFn = fn;
+            });
+
+            // when
+            const result = render(
+                <SessionAuth>
+                    <MockSessionConsumer />
+                </SessionAuth>
+            );
+
+            // Wait for full rendering
+            expect(await result.findByText(/^userId:/)).toBeInTheDocument();
+
+            act(() =>
+                listenerFn({
+                    action: "SIGN_OUT",
+                    sessionContext: {
+                        doesSessionExist: false,
+                        accessTokenPayload: {},
+                        userId: "",
+                    },
+                })
+            );
+
+            await result.findByText("Session doesn't exist");
         });
 
         test("update context on SESSION_CREATED", async () => {
@@ -339,162 +394,5 @@ describe("SessionAuth", () => {
         expect(await result.findByText(/^accessTokenPayload:/)).toHaveTextContent(
             `accessTokenPayload: ${JSON.stringify(mockAccessTokenPayload)}`
         );
-    });
-
-    describe("onSessionExpired", () => {
-        test("not update context when prop is passed", async () => {
-            // given
-            const mockOnSessionExpired = jest.fn();
-            let listenerFn: (event: any) => void;
-
-            MockSession.addEventListener.mockImplementationOnce((listener) => {
-                listenerFn = listener;
-
-                return () => {};
-            });
-
-            setMockResolves({
-                doesSessionExist: true,
-                accessTokenPayload: { foo: "bar" },
-                userId: "before-id",
-                loading: false,
-            });
-
-            const result = render(
-                <SessionAuth requireAuth={true} redirectToLogin={() => {}}>
-                    <MockSessionConsumer />
-                </SessionAuth>
-            );
-
-            const UserId = () => result.findByText(/^userId/);
-            const AccessTokenPayload = () => result.findByText(/^accessTokenPayload/);
-
-            expect(await UserId()).toHaveTextContent(`userId: before-id`);
-            expect(await AccessTokenPayload()).toHaveTextContent(
-                `accessTokenPayload: ${JSON.stringify({ foo: "bar" })}`
-            );
-
-            // when
-            await act(() =>
-                listenerFn({
-                    action: "UNAUTHORISED",
-                    sessionContext: {
-                        doesSessionExist: false,
-                        accessTokenPayload: { foo: "baz" },
-                        userId: "after-id",
-                    },
-                })
-            );
-
-            // then
-            expect(await UserId()).toHaveTextContent(`userId: before-id`);
-            expect(await AccessTokenPayload()).toHaveTextContent(
-                `accessTokenPayload: ${JSON.stringify({ foo: "bar" })}`
-            );
-        });
-
-        test("not update context when prop is passed in parent SessionAuth", async () => {
-            // given
-            const mockOnSessionExpired = jest.fn();
-            let listenerFn: (event: any) => void;
-
-            MockSession.addEventListener.mockImplementation((fn) => {
-                listenerFn = fn;
-
-                return () => {};
-            });
-
-            MockSession.doesSessionExist.mockResolvedValue(true);
-            MockSession.getUserId.mockResolvedValue("before-id");
-            MockSession.getAccessTokenPayloadSecurely.mockResolvedValue({
-                foo: "bar",
-            });
-
-            const result = render(
-                <SessionAuth onSessionExpired={mockOnSessionExpired}>
-                    <SessionAuth requireAuth={true} redirectToLogin={() => {}}>
-                        <MockSessionConsumer />
-                    </SessionAuth>
-                </SessionAuth>
-            );
-
-            const UserId = () => result.findByText(/^userId/);
-            const AccessTokenPayload = () => result.findByText(/^accessTokenPayload/);
-
-            expect(await UserId()).toHaveTextContent(`userId: before-id`);
-            expect(await AccessTokenPayload()).toHaveTextContent(
-                `accessTokenPayload: ${JSON.stringify({ foo: "bar" })}`
-            );
-
-            // when
-            await act(() =>
-                listenerFn({
-                    action: "UNAUTHORISED",
-                    sessionContext: {
-                        doesSessionExist: false,
-                        accessTokenPayload: {},
-                        userId: "",
-                    },
-                })
-            );
-
-            // then
-            expect(await UserId()).toHaveTextContent(`userId: before-id`);
-            expect(await AccessTokenPayload()).toHaveTextContent(
-                `accessTokenPayload: ${JSON.stringify({ foo: "bar" })}`
-            );
-        });
-    });
-
-    describe("onSignOut", () => {
-        test("not update context when sign out event is fired and requireAuth is true", async () => {
-            // given
-            const mockOnSessionExpired = jest.fn();
-            let listenerFn: (event: any) => void;
-
-            MockSession.addEventListener.mockImplementation((fn) => {
-                listenerFn = fn;
-
-                return () => {};
-            });
-
-            MockSession.doesSessionExist.mockResolvedValue(true);
-            MockSession.getUserId.mockResolvedValue("before-id");
-            MockSession.getAccessTokenPayloadSecurely.mockResolvedValue({
-                foo: "bar",
-            });
-
-            const result = render(
-                <SessionAuth requireAuth={true} redirectToLogin={() => {}}>
-                    <MockSessionConsumer />
-                </SessionAuth>
-            );
-
-            const UserId = () => result.findByText(/^userId/);
-            const AccessTokenPayload = () => result.findByText(/^accessTokenPayload/);
-
-            expect(await UserId()).toHaveTextContent(`userId: before-id`);
-            expect(await AccessTokenPayload()).toHaveTextContent(
-                `accessTokenPayload: ${JSON.stringify({ foo: "bar" })}`
-            );
-
-            // when
-            await act(() =>
-                listenerFn({
-                    action: "SIGN_OUT",
-                    sessionContext: {
-                        doesSessionExist: false,
-                        accessTokenPayload: {},
-                        userId: "",
-                    },
-                })
-            );
-
-            // then
-            expect(await UserId()).toHaveTextContent(`userId: before-id`);
-            expect(await AccessTokenPayload()).toHaveTextContent(
-                `accessTokenPayload: ${JSON.stringify({ foo: "bar" })}`
-            );
-        });
     });
 });

--- a/test/unit/ssr.test.tsx
+++ b/test/unit/ssr.test.tsx
@@ -1,0 +1,52 @@
+import React, { PropsWithChildren } from "react";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import { EmailPasswordAuth } from "../../lib/ts/recipe/emailpassword";
+import { PasswordlessAuth } from "../../lib/ts/recipe/passwordless";
+import { ThirdPartyAuth } from "../../lib/ts/recipe/thirdparty";
+import { ThirdPartyEmailPasswordAuth } from "../../lib/ts/recipe/thirdpartyemailpassword";
+import { ThirdPartyPasswordlessAuth } from "../../lib/ts/recipe/thirdpartypasswordless";
+
+class ErrorBoundary extends React.Component<PropsWithChildren<any>, { error: any }> {
+    constructor(props: any) {
+        super(props);
+        this.state = { error: undefined };
+    }
+
+    componentDidCatch(error: any) {
+        this.setState({ error });
+    }
+
+    render() {
+        return this.state.error ? <div>{this.state.error.toString()}</div> : this.props.children;
+    }
+}
+
+describe("Auth wrappers in SSR", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    const authComponents = [
+        EmailPasswordAuth,
+        PasswordlessAuth,
+        ThirdPartyAuth,
+        ThirdPartyEmailPasswordAuth,
+        ThirdPartyPasswordlessAuth,
+    ];
+    for (const Auth of authComponents) {
+        test(`${Auth.name} should work without recipe init`, async () => {
+            // We "simulate" SSR rendering by mocking useEffect to not be called
+            jest.spyOn(React, "useEffect").mockImplementation((fn) => {});
+            render(<Auth />);
+        });
+    }
+    for (const Auth of authComponents) {
+        test(`${Auth.name} should work without recipe init`, async () => {
+            // We suppress errors from react to not spam the console with uncaught error exceptions
+            jest.spyOn(console, "error").mockImplementation(() => {});
+            expect(() => render(<Auth />)).toThrow(/No instance of Session found/);
+        });
+    }
+});

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import "./App.css";
-import SuperTokens, { getSuperTokensRoutesForReactRouterDom } from "../../../";
+import SuperTokens, { getSuperTokensRoutesForReactRouterDom, SuperTokensWrapper } from "../../../";
 import EmailPassword, {
     GetRedirectionURLContext as EmailPasswordGetRedirectionURLContext,
     OnHandleEventContext as EmailPasswordOnHandleEventContext,
     PreAPIHookContext as EmailPasswordPreAPIHookContext,
 } from "../../../recipe/emailpassword";
-import Session, { SuperTokensWrapper } from "../../../recipe/session";
+import Session from "../../../recipe/session";
 import ThirdParty, {
     GetRedirectionURLContext as ThirdPartyGetRedirectionURLContext,
     OnHandleEventContext as ThirdPartyOnHandleEventContext,

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -6,7 +6,7 @@ import EmailPassword, {
     OnHandleEventContext as EmailPasswordOnHandleEventContext,
     PreAPIHookContext as EmailPasswordPreAPIHookContext,
 } from "../../../recipe/emailpassword";
-import Session from "../../../recipe/session";
+import Session, { SuperTokensWrapper } from "../../../recipe/session";
 import ThirdParty, {
     GetRedirectionURLContext as ThirdPartyGetRedirectionURLContext,
     OnHandleEventContext as ThirdPartyOnHandleEventContext,
@@ -80,32 +80,34 @@ SuperTokens.init({
 function App() {
     return (
         <div className="App">
-            <Router>
-                <div className="fill">
-                    <Routes>
-                        {getSuperTokensRoutesForReactRouterDom(require("react-router-dom"))}
-                        <Route
-                            path="/"
-                            element={
-                                <Auth>
-                                    <Home />
-                                </Auth>
-                            }
-                        />
-                        <Route
-                            path="/redirect-to-this-custom-path"
-                            element={
-                                <Auth>
-                                    <Home />
-                                </Auth>
-                            }
-                        />
-                    </Routes>
-                </div>
-                <div className="footer">
-                    <Footer />
-                </div>
-            </Router>
+            <SuperTokensWrapper>
+                <Router>
+                    <div className="fill">
+                        <Routes>
+                            {getSuperTokensRoutesForReactRouterDom(require("react-router-dom"))}
+                            <Route
+                                path="/"
+                                element={
+                                    <Auth>
+                                        <Home />
+                                    </Auth>
+                                }
+                            />
+                            <Route
+                                path="/redirect-to-this-custom-path"
+                                element={
+                                    <Auth>
+                                        <Home />
+                                    </Auth>
+                                }
+                            />
+                        </Routes>
+                    </div>
+                    <div className="footer">
+                        <Footer />
+                    </div>
+                </Router>
+            </SuperTokensWrapper>
         </div>
     );
 }

--- a/test/with-typescript/src/Home/index.tsx
+++ b/test/with-typescript/src/Home/index.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { signOut } from "../../../../recipe/emailpassword";
 
 export default function Home() {
-    const userId = useSessionContext().userId;
+    const sessionContext = useSessionContext();
     const navigate = useNavigate();
 
     async function logoutClicked() {
@@ -14,10 +14,14 @@ export default function Home() {
         navigate("/auth");
     }
 
+    if (sessionContext.loading === true) {
+        return null;
+    }
+
     return (
         <div className="fill">
             <Logout logoutClicked={logoutClicked} />
-            <SuccessView userId={userId} />
+            <SuccessView userId={sessionContext.userId} />
         </div>
     );
 }


### PR DESCRIPTION
## Summary of change

- Updated session context to include loading stat
- Added a session context wrapper devs can use to wrap their entire app
- Made SessionAuth SSR compatible

## Related issues

-   #263 

## Test Plan
- [x] Update existing tests
- [x] Test `requireAuth=false` can render with `loading=true` first

## Documentation changes

- [ ] New wrapper docs
- [ ] Update next.js example

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

