### PR TITLE
chore: Update example apps to use direct imports instead of build directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+-   Refactors example apps to not import from build directories
+
 ## [0.22.4] - 2022-06-20
 
 ### Added

--- a/examples/with-passwordless/package.json
+++ b/examples/with-passwordless/package.json
@@ -15,7 +15,7 @@
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.2.1",
         "react-scripts": "4.0.0",
-        "supertokens-auth-react": "^0.22.3",
+        "supertokens-auth-react": "^0.22.4",
         "supertokens-node": "^9.3.0",
         "twilio": "^3.73.1",
         "web-vitals": "^0.2.4"

--- a/examples/with-passwordless/src/Footer/index.js
+++ b/examples/with-passwordless/src/Footer/index.js
@@ -1,20 +1,17 @@
 import React from "react";
-import PasswordlessRecipeRaw from "supertokens-auth-react/lib/build//recipe/passwordless/recipe";
+import PasswordlessRecipe from "supertokens-auth-react/recipe/passwordless";
 
 export default function Footer() {
     let [showSMSMessage, setShowSMSMessage] = React.useState(false);
     React.useEffect(() => {
         function checkLoginAttemptInfo() {
-            // TODO: change this to not use the build folder
-            PasswordlessRecipeRaw.getInstanceOrThrow()
-                .recipeImpl.getLoginAttemptInfo({})
-                .then((info) => {
-                    if (info !== undefined && info.contactMethod === "PHONE") {
-                        setShowSMSMessage(true);
-                    } else {
-                        setShowSMSMessage(false);
-                    }
-                });
+            PasswordlessRecipe.getLoginAttemptInfo().then((info) => {
+                if (info !== undefined && info.contactMethod === "PHONE") {
+                    setShowSMSMessage(true);
+                } else {
+                    setShowSMSMessage(false);
+                }
+            });
         }
         const intervalId = setInterval(checkLoginAttemptInfo, 500);
         return () => {

--- a/examples/with-thirdpartyemailpassword-2fa-passwordless/src/SecondFactor/index.tsx
+++ b/examples/with-thirdpartyemailpassword-2fa-passwordless/src/SecondFactor/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Passwordless from "supertokens-auth-react/recipe/passwordless";
 import Session from "supertokens-auth-react/recipe/session";
-import ThirdPartyEmailPassword from "supertokens-auth-react/lib/build/recipe/thirdpartyemailpassword";
+import ThirdPartyEmailPassword from "supertokens-auth-react/recipe/thirdpartyemailpassword";
 
 export default function SecondFactor() {
     React.useEffect(() => {

--- a/examples/with-thirdpartypasswordless/package.json
+++ b/examples/with-thirdpartypasswordless/package.json
@@ -15,7 +15,7 @@
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.2.1",
         "react-scripts": "4.0.0",
-        "supertokens-auth-react": "^0.22.3",
+        "supertokens-auth-react": "^0.22.4",
         "supertokens-node": "^9.3.0",
         "twilio": "^3.73.1",
         "web-vitals": "^0.2.4"

--- a/examples/with-thirdpartypasswordless/src/Footer/index.js
+++ b/examples/with-thirdpartypasswordless/src/Footer/index.js
@@ -1,20 +1,17 @@
 import React from "react";
-import ThirdPartyPasswordlessRecipeRaw from "supertokens-auth-react/lib/build/recipe/thirdpartypasswordless/recipe";
+import ThirdPartyPasswordlessRecipe from "supertokens-auth-react/recipe/thirdpartypasswordless";
 
 export default function Footer() {
     let [showSMSMessage, setShowSMSMessage] = React.useState(false);
     React.useEffect(() => {
         function checkLoginAttemptInfo() {
-            // TODO: change this to not use the build folder
-            ThirdPartyPasswordlessRecipeRaw.getInstanceOrThrow()
-                .recipeImpl.getPasswordlessLoginAttemptInfo()
-                .then((info) => {
-                    if (info !== undefined && info.contactMethod === "PHONE") {
-                        setShowSMSMessage(true);
-                    } else {
-                        setShowSMSMessage(false);
-                    }
-                });
+            ThirdPartyPasswordlessRecipe.getPasswordlessLoginAttemptInfo().then((info) => {
+                if (info !== undefined && info.contactMethod === "PHONE") {
+                    setShowSMSMessage(true);
+                } else {
+                    setShowSMSMessage(false);
+                }
+            });
         }
         const intervalId = setInterval(checkLoginAttemptInfo, 500);
         return () => {

--- a/examples/with-thirdpartypasswordless/src/Footer/index.js
+++ b/examples/with-thirdpartypasswordless/src/Footer/index.js
@@ -1,11 +1,11 @@
 import React from "react";
-import ThirdPartyPasswordlessRecipe from "supertokens-auth-react/recipe/thirdpartypasswordless";
+import ThirdPartyPasswordless from "supertokens-auth-react/recipe/thirdpartypasswordless";
 
 export default function Footer() {
     let [showSMSMessage, setShowSMSMessage] = React.useState(false);
     React.useEffect(() => {
         function checkLoginAttemptInfo() {
-            ThirdPartyPasswordlessRecipe.getPasswordlessLoginAttemptInfo().then((info) => {
+            ThirdPartyPasswordless.getPasswordlessLoginAttemptInfo().then((info) => {
                 if (info !== undefined && info.contactMethod === "PHONE") {
                     setShowSMSMessage(true);
                 } else {


### PR DESCRIPTION
## Summary of change

- Updates with-thirdpartypasswordless to call `getPasswordlessLoginAttemptInfo` from the index functions directly
- Update with-passwordless to call `getLoginAttemptInfo` from the index functions directly
- Updates with-thirdpartyemailpassword-2fa-passwordless to import from the default recipe export

## Related issues

-   ...

## Test Plan

No logical changes

## Documentation changes

None

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Remaining TODOs for this PR

-   [ ] ...
