### PR TITLE
refactor: Add check for node sdk version when adding general error feature flag

### DIFF
--- a/test/server/index.js
+++ b/test/server/index.js
@@ -33,7 +33,8 @@ let bodyParser = require("body-parser");
 let http = require("http");
 let cors = require("cors");
 const morgan = require("morgan");
-let { startST, killAllST, setupST, cleanST, setKeyValueInConfig, customAuth0Provider } = require("./utils");
+let { startST, killAllST, setupST, cleanST, setKeyValueInConfig, customAuth0Provider, maxVersion } = require("./utils");
+let { version: nodeSDKVersion } = require("supertokens-node/lib/build/version");
 
 let passwordlessSupported;
 let PasswordlessRaw;
@@ -57,6 +58,15 @@ try {
     thirdPartyPasswordlessSupported = true;
 } catch (ex) {
     thirdPartyPasswordlessSupported = false;
+}
+
+let generalErrorSupported;
+
+if (maxVersion(nodeSDKVersion, "9.9.9") === "9.9.9") {
+    // General error is only supported by 10.0.0 and above
+    generalErrorSupported = false;
+} else {
+    generalErrorSupported = true;
 }
 
 let urlencodedParser = bodyParser.urlencoded({ limit: "20mb", extended: true, parameterLimit: 20000 });
@@ -207,8 +217,9 @@ app.get("/test/featureFlags", (req, res) => {
         available.push("thirdpartypasswordless");
     }
 
-    // TODO: only if above certain node version
-    available.push("generalerror");
+    if (generalErrorSupported) {
+        available.push("generalerror");
+    }
 
     res.send({
         available,

--- a/test/server/utils.js
+++ b/test/server/utils.js
@@ -220,3 +220,22 @@ async function getListOfPids() {
     }
     return result;
 }
+
+module.exports.maxVersion = function (version1, version2) {
+    let splittedv1 = version1.split(".");
+    let splittedv2 = version2.split(".");
+    let minLength = Math.min(splittedv1.length, splittedv2.length);
+    for (let i = 0; i < minLength; i++) {
+        let v1 = Number(splittedv1[i]);
+        let v2 = Number(splittedv2[i]);
+        if (v1 > v2) {
+            return version1;
+        } else if (v2 > v1) {
+            return version2;
+        }
+    }
+    if (splittedv1.length >= splittedv2.length) {
+        return version1;
+    }
+    return version2;
+};


### PR DESCRIPTION
## Summary of change

- Makes sure that the node SDK version is 10.0.0 or greater when enabling general errors

## Related issues

-   

## Test Plan


## Documentation changes


## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Remaining TODOs for this PR

-   [ ] 