### PR TITLE
build: disable tslib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added new tests for checking general error handling
 -   Refactors example apps to not import from build directories
 -   fixes to angular example app
+-   Not importing helpers from `tslib`
 
 ### Added
 

--- a/lib/build/components/SuperTokensBranding.js
+++ b/lib/build/components/SuperTokensBranding.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SuperTokensBranding = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -18,14 +36,14 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * under the License.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../styles/styleContext"));
 var translationContext_1 = require("../translation/translationContext");
 function SuperTokensBranding() {
     var styles = (0, react_1.useContext)(styleContext_1.default);
     var t = (0, translationContext_1.useTranslation)();
     return (0, jsx_runtime_1.jsxs)(
         "a",
-        tslib_1.__assign(
+        __assign(
             {
                 "data-supertokens": "superTokensBranding",
                 css: styles.superTokensBranding,

--- a/lib/build/components/assets/arrowLeftIcon.js
+++ b/lib/build/components/assets/arrowLeftIcon.js
@@ -1,6 +1,19 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -26,7 +39,7 @@ function ArrowRightIcon(_a) {
     var color = _a.color;
     return (0, jsx_runtime_1.jsx)(
         "svg",
-        tslib_1.__assign(
+        __assign(
             { xmlns: "http://www.w3.org/2000/svg", width: "11.272", height: "9.49", viewBox: "0 0 11.272 9.49" },
             {
                 children: (0, jsx_runtime_1.jsx)("path", {

--- a/lib/build/components/assets/arrowRightIcon.js
+++ b/lib/build/components/assets/arrowRightIcon.js
@@ -1,6 +1,19 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -26,7 +39,7 @@ function ArrowRightIcon(_a) {
     var color = _a.color;
     return (0, jsx_runtime_1.jsx)(
         "svg",
-        tslib_1.__assign(
+        __assign(
             { xmlns: "http://www.w3.org/2000/svg", width: "11.272", height: "9.49", viewBox: "0 0 11.272 9.49" },
             {
                 children: (0, jsx_runtime_1.jsx)("path", {

--- a/lib/build/components/assets/checkedIcon.js
+++ b/lib/build/components/assets/checkedIcon.js
@@ -1,6 +1,19 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -26,7 +39,7 @@ function CheckedIcon(_a) {
     var color = _a.color;
     return (0, jsx_runtime_1.jsx)(
         "svg",
-        tslib_1.__assign(
+        __assign(
             { xmlns: "http://www.w3.org/2000/svg", width: "14.862", height: "12.033", viewBox: "0 0 14.862 12.033" },
             {
                 children: (0, jsx_runtime_1.jsx)("path", {

--- a/lib/build/components/assets/checkedRoundIcon.js
+++ b/lib/build/components/assets/checkedRoundIcon.js
@@ -1,6 +1,19 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -26,12 +39,12 @@ function CheckedRoundIcon(_a) {
     var color = _a.color;
     return (0, jsx_runtime_1.jsx)(
         "svg",
-        tslib_1.__assign(
+        __assign(
             { xmlns: "http://www.w3.org/2000/svg", width: "33", height: "33", viewBox: "0 0 33 33" },
             {
                 children: (0, jsx_runtime_1.jsxs)(
                     "g",
-                    tslib_1.__assign(
+                    __assign(
                         { fill: color, stroke: color },
                         {
                             children: [

--- a/lib/build/components/assets/emailLargeIcon.js
+++ b/lib/build/components/assets/emailLargeIcon.js
@@ -1,6 +1,19 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -25,12 +38,12 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 function EmailLargeIcon() {
     return (0, jsx_runtime_1.jsx)(
         "svg",
-        tslib_1.__assign(
+        __assign(
             { xmlns: "http://www.w3.org/2000/svg", width: "59.867", height: "40.34", viewBox: "0 0 59.867 40.34" },
             {
                 children: (0, jsx_runtime_1.jsxs)(
                     "g",
-                    tslib_1.__assign(
+                    __assign(
                         { id: "email", transform: "translate(0 -83.5)" },
                         {
                             children: [

--- a/lib/build/components/assets/errorIcon.js
+++ b/lib/build/components/assets/errorIcon.js
@@ -1,6 +1,19 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -26,14 +39,14 @@ function ErrorIcon(_a) {
     var color = _a.color;
     return (0, jsx_runtime_1.jsx)(
         "svg",
-        tslib_1.__assign(
+        __assign(
             { xmlns: "http://www.w3.org/2000/svg", width: "17", height: "15", viewBox: "0 0 17 15" },
             {
                 children: (0, jsx_runtime_1.jsxs)("g", {
                     children: [
                         (0, jsx_runtime_1.jsx)(
                             "g",
-                            tslib_1.__assign(
+                            __assign(
                                 { fill: color },
                                 {
                                     children: (0, jsx_runtime_1.jsx)("path", {
@@ -45,7 +58,7 @@ function ErrorIcon(_a) {
                         ),
                         (0, jsx_runtime_1.jsx)(
                             "text",
-                            tslib_1.__assign(
+                            __assign(
                                 {
                                     fill: "#fff",
                                     fontSize: "10px",
@@ -55,7 +68,7 @@ function ErrorIcon(_a) {
                                 {
                                     children: (0, jsx_runtime_1.jsx)(
                                         "tspan",
-                                        tslib_1.__assign({ x: "0", y: "0" }, { children: "!" })
+                                        __assign({ x: "0", y: "0" }, { children: "!" })
                                     ),
                                 }
                             )

--- a/lib/build/components/assets/errorLargeIcon.js
+++ b/lib/build/components/assets/errorLargeIcon.js
@@ -1,6 +1,19 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -26,14 +39,14 @@ function ErrorLargeIcon(_a) {
     var color = _a.color;
     return (0, jsx_runtime_1.jsx)(
         "svg",
-        tslib_1.__assign(
+        __assign(
             { xmlns: "http://www.w3.org/2000/svg", width: "33", height: "30", viewBox: "0 0 33 30" },
             {
                 children: (0, jsx_runtime_1.jsxs)("g", {
                     children: [
                         (0, jsx_runtime_1.jsx)(
                             "g",
-                            tslib_1.__assign(
+                            __assign(
                                 { fill: color },
                                 {
                                     children: (0, jsx_runtime_1.jsx)("path", {
@@ -45,7 +58,7 @@ function ErrorLargeIcon(_a) {
                         ),
                         (0, jsx_runtime_1.jsx)(
                             "text",
-                            tslib_1.__assign(
+                            __assign(
                                 {
                                     fill: "#fff",
                                     "font-family": "Rubik-Bold, Rubik",
@@ -56,7 +69,7 @@ function ErrorLargeIcon(_a) {
                                 {
                                     children: (0, jsx_runtime_1.jsx)(
                                         "tspan",
-                                        tslib_1.__assign({ x: "0", y: "0" }, { children: "!" })
+                                        __assign({ x: "0", y: "0" }, { children: "!" })
                                     ),
                                 }
                             )

--- a/lib/build/components/assets/heavyArrowLeftIcon.js
+++ b/lib/build/components/assets/heavyArrowLeftIcon.js
@@ -1,6 +1,19 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -26,7 +39,7 @@ function HeavyArrowLeftIcon(_a) {
     var color = _a.color;
     return (0, jsx_runtime_1.jsx)(
         "svg",
-        tslib_1.__assign(
+        __assign(
             { xmlns: "http://www.w3.org/2000/svg", width: "16", height: "13", viewBox: "0 0 16 13" },
             {
                 children: (0, jsx_runtime_1.jsx)("path", {

--- a/lib/build/components/assets/showPasswordIcon.js
+++ b/lib/build/components/assets/showPasswordIcon.js
@@ -1,6 +1,19 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -30,7 +43,7 @@ function ShowPasswordIcon(_a) {
         return (0, jsx_runtime_1.jsx)("div", {
             children: (0, jsx_runtime_1.jsx)(
                 "svg",
-                tslib_1.__assign(
+                __assign(
                     {
                         xmlns: "http://www.w3.org/2000/svg",
                         width: "18.391",
@@ -54,7 +67,7 @@ function ShowPasswordIcon(_a) {
                                 }),
                                 (0, jsx_runtime_1.jsxs)(
                                     "g",
-                                    tslib_1.__assign(
+                                    __assign(
                                         {
                                             fill: primaryColor,
                                             stroke: secondaryColor,
@@ -103,7 +116,7 @@ function ShowPasswordIcon(_a) {
     return (0, jsx_runtime_1.jsx)("div", {
         children: (0, jsx_runtime_1.jsx)(
             "svg",
-            tslib_1.__assign(
+            __assign(
                 {
                     xmlns: "http://www.w3.org/2000/svg",
                     width: "18.281",
@@ -127,7 +140,7 @@ function ShowPasswordIcon(_a) {
                             }),
                             (0, jsx_runtime_1.jsxs)(
                                 "g",
-                                tslib_1.__assign(
+                                __assign(
                                     {
                                         fill: primaryColor,
                                         stroke: secondaryColor,

--- a/lib/build/components/assets/smsLargeIcon.js
+++ b/lib/build/components/assets/smsLargeIcon.js
@@ -1,6 +1,19 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -25,29 +38,29 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 function SMSLargeIcon() {
     return (0, jsx_runtime_1.jsx)(
         "svg",
-        tslib_1.__assign(
+        __assign(
             { xmlns: "http://www.w3.org/2000/svg", width: "52.013", height: "41.889", viewBox: "0 0 52.013 41.889" },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     "g",
-                    tslib_1.__assign(
+                    __assign(
                         { id: "Group_10400", "data-name": "Group 10400", transform: "translate(-724.625 -241.125)" },
                         {
                             children: (0, jsx_runtime_1.jsxs)(
                                 "g",
-                                tslib_1.__assign(
+                                __assign(
                                     { id: "Group_10399", "data-name": "Group 10399" },
                                     {
                                         children: [
                                             (0, jsx_runtime_1.jsxs)(
                                                 "g",
-                                                tslib_1.__assign(
+                                                __assign(
                                                     { id: "Group_10398", "data-name": "Group 10398" },
                                                     {
                                                         children: [
                                                             (0, jsx_runtime_1.jsxs)(
                                                                 "g",
-                                                                tslib_1.__assign(
+                                                                __assign(
                                                                     {
                                                                         id: "_2639922_sms_icon",
                                                                         "data-name": "2639922_sms_icon",
@@ -97,7 +110,7 @@ function SMSLargeIcon() {
                                             ),
                                             (0, jsx_runtime_1.jsxs)(
                                                 "g",
-                                                tslib_1.__assign(
+                                                __assign(
                                                     {
                                                         id: "_2639922_sms_icon-2",
                                                         "data-name": "2639922_sms_icon",
@@ -129,7 +142,7 @@ function SMSLargeIcon() {
                                             ),
                                             (0, jsx_runtime_1.jsxs)(
                                                 "g",
-                                                tslib_1.__assign(
+                                                __assign(
                                                     { id: "Group_10397", "data-name": "Group 10397" },
                                                     {
                                                         children: [
@@ -159,7 +172,7 @@ function SMSLargeIcon() {
                                             ),
                                             (0, jsx_runtime_1.jsxs)(
                                                 "g",
-                                                tslib_1.__assign(
+                                                __assign(
                                                     { id: "Group_10396", "data-name": "Group 10396" },
                                                     {
                                                         children: [
@@ -196,7 +209,7 @@ function SMSLargeIcon() {
                                             }),
                                             (0, jsx_runtime_1.jsxs)(
                                                 "g",
-                                                tslib_1.__assign(
+                                                __assign(
                                                     { id: "Group_10395", "data-name": "Group 10395" },
                                                     {
                                                         children: [

--- a/lib/build/components/assets/spinnerIcon.js
+++ b/lib/build/components/assets/spinnerIcon.js
@@ -1,6 +1,19 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -26,12 +39,12 @@ function SpinnerIcon(_a) {
     var color = _a.color;
     return (0, jsx_runtime_1.jsx)(
         "svg",
-        tslib_1.__assign(
+        __assign(
             { version: "1.1", viewBox: "25 25 50 50" },
             {
                 children: (0, jsx_runtime_1.jsxs)(
                     "circle",
-                    tslib_1.__assign(
+                    __assign(
                         {
                             cx: "50",
                             cy: "50",

--- a/lib/build/components/componentOverride/componentOverrideContext.js
+++ b/lib/build/components/componentOverride/componentOverrideContext.js
@@ -1,6 +1,10 @@
 "use strict";
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ComponentOverrideContext = void 0;
-var tslib_1 = require("tslib");
-var react_1 = tslib_1.__importDefault(require("react"));
+var react_1 = __importDefault(require("react"));
 exports.ComponentOverrideContext = react_1.default.createContext("IS_DEFAULT");

--- a/lib/build/components/componentOverride/withOverride.js
+++ b/lib/build/components/componentOverride/withOverride.js
@@ -1,7 +1,20 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.withOverride = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var useComponentOverride_1 = require("./useComponentOverride");
 var withOverride = function (overrideKey, DefaultComponent) {
@@ -10,12 +23,9 @@ var withOverride = function (overrideKey, DefaultComponent) {
     return function (props) {
         var OverrideComponent = (0, useComponentOverride_1.useComponentOverride)(finalKey);
         if (OverrideComponent !== null) {
-            return (0, jsx_runtime_1.jsx)(
-                OverrideComponent,
-                tslib_1.__assign({ DefaultComponent: DefaultComponent }, props)
-            );
+            return (0, jsx_runtime_1.jsx)(OverrideComponent, __assign({ DefaultComponent: DefaultComponent }, props));
         }
-        return (0, jsx_runtime_1.jsx)(DefaultComponent, tslib_1.__assign({}, props));
+        return (0, jsx_runtime_1.jsx)(DefaultComponent, __assign({}, props));
     };
 };
 exports.withOverride = withOverride;

--- a/lib/build/components/errorBoundary.js
+++ b/lib/build/components/errorBoundary.js
@@ -1,6 +1,35 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,13 +48,13 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var react_1 = tslib_1.__importDefault(require("react"));
+var react_1 = __importDefault(require("react"));
 var react_2 = require("react");
 /*
  * Component.
  */
 var ErrorBoundary = /** @class */ (function (_super) {
-    tslib_1.__extends(ErrorBoundary, _super);
+    __extends(ErrorBoundary, _super);
     function ErrorBoundary(props) {
         var _this = _super.call(this, props) || this;
         _this.state = { hasError: false };

--- a/lib/build/components/featureWrapper.js
+++ b/lib/build/components/featureWrapper.js
@@ -1,6 +1,24 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,12 +37,12 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var emotion_1 = tslib_1.__importDefault(require("react-shadow/emotion"));
+var emotion_1 = __importDefault(require("react-shadow/emotion"));
 var constants_1 = require("../constants");
-var errorBoundary_1 = tslib_1.__importDefault(require("./errorBoundary"));
+var errorBoundary_1 = __importDefault(require("./errorBoundary"));
 var react_1 = require("@emotion/react");
-var cache_1 = tslib_1.__importDefault(require("@emotion/cache"));
-var superTokens_1 = tslib_1.__importDefault(require("../superTokens"));
+var cache_1 = __importDefault(require("@emotion/cache"));
+var superTokens_1 = __importDefault(require("../superTokens"));
 var translationContext_1 = require("../translation/translationContext");
 var utils_1 = require("../utils");
 var superTokensEmotionCache = (0, cache_1.default)({
@@ -41,7 +59,7 @@ function FeatureWrapper(_a) {
     return (0, jsx_runtime_1.jsx)(errorBoundary_1.default, {
         children: (0, jsx_runtime_1.jsx)(
             translationContext_1.TranslationContextProvider,
-            tslib_1.__assign(
+            __assign(
                 {
                     defaultLanguage: st.languageTranslations.defaultLanguage,
                     defaultStore: (0, utils_1.mergeObjects)(defaultStore, st.languageTranslations.userTranslationStore),
@@ -51,7 +69,7 @@ function FeatureWrapper(_a) {
                 {
                     children: (0, jsx_runtime_1.jsx)(
                         WithOrWithoutShadowDom,
-                        tslib_1.__assign({ useShadowDom: useShadowDom }, { children: children })
+                        __assign({ useShadowDom: useShadowDom }, { children: children })
                     ),
                 }
             )
@@ -66,13 +84,13 @@ function WithOrWithoutShadowDom(_a) {
     if (useShadowDom === false) {
         return (0, jsx_runtime_1.jsxs)(
             "div",
-            tslib_1.__assign(
+            __assign(
                 { id: constants_1.ST_ROOT_ID },
                 {
                     children: [
                         (0, jsx_runtime_1.jsx)(
                             react_1.CacheProvider,
-                            tslib_1.__assign({ value: superTokensEmotionCache }, { children: children })
+                            __assign({ value: superTokensEmotionCache }, { children: children })
                         ),
                         (0, jsx_runtime_1.jsx)(DisableAutoFillInput, {}),
                     ],
@@ -83,7 +101,7 @@ function WithOrWithoutShadowDom(_a) {
     // Otherwise, use shadow dom.
     return (0, jsx_runtime_1.jsxs)(
         emotion_1.default.div,
-        tslib_1.__assign(
+        __assign(
             { id: constants_1.ST_ROOT_ID },
             { children: [children, (0, jsx_runtime_1.jsx)(DisableAutoFillInput, {})] }
         )
@@ -93,7 +111,7 @@ function DisableAutoFillInput() {
     /* eslint-disable react/jsx-no-literals */
     return (0, jsx_runtime_1.jsx)(
         "style",
-        tslib_1.__assign(
+        __assign(
             { type: "text/css" },
             {
                 children:

--- a/lib/build/components/routingComponent.js
+++ b/lib/build/components/routingComponent.js
@@ -1,10 +1,14 @@
 "use strict";
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.RoutingComponent = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
-var react_1 = tslib_1.__importDefault(require("react"));
-var normalisedURLPath_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
+var react_1 = __importDefault(require("react"));
+var normalisedURLPath_1 = __importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
 function RoutingComponent(props) {
     var _a;
     var stInstance = props.supertokensInstance;

--- a/lib/build/components/superTokensRoute.js
+++ b/lib/build/components/superTokensRoute.js
@@ -1,7 +1,20 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getSuperTokensRoutesForReactRouterDom = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var routingComponent_1 = require("./routingComponent");
 /*
@@ -17,7 +30,7 @@ function getSuperTokensRoutesForReactRouterDom(supertokensInstance) {
     return Object.keys(pathsToFeatureComponentWithRecipeIdMap).map(function (path) {
         path = path === "" ? "/" : path;
         return (0,
-        jsx_runtime_1.jsx)(Route, tslib_1.__assign({ exact: true, path: path }, { children: (0, jsx_runtime_1.jsx)(routingComponent_1.RoutingComponent, { supertokensInstance: supertokensInstance, path: path }) }), "st-".concat(path));
+        jsx_runtime_1.jsx)(Route, __assign({ exact: true, path: path }, { children: (0, jsx_runtime_1.jsx)(routingComponent_1.RoutingComponent, { supertokensInstance: supertokensInstance, path: path }) }), "st-".concat(path));
     });
 }
 exports.getSuperTokensRoutesForReactRouterDom = getSuperTokensRoutesForReactRouterDom;

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -13,6 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.useUserContext =
     exports.useTranslation =
@@ -23,12 +28,11 @@ exports.useUserContext =
     exports.init =
     exports.canHandleRoute =
         void 0;
-var tslib_1 = require("tslib");
 /*
  * Imports.
  */
 var translationContext_1 = require("./translation/translationContext");
-var superTokens_1 = tslib_1.__importDefault(require("./superTokens"));
+var superTokens_1 = __importDefault(require("./superTokens"));
 var usercontext_1 = require("./usercontext");
 /*
  * API Wrapper exposed to user.

--- a/lib/build/recipe/authRecipe/authWidgetWrapper.js
+++ b/lib/build/recipe/authRecipe/authWidgetWrapper.js
@@ -1,6 +1,19 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -29,10 +42,7 @@ var utils_1 = require("../../utils");
 var AuthWidgetWrapper = function (props) {
     return (0, jsx_runtime_1.jsx)(
         session_1.SessionAuth,
-        tslib_1.__assign(
-            { requireAuth: false },
-            { children: (0, jsx_runtime_1.jsx)(Redirector, tslib_1.__assign({}, props)) }
-        )
+        __assign({ requireAuth: false }, { children: (0, jsx_runtime_1.jsx)(Redirector, __assign({}, props)) })
     );
 };
 var Redirector = function (props) {

--- a/lib/build/recipe/authRecipe/index.js
+++ b/lib/build/recipe/authRecipe/index.js
@@ -13,21 +13,195 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 /*
  * Imports.
  */
-var recipe_1 = tslib_1.__importDefault(require("../session/recipe"));
-var recipeModule_1 = tslib_1.__importDefault(require("../recipeModule"));
+var recipe_1 = __importDefault(require("../session/recipe"));
+var recipeModule_1 = __importDefault(require("../recipeModule"));
 var utils_1 = require("../../utils");
 var AuthRecipe = /** @class */ (function (_super) {
-    tslib_1.__extends(AuthRecipe, _super);
+    __extends(AuthRecipe, _super);
     function AuthRecipe(config) {
         var _this = _super.call(this, config) || this;
         _this.getAuthRecipeDefaultRedirectionURL = function (context) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     if (context.action === "SIGN_IN_AND_UP") {
                         return [
                             2 /*return*/,
@@ -45,8 +219,8 @@ var AuthRecipe = /** @class */ (function (_super) {
             });
         };
         _this.signOut = function (input) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [
@@ -64,8 +238,8 @@ var AuthRecipe = /** @class */ (function (_super) {
             });
         };
         _this.doesSessionExist = function (input) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [
@@ -87,7 +261,7 @@ var AuthRecipe = /** @class */ (function (_super) {
             if (queryParams === undefined) {
                 queryParams = {};
             }
-            queryParams = tslib_1.__assign(tslib_1.__assign({}, queryParams), { redirectToPath: redirectToPath });
+            queryParams = __assign(__assign({}, queryParams), { redirectToPath: redirectToPath });
             return _this.redirectToAuthWithoutRedirectToPath(show, history, queryParams);
         };
         _this.redirectToAuthWithoutRedirectToPath = function (show, history, queryParams) {
@@ -95,7 +269,7 @@ var AuthRecipe = /** @class */ (function (_super) {
                 queryParams = {};
             }
             if (show !== undefined) {
-                queryParams = tslib_1.__assign(tslib_1.__assign({}, queryParams), { show: show });
+                queryParams = __assign(__assign({}, queryParams), { show: show });
             }
             return _this.redirect(
                 {

--- a/lib/build/recipe/authRecipeWithEmailVerification/index.js
+++ b/lib/build/recipe/authRecipeWithEmailVerification/index.js
@@ -13,25 +13,199 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 /*
  * Imports.
  */
-var authRecipe_1 = tslib_1.__importDefault(require("../authRecipe"));
-var recipe_1 = tslib_1.__importDefault(require("../emailverification/recipe"));
+var authRecipe_1 = __importDefault(require("../authRecipe"));
+var recipe_1 = __importDefault(require("../emailverification/recipe"));
 var utils_1 = require("../../utils");
 var AuthRecipeWithEmailVerification = /** @class */ (function (_super) {
-    tslib_1.__extends(AuthRecipeWithEmailVerification, _super);
+    __extends(AuthRecipeWithEmailVerification, _super);
     function AuthRecipeWithEmailVerification(config, recipes) {
         var _this = _super.call(this, config) || this;
         // this function is used by auth recipes to save the success context before
         // redirecting to email verification screen - so that post verification,
         // the user is redirected to the correct place.
         _this.savePostEmailVerificationSuccessRedirectState = function (context) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
+            return __awaiter(_this, void 0, void 0, function () {
                 var jsonContext;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             jsonContext = JSON.stringify(context);
@@ -47,8 +221,8 @@ var AuthRecipeWithEmailVerification = /** @class */ (function (_super) {
             });
         };
         _this.getAuthRecipeWithEmailVerificationDefaultRedirectionURL = function (context) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     if (context.action === "SIGN_IN_AND_UP") {
                         return [
                             2 /*return*/,
@@ -74,17 +248,17 @@ var AuthRecipeWithEmailVerification = /** @class */ (function (_super) {
         _this.emailVerification =
             recipes.emailVerificationInstance === undefined
                 ? new recipe_1.default(
-                      tslib_1.__assign(
-                          tslib_1.__assign(
+                      __assign(
+                          __assign(
                               {
                                   appInfo: config.appInfo,
                                   recipeId: config.recipeId,
                                   signOut: _this.signOut,
                                   style: _this.config.rootStyle,
                                   postVerificationRedirect: function (history) {
-                                      return tslib_1.__awaiter(_this, void 0, void 0, function () {
+                                      return __awaiter(_this, void 0, void 0, function () {
                                           var successContextStr;
-                                          return tslib_1.__generator(this, function (_a) {
+                                          return __generator(this, function (_a) {
                                               switch (_a.label) {
                                                   case 0:
                                                       _a.trys.push([0, , 6, 8]);
@@ -136,8 +310,8 @@ var AuthRecipeWithEmailVerification = /** @class */ (function (_super) {
                                       });
                                   },
                                   redirectToSignIn: function (history) {
-                                      return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                                          return tslib_1.__generator(this, function (_a) {
+                                      return __awaiter(_this, void 0, void 0, function () {
+                                          return __generator(this, function (_a) {
                                               return [
                                                   2 /*return*/,
                                                   this.redirectToAuthWithoutRedirectToPath(undefined, history),

--- a/lib/build/recipe/authRecipeWithEmailVerification/utils.js
+++ b/lib/build/recipe/authRecipeWithEmailVerification/utils.js
@@ -13,12 +13,25 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.normaliseAuthRecipeWithEmailVerificationConfig = void 0;
-var tslib_1 = require("tslib");
 var utils_1 = require("../authRecipe/utils");
 function normaliseAuthRecipeWithEmailVerificationConfig(config) {
-    return tslib_1.__assign(tslib_1.__assign({}, (0, utils_1.normaliseAuthRecipe)(config)), {
+    return __assign(__assign({}, (0, utils_1.normaliseAuthRecipe)(config)), {
         emailVerificationFeature: config.emailVerificationFeature,
     });
 }

--- a/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/index.js
+++ b/lib/build/recipe/emailpassword/components/features/resetPasswordUsingToken/index.js
@@ -1,6 +1,89 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,15 +102,15 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var React = tslib_1.__importStar(require("react"));
+var React = __importStar(require("react"));
 var react_1 = require("react");
-var resetPasswordUsingToken_1 = tslib_1.__importDefault(require("../../themes/resetPasswordUsingToken"));
+var resetPasswordUsingToken_1 = __importDefault(require("../../themes/resetPasswordUsingToken"));
 var utils_1 = require("../../../../../utils");
-var featureWrapper_1 = tslib_1.__importDefault(require("../../../../../components/featureWrapper"));
+var featureWrapper_1 = __importDefault(require("../../../../../components/featureWrapper"));
 var componentOverrideContext_1 = require("../../../../../components/componentOverride/componentOverrideContext");
 var translations_1 = require("../../themes/translations");
 var ResetPasswordUsingToken = /** @class */ (function (_super) {
-    tslib_1.__extends(ResetPasswordUsingToken, _super);
+    __extends(ResetPasswordUsingToken, _super);
     /*
      * Constructor.
      */
@@ -45,12 +128,12 @@ var ResetPasswordUsingToken = /** @class */ (function (_super) {
                           error: _this.state.error,
                           onError: function (error) {
                               return _this.setState(function (os) {
-                                  return tslib_1.__assign(tslib_1.__assign({}, os), { error: error });
+                                  return __assign(__assign({}, os), { error: error });
                               });
                           },
                           clearError: function () {
                               return _this.setState(function (os) {
-                                  return tslib_1.__assign(tslib_1.__assign({}, os), { error: undefined });
+                                  return __assign(__assign({}, os), { error: undefined });
                               });
                           },
                           styleFromInit: submitNewPasswordFormFeature.style,
@@ -72,12 +155,12 @@ var ResetPasswordUsingToken = /** @class */ (function (_super) {
                 error: _this.state.error,
                 onError: function (error) {
                     return _this.setState(function (os) {
-                        return tslib_1.__assign(tslib_1.__assign({}, os), { error: error });
+                        return __assign(__assign({}, os), { error: error });
                     });
                 },
                 clearError: function () {
                     return _this.setState(function (os) {
-                        return tslib_1.__assign(tslib_1.__assign({}, os), { error: undefined });
+                        return __assign(__assign({}, os), { error: undefined });
                     });
                 },
                 styleFromInit: enterEmailFormFeature.style,
@@ -92,12 +175,12 @@ var ResetPasswordUsingToken = /** @class */ (function (_super) {
             };
             return (0, jsx_runtime_1.jsx)(
                 componentOverrideContext_1.ComponentOverrideContext.Provider,
-                tslib_1.__assign(
+                __assign(
                     { value: componentOverrides },
                     {
                         children: (0, jsx_runtime_1.jsx)(
                             featureWrapper_1.default,
-                            tslib_1.__assign(
+                            __assign(
                                 {
                                     useShadowDom: _this.props.recipe.config.useShadowDom,
                                     defaultStore: translations_1.defaultTranslationsEmailPassword,
@@ -108,7 +191,7 @@ var ResetPasswordUsingToken = /** @class */ (function (_super) {
                                             _this.props.children === undefined &&
                                                 (0, jsx_runtime_1.jsx)(
                                                     resetPasswordUsingToken_1.default,
-                                                    tslib_1.__assign({}, props)
+                                                    __assign({}, props)
                                                 ),
                                             _this.props.children &&
                                                 React.Children.map(_this.props.children, function (child) {

--- a/lib/build/recipe/emailpassword/components/features/signInAndUp/index.js
+++ b/lib/build/recipe/emailpassword/components/features/signInAndUp/index.js
@@ -1,7 +1,196 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignInAndUpFeature = exports.useChildProps = exports.useFeatureReducer = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -20,27 +209,27 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var React = tslib_1.__importStar(require("react"));
+var React = __importStar(require("react"));
 var react_1 = require("react");
-var signInAndUp_1 = tslib_1.__importDefault(require("../../themes/signInAndUp"));
+var signInAndUp_1 = __importDefault(require("../../themes/signInAndUp"));
 var utils_1 = require("../../../../../utils");
-var featureWrapper_1 = tslib_1.__importDefault(require("../../../../../components/featureWrapper"));
+var featureWrapper_1 = __importDefault(require("../../../../../components/featureWrapper"));
 var componentOverrideContext_1 = require("../../../../../components/componentOverride/componentOverrideContext");
 var translations_1 = require("../../themes/translations");
 var react_2 = require("react");
 var react_3 = require("react");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
 var usercontext_1 = require("../../../../../usercontext");
 var useFeatureReducer = function (recipe) {
     return React.useReducer(
         function (oldState, action) {
             switch (action.type) {
                 case "setSignIn":
-                    return tslib_1.__assign(tslib_1.__assign({}, oldState), { error: undefined, isSignUp: false });
+                    return __assign(__assign({}, oldState), { error: undefined, isSignUp: false });
                 case "setSignUp":
-                    return tslib_1.__assign(tslib_1.__assign({}, oldState), { error: undefined, isSignUp: true });
+                    return __assign(__assign({}, oldState), { error: undefined, isSignUp: true });
                 case "setError":
-                    return tslib_1.__assign(tslib_1.__assign({}, oldState), { error: action.error });
+                    return __assign(__assign({}, oldState), { error: action.error });
                 default:
                     return oldState;
             }
@@ -76,9 +265,9 @@ function useChildProps(recipe, state, dispatch, history) {
     var userContext = (0, usercontext_1.useUserContext)();
     var onSignInSuccess = (0, react_3.useCallback)(
         function () {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
+            return __awaiter(_this, void 0, void 0, function () {
                 var isEmailVerified, ignored_1;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             if (!recipe) {
@@ -139,8 +328,8 @@ function useChildProps(recipe, state, dispatch, history) {
     );
     var onSignUpSuccess = (0, react_3.useCallback)(
         function () {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             if (!recipe) {
@@ -244,12 +433,12 @@ var SignInAndUpFeature = function (props) {
     var childProps = useChildProps(props.recipe, state, dispatch, props.history);
     return (0, jsx_runtime_1.jsx)(
         componentOverrideContext_1.ComponentOverrideContext.Provider,
-        tslib_1.__assign(
+        __assign(
             { value: props.recipe.config.override.components },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     featureWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             useShadowDom: props.recipe.config.useShadowDom,
                             defaultStore: translations_1.defaultTranslationsEmailPassword,
@@ -260,17 +449,14 @@ var SignInAndUpFeature = function (props) {
                                     props.children === undefined &&
                                         (0, jsx_runtime_1.jsx)(
                                             signInAndUp_1.default,
-                                            tslib_1.__assign({}, childProps, {
-                                                featureState: state,
-                                                dispatch: dispatch,
-                                            })
+                                            __assign({}, childProps, { featureState: state, dispatch: dispatch })
                                         ),
                                     props.children &&
                                         React.Children.map(props.children, function (child) {
                                             if (React.isValidElement(child)) {
                                                 return React.cloneElement(
                                                     child,
-                                                    tslib_1.__assign(tslib_1.__assign({}, childProps), {
+                                                    __assign(__assign({}, childProps), {
                                                         featureState: state,
                                                         dispatch: dispatch,
                                                     })
@@ -290,13 +476,13 @@ var SignInAndUpFeature = function (props) {
 exports.SignInAndUpFeature = SignInAndUpFeature;
 exports.default = exports.SignInAndUpFeature;
 var getModifiedRecipeImplementation = function (origImpl) {
-    return tslib_1.__assign({}, origImpl);
+    return __assign({}, origImpl);
 };
 function getThemeSignUpFeatureFormFields(formFields, recipe, userContext) {
     var _this = this;
     var emailPasswordOnly = formFields.length === 2;
     return formFields.map(function (field) {
-        return tslib_1.__assign(tslib_1.__assign({}, field), {
+        return __assign(__assign({}, field), {
             showIsRequired: (function () {
                 // If email and password only, do not show required indicator (*).
                 if (emailPasswordOnly) {
@@ -312,9 +498,9 @@ function getThemeSignUpFeatureFormFields(formFields, recipe, userContext) {
                 }
                 // Otherwise, if email, use syntax validate method and check if email exists.
                 return function (value) {
-                    return tslib_1.__awaiter(_this, void 0, void 0, function () {
+                    return __awaiter(_this, void 0, void 0, function () {
                         var error, emailExists, err_1;
-                        return tslib_1.__generator(this, function (_a) {
+                        return __generator(this, function (_a) {
                             switch (_a.label) {
                                 case 0:
                                     return [4 /*yield*/, field.validate(value)];

--- a/lib/build/recipe/emailpassword/components/library/backButton.js
+++ b/lib/build/recipe/emailpassword/components/library/backButton.js
@@ -1,6 +1,24 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -20,8 +38,8 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../styles/styleContext"));
-var heavyArrowLeftIcon_1 = tslib_1.__importDefault(require("../../../../components/assets/heavyArrowLeftIcon"));
+var styleContext_1 = __importDefault(require("../../../../styles/styleContext"));
+var heavyArrowLeftIcon_1 = __importDefault(require("../../../../components/assets/heavyArrowLeftIcon"));
 /*
  * Component.
  */
@@ -30,7 +48,7 @@ function BackButton(_a) {
     var styles = (0, react_1.useContext)(styleContext_1.default);
     return (0, jsx_runtime_1.jsx)(
         "button",
-        tslib_1.__assign(
+        __assign(
             {
                 onClick: onClick,
                 css: [styles.backButton, styles.backButtonCommon],

--- a/lib/build/recipe/emailpassword/components/library/backToSignInButton.js
+++ b/lib/build/recipe/emailpassword/components/library/backToSignInButton.js
@@ -1,6 +1,24 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,8 +39,8 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  */
 var react_1 = require("react");
 var __1 = require("../../../..");
-var arrowLeftIcon_1 = tslib_1.__importDefault(require("../../../../components/assets/arrowLeftIcon"));
-var styleContext_1 = tslib_1.__importDefault(require("../../../../styles/styleContext"));
+var arrowLeftIcon_1 = __importDefault(require("../../../../components/assets/arrowLeftIcon"));
+var styleContext_1 = __importDefault(require("../../../../styles/styleContext"));
 /*
  * Component.
  */
@@ -32,7 +50,7 @@ function BackToSignInButton(_a) {
     var styles = (0, react_1.useContext)(styleContext_1.default);
     return (0, jsx_runtime_1.jsxs)(
         "div",
-        tslib_1.__assign(
+        __assign(
             {
                 "data-supertokens": "secondaryText secondaryLinkWithLeftArrow",
                 css: [styles.secondaryText, styles.secondaryLinkWithLeftArrow],

--- a/lib/build/recipe/emailpassword/components/library/button.js
+++ b/lib/build/recipe/emailpassword/components/library/button.js
@@ -1,6 +1,24 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,7 +39,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  */
 var react_1 = require("react");
 var __1 = require("../../../..");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../styles/styleContext"));
 /*
  * Component.
  */
@@ -38,7 +56,7 @@ function Button(_a) {
     }
     return (0, jsx_runtime_1.jsxs)(
         "button",
-        tslib_1.__assign(
+        __assign(
             { type: type, disabled: disabled, onClick: onClick, css: styles.button, "data-supertokens": "button" },
             { children: [t(label), isLoading && "..."] }
         )

--- a/lib/build/recipe/emailpassword/components/library/formBase.js
+++ b/lib/build/recipe/emailpassword/components/library/formBase.js
@@ -1,7 +1,168 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __spreadArray =
+    (this && this.__spreadArray) ||
+    function (to, from, pack) {
+        if (pack || arguments.length === 2)
+            for (var i = 0, l = from.length, ar; i < l; i++) {
+                if (ar || !(i in from)) {
+                    if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+                    ar[i] = from[i];
+                }
+            }
+        return to.concat(ar || Array.prototype.slice.call(from));
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.FormBase = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -26,7 +187,7 @@ var constants_1 = require("../../constants");
 var react_2 = require("react");
 var react_3 = require("react");
 var react_4 = require("react");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
 var FormBase = function (props) {
     var footer = props.footer,
         buttonLabel = props.buttonLabel,
@@ -61,11 +222,7 @@ var FormBase = function (props) {
                     return f.id === id;
                 });
                 if (field === undefined) {
-                    return tslib_1.__spreadArray(
-                        tslib_1.__spreadArray([], os, true),
-                        [update({ id: id, value: "" })],
-                        false
-                    );
+                    return __spreadArray(__spreadArray([], os, true), [update({ id: id, value: "" })], false);
                 }
                 return os
                     .filter(function (f) {
@@ -79,16 +236,16 @@ var FormBase = function (props) {
     var onInputFocus = (0, react_2.useCallback)(
         function (field) {
             updateFieldState(field.id, function (os) {
-                return tslib_1.__assign(tslib_1.__assign({}, os), { validated: false });
+                return __assign(__assign({}, os), { validated: false });
             });
         },
         [updateFieldState]
     );
     var onInputBlur = (0, react_2.useCallback)(
         function (field) {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+            return __awaiter(void 0, void 0, void 0, function () {
                 var fieldConfig, error, _a;
-                return tslib_1.__generator(this, function (_b) {
+                return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
                             if (!validateOnBlur) {
@@ -108,7 +265,7 @@ var FormBase = function (props) {
                         case 3:
                             error = _a;
                             updateFieldState(field.id, function (os) {
-                                return tslib_1.__assign(tslib_1.__assign({}, os), {
+                                return __assign(__assign({}, os), {
                                     error: error,
                                     validated: error === undefined && field.value.length !== 0,
                                 });
@@ -123,7 +280,7 @@ var FormBase = function (props) {
     var onInputChange = (0, react_2.useCallback)(
         function (field) {
             updateFieldState(field.id, function (os) {
-                return tslib_1.__assign(tslib_1.__assign({}, os), { value: field.value, error: undefined });
+                return __assign(__assign({}, os), { value: field.value, error: undefined });
             });
             props.clearError();
         },
@@ -131,7 +288,7 @@ var FormBase = function (props) {
     );
     var onFormSubmit = (0, react_2.useCallback)(
         function (e) {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+            return __awaiter(void 0, void 0, void 0, function () {
                 var apiFields,
                     fieldUpdates,
                     result,
@@ -143,7 +300,7 @@ var FormBase = function (props) {
                     field,
                     errorFields_1,
                     e_2;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             // Prevent default event propagation.
@@ -152,7 +309,7 @@ var FormBase = function (props) {
                             setIsLoading(true);
                             setFieldStates(function (os) {
                                 return os.map(function (fs) {
-                                    return tslib_1.__assign(tslib_1.__assign({}, fs), { error: undefined });
+                                    return __assign(__assign({}, fs), { error: undefined });
                                 });
                             });
                             apiFields = formFields.map(function (field) {
@@ -201,9 +358,7 @@ var FormBase = function (props) {
                                 if (update || field.clearOnSubmit === true) {
                                     // We can do these one by one, it's almost never more than one field
                                     updateFieldState(field.id, function (os) {
-                                        return tslib_1.__assign(tslib_1.__assign({}, os), {
-                                            value: update ? update.value : "",
-                                        });
+                                        return __assign(__assign({}, os), { value: update ? update.value : "" });
                                     });
                                 }
                             };
@@ -228,7 +383,7 @@ var FormBase = function (props) {
                                     setFieldStates(function (os) {
                                         return os.map(function (fs) {
                                             var _a;
-                                            return tslib_1.__assign(tslib_1.__assign({}, fs), {
+                                            return __assign(__assign({}, fs), {
                                                 error:
                                                     (_a = errorFields_1.find(function (ef) {
                                                         return ef.id === fs.id;
@@ -258,7 +413,7 @@ var FormBase = function (props) {
     );
     return (0, jsx_runtime_1.jsxs)(
         "form",
-        tslib_1.__assign(
+        __assign(
             { autoComplete: "on", noValidate: true, onSubmit: onFormSubmit },
             {
                 children: [
@@ -280,7 +435,7 @@ var FormBase = function (props) {
                             value: "",
                         };
                         return (0,
-                        jsx_runtime_1.jsx)(_1.FormRow, tslib_1.__assign({ hasError: fstate.error !== undefined }, { children: (0, jsx_runtime_1.jsxs)(react_1.Fragment, { children: [showLabels && (field.labelComponent !== undefined ? field.labelComponent : (0, jsx_runtime_1.jsx)(_1.Label, { value: field.label, showIsRequired: field.showIsRequired })), field.inputComponent !== undefined ? (0, jsx_runtime_1.jsx)(field.inputComponent, { type: type, name: field.id, validated: fstate.validated === true, placeholder: field.placeholder, value: fstate.value, autoComplete: field.autoComplete, autofocus: field.autofocus, onInputFocus: onInputFocus, onInputBlur: onInputBlur, onChange: onInputChange, hasError: fstate.error !== undefined }) : (0, jsx_runtime_1.jsx)(_1.Input, { type: type, name: field.id, validated: fstate.validated === true, placeholder: field.placeholder, value: fstate.value, autoComplete: field.autoComplete, onInputFocus: onInputFocus, onInputBlur: onInputBlur, onChange: onInputChange, autofocus: field.autofocus, hasError: fstate.error !== undefined }), fstate.error && (0, jsx_runtime_1.jsx)(_1.InputError, { error: fstate.error })] }) }), field.id);
+                        jsx_runtime_1.jsx)(_1.FormRow, __assign({ hasError: fstate.error !== undefined }, { children: (0, jsx_runtime_1.jsxs)(react_1.Fragment, { children: [showLabels && (field.labelComponent !== undefined ? field.labelComponent : (0, jsx_runtime_1.jsx)(_1.Label, { value: field.label, showIsRequired: field.showIsRequired })), field.inputComponent !== undefined ? (0, jsx_runtime_1.jsx)(field.inputComponent, { type: type, name: field.id, validated: fstate.validated === true, placeholder: field.placeholder, value: fstate.value, autoComplete: field.autoComplete, autofocus: field.autofocus, onInputFocus: onInputFocus, onInputBlur: onInputBlur, onChange: onInputChange, hasError: fstate.error !== undefined }) : (0, jsx_runtime_1.jsx)(_1.Input, { type: type, name: field.id, validated: fstate.validated === true, placeholder: field.placeholder, value: fstate.value, autoComplete: field.autoComplete, onInputFocus: onInputFocus, onInputBlur: onInputBlur, onChange: onInputChange, autofocus: field.autofocus, hasError: fstate.error !== undefined }), fstate.error && (0, jsx_runtime_1.jsx)(_1.InputError, { error: fstate.error })] }) }), field.id);
                     }),
                     (0, jsx_runtime_1.jsx)(
                         _1.FormRow,

--- a/lib/build/recipe/emailpassword/components/library/formRow.js
+++ b/lib/build/recipe/emailpassword/components/library/formRow.js
@@ -1,6 +1,24 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -20,7 +38,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../styles/styleContext"));
 /*
  * Component.
  */
@@ -39,7 +57,7 @@ function FormRow(_a) {
             : {};
     return (0, jsx_runtime_1.jsx)(
         "div",
-        tslib_1.__assign({ "data-supertokens": "formRow", css: [styles.formRow, errorStyle] }, { children: children })
+        __assign({ "data-supertokens": "formRow", css: [styles.formRow, errorStyle] }, { children: children })
     );
 }
 exports.default = FormRow;

--- a/lib/build/recipe/emailpassword/components/library/generalError.js
+++ b/lib/build/recipe/emailpassword/components/library/generalError.js
@@ -1,6 +1,24 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -18,14 +36,14 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  */
 var react_1 = require("react");
 var translationContext_1 = require("../../../../translation/translationContext");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../styles/styleContext"));
 function GeneralError(_a) {
     var error = _a.error;
     var styles = (0, react_1.useContext)(styleContext_1.default);
     var t = (0, translationContext_1.useTranslation)();
     return (0, jsx_runtime_1.jsx)(
         "div",
-        tslib_1.__assign({ "data-supertokens": "generalError", css: styles.generalError }, { children: t(error) })
+        __assign({ "data-supertokens": "generalError", css: styles.generalError }, { children: t(error) })
     );
 }
 exports.default = GeneralError;

--- a/lib/build/recipe/emailpassword/components/library/index.js
+++ b/lib/build/recipe/emailpassword/components/library/index.js
@@ -13,16 +13,20 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Label = exports.InputError = exports.Input = exports.FormRow = exports.Button = void 0;
-var tslib_1 = require("tslib");
-var button_1 = tslib_1.__importDefault(require("./button"));
+var button_1 = __importDefault(require("./button"));
 exports.Button = button_1.default;
-var formRow_1 = tslib_1.__importDefault(require("./formRow"));
+var formRow_1 = __importDefault(require("./formRow"));
 exports.FormRow = formRow_1.default;
-var input_1 = tslib_1.__importDefault(require("./input"));
+var input_1 = __importDefault(require("./input"));
 exports.Input = input_1.default;
-var inputError_1 = tslib_1.__importDefault(require("./inputError"));
+var inputError_1 = __importDefault(require("./inputError"));
 exports.InputError = inputError_1.default;
-var label_1 = tslib_1.__importDefault(require("./label"));
+var label_1 = __importDefault(require("./label"));
 exports.Label = label_1.default;

--- a/lib/build/recipe/emailpassword/components/library/input.js
+++ b/lib/build/recipe/emailpassword/components/library/input.js
@@ -1,13 +1,31 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var react_1 = require("react");
 var react_2 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../styles/styleContext"));
-var showPasswordIcon_1 = tslib_1.__importDefault(require("../../../../components/assets/showPasswordIcon"));
-var checkedIcon_1 = tslib_1.__importDefault(require("../../../../components/assets/checkedIcon"));
-var errorIcon_1 = tslib_1.__importDefault(require("../../../../components/assets/errorIcon"));
+var styleContext_1 = __importDefault(require("../../../../styles/styleContext"));
+var showPasswordIcon_1 = __importDefault(require("../../../../components/assets/showPasswordIcon"));
+var checkedIcon_1 = __importDefault(require("../../../../components/assets/checkedIcon"));
+var errorIcon_1 = __importDefault(require("../../../../components/assets/errorIcon"));
 var __1 = require("../../../..");
 var Input = function (_a) {
     var type = _a.type,
@@ -63,12 +81,12 @@ var Input = function (_a) {
     }
     return (0, jsx_runtime_1.jsx)(
         "div",
-        tslib_1.__assign(
+        __assign(
             { "data-supertokens": "inputContainer", css: styles.inputContainer },
             {
                 children: (0, jsx_runtime_1.jsxs)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "inputWrapper inputError", css: [styles.inputWrapper, errorStyle] },
                         {
                             children: [
@@ -88,7 +106,7 @@ var Input = function (_a) {
                                 hasError === true &&
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             {
                                                 "data-supertokens": "inputAdornment inputAdornmentError",
                                                 css: [styles.inputAdornment, styles.inputAdornmentError],
@@ -104,7 +122,7 @@ var Input = function (_a) {
                                     hasError === false &&
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             {
                                                 "data-supertokens": "inputAdornment inputAdornmentSuccess",
                                                 css: [styles.inputAdornment, styles.inputAdornmentSuccess],
@@ -120,7 +138,7 @@ var Input = function (_a) {
                                     value.length > 0 &&
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             {
                                                 onClick: function () {
                                                     return setShowPassword(showPassword === false);

--- a/lib/build/recipe/emailpassword/components/library/inputError.js
+++ b/lib/build/recipe/emailpassword/components/library/inputError.js
@@ -1,6 +1,24 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -18,17 +36,14 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  */
 var react_1 = require("react");
 var translationContext_1 = require("../../../../translation/translationContext");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../styles/styleContext"));
 function InputError(_a) {
     var error = _a.error;
     var styles = (0, react_1.useContext)(styleContext_1.default);
     var t = (0, translationContext_1.useTranslation)();
     return (0, jsx_runtime_1.jsx)(
         "div",
-        tslib_1.__assign(
-            { "data-supertokens": "inputErrorMessage", css: styles.inputErrorMessage },
-            { children: t(error) }
-        )
+        __assign({ "data-supertokens": "inputErrorMessage", css: styles.inputErrorMessage }, { children: t(error) })
     );
 }
 exports.default = InputError;

--- a/lib/build/recipe/emailpassword/components/library/label.js
+++ b/lib/build/recipe/emailpassword/components/library/label.js
@@ -1,6 +1,24 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,7 +39,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  */
 var react_1 = require("react");
 var __1 = require("../../../..");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../styles/styleContext"));
 function Label(_a) {
     var value = _a.value,
         showIsRequired = _a.showIsRequired;
@@ -29,10 +47,7 @@ function Label(_a) {
     var styles = (0, react_1.useContext)(styleContext_1.default);
     return (0, jsx_runtime_1.jsxs)(
         "div",
-        tslib_1.__assign(
-            { "data-supertokens": "label", css: styles.label },
-            { children: [t(value), showIsRequired && " *"] }
-        )
+        __assign({ "data-supertokens": "label", css: styles.label }, { children: [t(value), showIsRequired && " *"] })
     );
 }
 exports.default = Label;

--- a/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/index.js
+++ b/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/index.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ResetPasswordUsingTokenTheme = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var themeBase_1 = require("../themeBase");
 var resetPasswordEmail_1 = require("./resetPasswordEmail");
@@ -9,7 +27,7 @@ var submitNewPassword_1 = require("./submitNewPassword");
 var styles_1 = require("../styles/styles");
 var styleContext_1 = require("../../../../../styles/styleContext");
 var styles_2 = require("../../../../../styles/styles");
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../../../../usercontext/userContextWrapper"));
+var userContextWrapper_1 = __importDefault(require("../../../../../usercontext/userContextWrapper"));
 /*
  * Component.
  */
@@ -21,7 +39,7 @@ function ResetPasswordUsingTokenTheme(props) {
     if (props.submitNewPasswordForm !== undefined) {
         return (0, jsx_runtime_1.jsx)(
             styleContext_1.StyleProvider,
-            tslib_1.__assign(
+            __assign(
                 {
                     rawPalette: props.config.palette,
                     defaultPalette: styles_2.defaultPalette,
@@ -32,7 +50,7 @@ function ResetPasswordUsingTokenTheme(props) {
                 {
                     children: (0, jsx_runtime_1.jsx)(
                         submitNewPassword_1.SubmitNewPassword,
-                        tslib_1.__assign({}, props.submitNewPasswordForm)
+                        __assign({}, props.submitNewPasswordForm)
                     ),
                 }
             )
@@ -41,7 +59,7 @@ function ResetPasswordUsingTokenTheme(props) {
     // Otherwise, return EnterEmail.
     return (0, jsx_runtime_1.jsx)(
         styleContext_1.StyleProvider,
-        tslib_1.__assign(
+        __assign(
             {
                 rawPalette: props.config.palette,
                 defaultPalette: styles_2.defaultPalette,
@@ -52,7 +70,7 @@ function ResetPasswordUsingTokenTheme(props) {
             {
                 children: (0, jsx_runtime_1.jsx)(
                     resetPasswordEmail_1.ResetPasswordEmail,
-                    tslib_1.__assign({}, props.enterEmailForm)
+                    __assign({}, props.enterEmailForm)
                 ),
             }
         )
@@ -63,14 +81,14 @@ function ResetPasswordUsingTokenThemeWrapper(props) {
     var hasFont = (0, styles_2.hasFontDefined)(props.config.rootStyle);
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
-        tslib_1.__assign(
+        __assign(
             { userContext: props.userContext },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     themeBase_1.ThemeBase,
-                    tslib_1.__assign(
+                    __assign(
                         { loadDefaultFont: !hasFont },
-                        { children: (0, jsx_runtime_1.jsx)(ResetPasswordUsingTokenTheme, tslib_1.__assign({}, props)) }
+                        { children: (0, jsx_runtime_1.jsx)(ResetPasswordUsingTokenTheme, __assign({}, props)) }
                     )
                 ),
             }

--- a/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/resetPasswordEmail.js
+++ b/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/resetPasswordEmail.js
@@ -1,7 +1,156 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ResetPasswordEmail = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -18,15 +167,15 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * under the License.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
-var formBase_1 = tslib_1.__importDefault(require("../../library/formBase"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
+var formBase_1 = __importDefault(require("../../library/formBase"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
 var utils_1 = require("../../../../../utils");
-var generalError_1 = tslib_1.__importDefault(require("../../library/generalError"));
+var generalError_1 = __importDefault(require("../../library/generalError"));
 var usercontext_1 = require("../../../../../usercontext");
-var backToSignInButton_1 = tslib_1.__importDefault(require("../../library/backToSignInButton"));
-var backButton_1 = tslib_1.__importDefault(require("../../library/backButton"));
+var backToSignInButton_1 = __importDefault(require("../../library/backToSignInButton"));
+var backButton_1 = __importDefault(require("../../library/backButton"));
 var EmailPasswordResetPasswordEmail = function (props) {
     var styles = (0, react_1.useContext)(styleContext_1.default);
     var t = (0, translationContext_1.useTranslation)();
@@ -53,18 +202,18 @@ var EmailPasswordResetPasswordEmail = function (props) {
     if (status === "SENT") {
         return (0, jsx_runtime_1.jsx)(
             "div",
-            tslib_1.__assign(
+            __assign(
                 { "data-supertokens": "container", css: styles.container },
                 {
                     children: (0, jsx_runtime_1.jsxs)(
                         "div",
-                        tslib_1.__assign(
+                        __assign(
                             { "data-supertokens": "row", css: styles.row },
                             {
                                 children: [
                                     (0, jsx_runtime_1.jsxs)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             {
                                                 "data-supertokens": "primaryText enterEmailSuccessMessage",
                                                 css: [styles.primaryText, styles.enterEmailSuccessMessage],
@@ -74,7 +223,7 @@ var EmailPasswordResetPasswordEmail = function (props) {
                                                     emailSuccessText,
                                                     (0, jsx_runtime_1.jsx)(
                                                         "span",
-                                                        tslib_1.__assign(
+                                                        __assign(
                                                             {
                                                                 "data-supertokens": "link resendEmailLink",
                                                                 css: [styles.link, styles.resendEmailLink],
@@ -101,18 +250,18 @@ var EmailPasswordResetPasswordEmail = function (props) {
     // Otherwise, return Form.
     return (0, jsx_runtime_1.jsx)(
         "div",
-        tslib_1.__assign(
+        __assign(
             { "data-supertokens": "container", css: styles.container },
             {
                 children: (0, jsx_runtime_1.jsxs)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "row", css: styles.row },
                         {
                             children: [
                                 (0, jsx_runtime_1.jsxs)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         {
                                             "data-supertokens": "headerTitle resetPasswordHeaderTitle",
                                             css: [styles.headerTitle, styles.resetPasswordHeaderTitle],
@@ -133,12 +282,12 @@ var EmailPasswordResetPasswordEmail = function (props) {
                                 ),
                                 (0, jsx_runtime_1.jsx)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         { "data-supertokens": "headerSubtitle", css: styles.headerSubtitle },
                                         {
                                             children: (0, jsx_runtime_1.jsx)(
                                                 "div",
-                                                tslib_1.__assign(
+                                                __assign(
                                                     { "data-supertokens": "secondaryText", css: styles.secondaryText },
                                                     { children: t("EMAIL_PASSWORD_RESET_HEADER_SUBTITLE") }
                                                 )
@@ -155,9 +304,9 @@ var EmailPasswordResetPasswordEmail = function (props) {
                                     buttonLabel: "EMAIL_PASSWORD_RESET_SEND_BTN",
                                     onSuccess: onSuccess,
                                     callAPI: function (formFields) {
-                                        return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+                                        return __awaiter(void 0, void 0, void 0, function () {
                                             var validationErrors, emailField;
-                                            return tslib_1.__generator(this, function (_a) {
+                                            return __generator(this, function (_a) {
                                                 switch (_a.label) {
                                                     case 0:
                                                         return [

--- a/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/submitNewPassword.js
+++ b/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/submitNewPassword.js
@@ -1,7 +1,156 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SubmitNewPassword = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,14 +170,14 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var library_1 = require("../../library");
-var formBase_1 = tslib_1.__importDefault(require("../../library/formBase"));
+var formBase_1 = __importDefault(require("../../library/formBase"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
 var utils_1 = require("../../../../../utils");
-var generalError_1 = tslib_1.__importDefault(require("../../library/generalError"));
+var generalError_1 = __importDefault(require("../../library/generalError"));
 var usercontext_1 = require("../../../../../usercontext");
 var EmailPasswordSubmitNewPassword = function (props) {
     var styles = (0, react_1.useContext)(styleContext_1.default);
@@ -45,18 +194,18 @@ var EmailPasswordSubmitNewPassword = function (props) {
     if (status === "SUCCESS") {
         return (0, jsx_runtime_1.jsx)(
             "div",
-            tslib_1.__assign(
+            __assign(
                 { "data-supertokens": "container", css: styles.container },
                 {
                     children: (0, jsx_runtime_1.jsxs)(
                         "div",
-                        tslib_1.__assign(
+                        __assign(
                             { "data-supertokens": "row", css: styles.row },
                             {
                                 children: [
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             { "data-supertokens": "headerTitle", css: styles.headerTitle },
                                             { children: t("EMAIL_PASSWORD_RESET_SUBMIT_PW_SUCCESS_HEADER_TITLE") }
                                         )
@@ -68,7 +217,7 @@ var EmailPasswordSubmitNewPassword = function (props) {
                                                 children: [
                                                     (0, jsx_runtime_1.jsx)(
                                                         "div",
-                                                        tslib_1.__assign(
+                                                        __assign(
                                                             {
                                                                 "data-supertokens":
                                                                     "primaryText submitNewPasswordSuccessMessage",
@@ -106,30 +255,30 @@ var EmailPasswordSubmitNewPassword = function (props) {
     }
     return (0, jsx_runtime_1.jsx)(
         "div",
-        tslib_1.__assign(
+        __assign(
             { "data-supertokens": "container", css: styles.container },
             {
                 children: (0, jsx_runtime_1.jsxs)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "row", css: styles.row },
                         {
                             children: [
                                 (0, jsx_runtime_1.jsx)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         { "data-supertokens": "headerTitle", css: styles.headerTitle },
                                         { children: t("EMAIL_PASSWORD_RESET_SUBMIT_PW_HEADER_TITLE") }
                                     )
                                 ),
                                 (0, jsx_runtime_1.jsx)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         { "data-supertokens": "headerSubtitle", css: styles.headerSubtitle },
                                         {
                                             children: (0, jsx_runtime_1.jsx)(
                                                 "div",
-                                                tslib_1.__assign(
+                                                __assign(
                                                     { "data-supertokens": "secondaryText", css: styles.secondaryText },
                                                     { children: t("EMAIL_PASSWORD_RESET_SUBMIT_PW_HEADER_SUBTITLE") }
                                                 )
@@ -147,9 +296,9 @@ var EmailPasswordSubmitNewPassword = function (props) {
                                     onSuccess: onSuccess,
                                     validateOnBlur: true,
                                     callAPI: function (fields) {
-                                        return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+                                        return __awaiter(void 0, void 0, void 0, function () {
                                             var validationErrors, response;
-                                            return tslib_1.__generator(this, function (_a) {
+                                            return __generator(this, function (_a) {
                                                 switch (_a.label) {
                                                     case 0:
                                                         return [

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/index.js
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/index.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignInAndUpTheme = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var signUp_1 = require("./signUp");
 var signIn_1 = require("./signIn");
@@ -9,13 +27,13 @@ var themeBase_1 = require("../themeBase");
 var styleContext_1 = require("../../../../../styles/styleContext");
 var styles_1 = require("../../../../../styles/styles");
 var styles_2 = require("../styles/styles");
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../../../../usercontext/userContextWrapper"));
+var userContextWrapper_1 = __importDefault(require("../../../../../usercontext/userContextWrapper"));
 var SignInAndUpTheme = function (props) {
     // If isSignUp, return signUp.
     if (props.featureState.isSignUp) {
         return (0, jsx_runtime_1.jsx)(
             styleContext_1.StyleProvider,
-            tslib_1.__assign(
+            __assign(
                 {
                     rawPalette: props.config.palette,
                     defaultPalette: styles_1.defaultPalette,
@@ -26,7 +44,7 @@ var SignInAndUpTheme = function (props) {
                 {
                     children: (0, jsx_runtime_1.jsx)(
                         signUp_1.SignUp,
-                        tslib_1.__assign({}, props.signUpForm, {
+                        __assign({}, props.signUpForm, {
                             signInClicked: function () {
                                 props.dispatch({ type: "setSignIn" });
                             },
@@ -39,7 +57,7 @@ var SignInAndUpTheme = function (props) {
     // Otherwise, return SignIn.
     return (0, jsx_runtime_1.jsx)(
         styleContext_1.StyleProvider,
-        tslib_1.__assign(
+        __assign(
             {
                 rawPalette: props.config.palette,
                 defaultPalette: styles_1.defaultPalette,
@@ -50,7 +68,7 @@ var SignInAndUpTheme = function (props) {
             {
                 children: (0, jsx_runtime_1.jsx)(
                     signIn_1.SignIn,
-                    tslib_1.__assign({}, props.signInForm, {
+                    __assign({}, props.signInForm, {
                         signUpClicked: function () {
                             props.dispatch({ type: "setSignUp" });
                         },
@@ -65,14 +83,14 @@ function SignInAndUpThemeWrapper(props) {
     var hasFont = (0, styles_1.hasFontDefined)(props.config.rootStyle);
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
-        tslib_1.__assign(
+        __assign(
             { userContext: props.userContext },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     themeBase_1.ThemeBase,
-                    tslib_1.__assign(
+                    __assign(
                         { loadDefaultFont: !hasFont },
-                        { children: (0, jsx_runtime_1.jsx)(exports.SignInAndUpTheme, tslib_1.__assign({}, props)) }
+                        { children: (0, jsx_runtime_1.jsx)(exports.SignInAndUpTheme, __assign({}, props)) }
                     )
                 ),
             }

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signIn.js
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signIn.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignIn = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,15 +39,15 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var signInFooter_1 = require("./signInFooter");
 var signInForm_1 = require("./signInForm");
 var signInHeader_1 = require("./signInHeader");
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var SuperTokensBranding_1 = require("../../../../../components/SuperTokensBranding");
-var generalError_1 = tslib_1.__importDefault(require("../../library/generalError"));
+var generalError_1 = __importDefault(require("../../library/generalError"));
 exports.SignIn = (0, withOverride_1.withOverride)("EmailPasswordSignIn", function EmailPasswordSignIn(props) {
     var styles = (0, react_1.useContext)(styleContext_1.default);
     return (0,
-    jsx_runtime_1.jsxs)("div", tslib_1.__assign({ "data-supertokens": "container", css: styles.container }, { children: [(0, jsx_runtime_1.jsxs)("div", tslib_1.__assign({ "data-supertokens": "row", css: styles.row }, { children: [(0, jsx_runtime_1.jsx)(signInHeader_1.SignInHeader, { onClick: props.signUpClicked }), props.error !== undefined && (0, jsx_runtime_1.jsx)(generalError_1.default, { error: props.error }), (0, jsx_runtime_1.jsx)(signInForm_1.SignInForm, tslib_1.__assign({}, props, { footer: (0, jsx_runtime_1.jsx)(signInFooter_1.SignInFooter, { onClick: props.forgotPasswordClick }) }))] })), (0, jsx_runtime_1.jsx)(SuperTokensBranding_1.SuperTokensBranding, {})] }));
+    jsx_runtime_1.jsxs)("div", __assign({ "data-supertokens": "container", css: styles.container }, { children: [(0, jsx_runtime_1.jsxs)("div", __assign({ "data-supertokens": "row", css: styles.row }, { children: [(0, jsx_runtime_1.jsx)(signInHeader_1.SignInHeader, { onClick: props.signUpClicked }), props.error !== undefined && (0, jsx_runtime_1.jsx)(generalError_1.default, { error: props.error }), (0, jsx_runtime_1.jsx)(signInForm_1.SignInForm, __assign({}, props, { footer: (0, jsx_runtime_1.jsx)(signInFooter_1.SignInFooter, { onClick: props.forgotPasswordClick }) }))] })), (0, jsx_runtime_1.jsx)(SuperTokensBranding_1.SuperTokensBranding, {})] }));
 });

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signInFooter.js
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signInFooter.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignInFooter = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -18,7 +36,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * under the License.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
 exports.SignInFooter = (0, withOverride_1.withOverride)(
@@ -29,7 +47,7 @@ exports.SignInFooter = (0, withOverride_1.withOverride)(
         var t = (0, translationContext_1.useTranslation)();
         return (0, jsx_runtime_1.jsx)(
             "div",
-            tslib_1.__assign(
+            __assign(
                 {
                     "data-supertokens": "link secondaryText forgotPasswordLink",
                     css: [styles.link, styles.secondaryText, styles.forgotPasswordLink],

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signInForm.js
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signInForm.js
@@ -1,12 +1,147 @@
 "use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignInForm = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
-var formBase_1 = tslib_1.__importDefault(require("../../library/formBase"));
+var formBase_1 = __importDefault(require("../../library/formBase"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var utils_1 = require("../../../../../utils");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
 var usercontext_1 = require("../../../../../usercontext");
 exports.SignInForm = (0, withOverride_1.withOverride)(
     "EmailPasswordSignInForm",
@@ -20,9 +155,9 @@ exports.SignInForm = (0, withOverride_1.withOverride)(
             buttonLabel: "EMAIL_PASSWORD_SIGN_IN_SUBMIT_BTN",
             onSuccess: props.onSuccess,
             callAPI: function (formFields) {
-                return tslib_1.__awaiter(_this, void 0, void 0, function () {
+                return __awaiter(_this, void 0, void 0, function () {
                     var validationErrors, response;
-                    return tslib_1.__generator(this, function (_a) {
+                    return __generator(this, function (_a) {
                         switch (_a.label) {
                             case 0:
                                 return [

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signInHeader.js
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signInHeader.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignInHeader = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -18,7 +36,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * under the License.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
 exports.SignInHeader = (0, withOverride_1.withOverride)(
@@ -31,26 +49,26 @@ exports.SignInHeader = (0, withOverride_1.withOverride)(
             children: [
                 (0, jsx_runtime_1.jsx)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "headerTitle", css: styles.headerTitle },
                         { children: t("EMAIL_PASSWORD_SIGN_IN_HEADER_TITLE") }
                     )
                 ),
                 (0, jsx_runtime_1.jsx)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "headerSubtitle", css: styles.headerSubtitle },
                         {
                             children: (0, jsx_runtime_1.jsxs)(
                                 "div",
-                                tslib_1.__assign(
+                                __assign(
                                     { "data-supertokens": "secondaryText", css: styles.secondaryText },
                                     {
                                         children: [
                                             t("EMAIL_PASSWORD_SIGN_IN_HEADER_SUBTITLE_START"),
                                             (0, jsx_runtime_1.jsx)(
                                                 "span",
-                                                tslib_1.__assign(
+                                                __assign(
                                                     { "data-supertokens": "link", onClick: onClick, css: styles.link },
                                                     {
                                                         children: t(

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUp.js
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUp.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignUp = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -20,13 +38,13 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var react_1 = require("react");
 var signUpFooter_1 = require("./signUpFooter");
 var signUpHeader_1 = require("./signUpHeader");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var signUpForm_1 = require("./signUpForm");
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var SuperTokensBranding_1 = require("../../../../../components/SuperTokensBranding");
-var generalError_1 = tslib_1.__importDefault(require("../../library/generalError"));
+var generalError_1 = __importDefault(require("../../library/generalError"));
 exports.SignUp = (0, withOverride_1.withOverride)("EmailPasswordSignUp", function EmailPasswordSignUp(props) {
     var styles = (0, react_1.useContext)(styleContext_1.default);
     return (0,
-    jsx_runtime_1.jsxs)("div", tslib_1.__assign({ "data-supertokens": "container", css: styles.container }, { children: [(0, jsx_runtime_1.jsxs)("div", tslib_1.__assign({ "data-supertokens": "row", css: styles.row }, { children: [(0, jsx_runtime_1.jsx)(signUpHeader_1.SignUpHeader, { onClick: props.signInClicked }), props.error !== undefined && (0, jsx_runtime_1.jsx)(generalError_1.default, { error: props.error }), (0, jsx_runtime_1.jsx)(signUpForm_1.SignUpForm, tslib_1.__assign({}, props, { footer: (0, jsx_runtime_1.jsx)(signUpFooter_1.SignUpFooter, { privacyPolicyLink: props.config.signInAndUpFeature.signUpForm.privacyPolicyLink, termsOfServiceLink: props.config.signInAndUpFeature.signUpForm.termsOfServiceLink }) }))] })), (0, jsx_runtime_1.jsx)(SuperTokensBranding_1.SuperTokensBranding, {})] }));
+    jsx_runtime_1.jsxs)("div", __assign({ "data-supertokens": "container", css: styles.container }, { children: [(0, jsx_runtime_1.jsxs)("div", __assign({ "data-supertokens": "row", css: styles.row }, { children: [(0, jsx_runtime_1.jsx)(signUpHeader_1.SignUpHeader, { onClick: props.signInClicked }), props.error !== undefined && (0, jsx_runtime_1.jsx)(generalError_1.default, { error: props.error }), (0, jsx_runtime_1.jsx)(signUpForm_1.SignUpForm, __assign({}, props, { footer: (0, jsx_runtime_1.jsx)(signUpFooter_1.SignUpFooter, { privacyPolicyLink: props.config.signInAndUpFeature.signUpForm.privacyPolicyLink, termsOfServiceLink: props.config.signInAndUpFeature.signUpForm.termsOfServiceLink }) }))] })), (0, jsx_runtime_1.jsx)(SuperTokensBranding_1.SuperTokensBranding, {})] }));
 });

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUpFooter.js
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUpFooter.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignUpFooter = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,7 +39,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
 exports.SignUpFooter = (0, withOverride_1.withOverride)(
@@ -36,7 +54,7 @@ exports.SignUpFooter = (0, withOverride_1.withOverride)(
         }
         return (0, jsx_runtime_1.jsxs)(
             "div",
-            tslib_1.__assign(
+            __assign(
                 {
                     "data-supertokens": "secondaryText privacyPolicyAndTermsAndConditions",
                     css: [styles.secondaryText, styles.privacyPolicyAndTermsAndConditions],
@@ -47,7 +65,7 @@ exports.SignUpFooter = (0, withOverride_1.withOverride)(
                         termsOfServiceLink !== undefined &&
                             (0, jsx_runtime_1.jsx)(
                                 "a",
-                                tslib_1.__assign(
+                                __assign(
                                     {
                                         "data-supertokens": "link",
                                         css: styles.link,
@@ -64,7 +82,7 @@ exports.SignUpFooter = (0, withOverride_1.withOverride)(
                         privacyPolicyLink !== undefined &&
                             (0, jsx_runtime_1.jsx)(
                                 "a",
-                                tslib_1.__assign(
+                                __assign(
                                     {
                                         "data-supertokens": "link",
                                         css: styles.link,

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUpForm.js
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUpForm.js
@@ -1,9 +1,144 @@
 "use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignUpForm = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
-var formBase_1 = tslib_1.__importDefault(require("../../library/formBase"));
+var formBase_1 = __importDefault(require("../../library/formBase"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var utils_1 = require("../../../../../utils");
 var usercontext_1 = require("../../../../../usercontext");
@@ -22,9 +157,9 @@ exports.SignUpForm = (0, withOverride_1.withOverride)(
             buttonLabel: "EMAIL_PASSWORD_SIGN_UP_SUBMIT_BTN",
             onSuccess: props.onSuccess,
             callAPI: function (formFields) {
-                return tslib_1.__awaiter(_this, void 0, void 0, function () {
+                return __awaiter(_this, void 0, void 0, function () {
                     var validationErrors;
-                    return tslib_1.__generator(this, function (_a) {
+                    return __generator(this, function (_a) {
                         switch (_a.label) {
                             case 0:
                                 return [

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUpHeader.js
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUpHeader.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignUpHeader = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,7 +39,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
 exports.SignUpHeader = (0, withOverride_1.withOverride)(
@@ -34,26 +52,26 @@ exports.SignUpHeader = (0, withOverride_1.withOverride)(
             children: [
                 (0, jsx_runtime_1.jsx)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "headerTitle", css: styles.headerTitle },
                         { children: t("EMAIL_PASSWORD_SIGN_UP_HEADER_TITLE") }
                     )
                 ),
                 (0, jsx_runtime_1.jsx)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "headerSubtitle", css: styles.headerSubtitle },
                         {
                             children: (0, jsx_runtime_1.jsxs)(
                                 "div",
-                                tslib_1.__assign(
+                                __assign(
                                     { "data-supertokens": "secondaryText", css: styles.secondaryText },
                                     {
                                         children: [
                                             t("EMAIL_PASSWORD_SIGN_UP_HEADER_SUBTITLE_START"),
                                             (0, jsx_runtime_1.jsx)(
                                                 "span",
-                                                tslib_1.__assign(
+                                                __assign(
                                                     { "data-supertokens": "link", onClick: onClick, css: styles.link },
                                                     {
                                                         children: t(

--- a/lib/build/recipe/emailpassword/components/themes/styles/styles.js
+++ b/lib/build/recipe/emailpassword/components/themes/styles/styles.js
@@ -13,10 +13,14 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getStyles = void 0;
-var tslib_1 = require("tslib");
-var chroma_js_1 = tslib_1.__importDefault(require("chroma-js"));
+var chroma_js_1 = __importDefault(require("chroma-js"));
 var styles_1 = require("../../../../../styles/styles");
 function getStyles(palette) {
     var baseStyles = (0, styles_1.getDefaultStyles)(palette);

--- a/lib/build/recipe/emailpassword/components/themes/translations.js
+++ b/lib/build/recipe/emailpassword/components/themes/translations.js
@@ -1,13 +1,26 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.defaultTranslationsEmailPassword = void 0;
-var tslib_1 = require("tslib");
 var translations_1 = require("../../../../translation/translations");
 var translations_2 = require("../../../emailverification/components/themes/translations");
 exports.defaultTranslationsEmailPassword = {
-    en: tslib_1.__assign(
-        tslib_1.__assign(
-            tslib_1.__assign({}, translations_1.defaultTranslationsCommon.en),
+    en: __assign(
+        __assign(
+            __assign({}, translations_1.defaultTranslationsCommon.en),
             translations_2.defaultTranslationsEmailVerification.en
         ),
         {

--- a/lib/build/recipe/emailpassword/emailPasswordAuth.js
+++ b/lib/build/recipe/emailpassword/emailPasswordAuth.js
@@ -1,30 +1,45 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var react_1 = require("react");
-var recipe_1 = tslib_1.__importDefault(require("./recipe"));
-var sessionAuth_1 = tslib_1.__importDefault(require("../session/sessionAuth"));
-var emailVerificationAuth_1 = tslib_1.__importDefault(require("../emailverification/emailVerificationAuth"));
-var superTokens_1 = tslib_1.__importDefault(require("../../superTokens"));
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../usercontext/userContextWrapper"));
+var recipe_1 = __importDefault(require("./recipe"));
+var sessionAuth_1 = __importDefault(require("../session/sessionAuth"));
+var emailVerificationAuth_1 = __importDefault(require("../emailverification/emailVerificationAuth"));
+var superTokens_1 = __importDefault(require("../../superTokens"));
+var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
 function EmailPasswordAuth(props) {
     var emailVerification = (0, jsx_runtime_1.jsx)(
         emailVerificationAuth_1.default,
-        tslib_1.__assign(
-            { recipe: props.recipe.emailVerification, history: props.history },
-            { children: props.children }
-        )
+        __assign({ recipe: props.recipe.emailVerification, history: props.history }, { children: props.children })
     );
     if (props.requireAuth === false) {
         return (0, jsx_runtime_1.jsx)(
             sessionAuth_1.default,
-            tslib_1.__assign({ onSessionExpired: props.onSessionExpired }, { children: emailVerification })
+            __assign({ onSessionExpired: props.onSessionExpired }, { children: emailVerification })
         );
     }
     return (0, jsx_runtime_1.jsx)(
         sessionAuth_1.default,
-        tslib_1.__assign(
+        __assign(
             {
                 redirectToLogin: function () {
                     return recipe_1.default
@@ -48,12 +63,12 @@ var EmailPasswordAuthWrapper = function (_a) {
     var history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
-        tslib_1.__assign(
+        __assign(
             { userContext: userContext },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     EmailPasswordAuthMemo,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             history: history,
                             onSessionExpired: onSessionExpired,

--- a/lib/build/recipe/emailpassword/index.js
+++ b/lib/build/recipe/emailpassword/index.js
@@ -13,6 +13,156 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.EmailVerificationTheme =
     exports.EmailVerification =
@@ -35,15 +185,14 @@ exports.EmailVerificationTheme =
     exports.init =
     exports.EmailPasswordAuth =
         void 0;
-var tslib_1 = require("tslib");
-var recipe_1 = tslib_1.__importDefault(require("./recipe"));
-var emailPasswordAuth_1 = tslib_1.__importDefault(require("./emailPasswordAuth"));
+var recipe_1 = __importDefault(require("./recipe"));
+var emailPasswordAuth_1 = __importDefault(require("./emailPasswordAuth"));
 exports.EmailPasswordAuth = emailPasswordAuth_1.default;
-var signInAndUp_1 = tslib_1.__importDefault(require("./components/themes/signInAndUp"));
+var signInAndUp_1 = __importDefault(require("./components/themes/signInAndUp"));
 exports.SignInAndUpTheme = signInAndUp_1.default;
-var resetPasswordUsingToken_1 = tslib_1.__importDefault(require("./components/themes/resetPasswordUsingToken"));
+var resetPasswordUsingToken_1 = __importDefault(require("./components/themes/resetPasswordUsingToken"));
 exports.ResetPasswordUsingTokenTheme = resetPasswordUsingToken_1.default;
-var emailVerification_1 = tslib_1.__importDefault(require("../emailverification/components/themes/emailVerification"));
+var emailVerification_1 = __importDefault(require("../emailverification/components/themes/emailVerification"));
 exports.EmailVerificationTheme = emailVerification_1.default;
 var utils_1 = require("../../utils");
 var Wrapper = /** @class */ (function () {
@@ -52,8 +201,8 @@ var Wrapper = /** @class */ (function () {
         return recipe_1.default.init(config);
     };
     Wrapper.signOut = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().signOut({
@@ -66,12 +215,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.isEmailVerified = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.isEmailVerified(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -82,12 +231,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.verifyEmail = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.verifyEmail(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -98,12 +247,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.sendVerificationEmail = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.sendVerificationEmail(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -115,7 +264,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getEmailVerificationTokenFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.getEmailVerificationTokenFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -124,8 +273,8 @@ var Wrapper = /** @class */ (function () {
     };
     // have backwards compatibility to allow input as "signin" | "signup"
     Wrapper.redirectToAuth = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 if (input === undefined || typeof input === "string") {
                     return [
                         2 /*return*/,
@@ -149,12 +298,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.submitNewPassword = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.submitNewPassword(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -163,12 +312,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.sendPasswordResetEmail = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.sendPasswordResetEmail(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -177,12 +326,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.signUp = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.signUp(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -191,12 +340,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.signIn = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.signIn(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -205,12 +354,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.doesEmailExist = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.doesEmailExist(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -220,7 +369,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getResetPasswordTokenFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getResetPasswordTokenFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),

--- a/lib/build/recipe/emailpassword/recipe.js
+++ b/lib/build/recipe/emailpassword/recipe.js
@@ -1,6 +1,180 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,23 +193,23 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var authRecipeWithEmailVerification_1 = tslib_1.__importDefault(require("../authRecipeWithEmailVerification"));
+var authRecipeWithEmailVerification_1 = __importDefault(require("../authRecipeWithEmailVerification"));
 var utils_1 = require("../../utils");
 var utils_2 = require("./utils");
-var normalisedURLPath_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
+var normalisedURLPath_1 = __importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
 var constants_1 = require("./constants");
 var constants_2 = require("../../constants");
-var signInAndUp_1 = tslib_1.__importDefault(require("./components/features/signInAndUp"));
-var resetPasswordUsingToken_1 = tslib_1.__importDefault(require("./components/features/resetPasswordUsingToken"));
-var recipeImplementation_1 = tslib_1.__importDefault(require("./recipeImplementation"));
-var authWidgetWrapper_1 = tslib_1.__importDefault(require("../authRecipe/authWidgetWrapper"));
-var supertokens_js_override_1 = tslib_1.__importDefault(require("supertokens-js-override"));
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../usercontext/userContextWrapper"));
+var signInAndUp_1 = __importDefault(require("./components/features/signInAndUp"));
+var resetPasswordUsingToken_1 = __importDefault(require("./components/features/resetPasswordUsingToken"));
+var recipeImplementation_1 = __importDefault(require("./recipeImplementation"));
+var authWidgetWrapper_1 = __importDefault(require("../authRecipe/authWidgetWrapper"));
+var supertokens_js_override_1 = __importDefault(require("supertokens-js-override"));
+var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
 /*
  * Class.
  */
 var EmailPassword = /** @class */ (function (_super) {
-    tslib_1.__extends(EmailPassword, _super);
+    __extends(EmailPassword, _super);
     function EmailPassword(config, recipes) {
         var _this =
             _super.call(this, (0, utils_2.normaliseEmailPasswordConfig)(config), {
@@ -65,12 +239,12 @@ var EmailPassword = /** @class */ (function (_super) {
                     },
                 };
             }
-            return tslib_1.__assign(tslib_1.__assign({}, features), _this.getAuthRecipeWithEmailVerificationFeatures());
+            return __assign(__assign({}, features), _this.getAuthRecipeWithEmailVerificationFeatures());
         };
         _this.getDefaultRedirectionURL = function (context) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
+            return __awaiter(_this, void 0, void 0, function () {
                 var resetPasswordPath;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     if (context.action === "RESET_PASSWORD") {
                         resetPasswordPath = new normalisedURLPath_1.default(constants_1.DEFAULT_RESET_PASSWORD_PATH);
                         return [
@@ -93,17 +267,17 @@ var EmailPassword = /** @class */ (function (_super) {
             if (componentName === "signinup") {
                 return (0, jsx_runtime_1.jsx)(
                     userContextWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         { userContext: props.userContext },
                         {
                             children: (0, jsx_runtime_1.jsx)(
                                 authWidgetWrapper_1.default,
-                                tslib_1.__assign(
+                                __assign(
                                     { authRecipe: _this, history: props.history },
                                     {
                                         children: (0, jsx_runtime_1.jsx)(
                                             signInAndUp_1.default,
-                                            tslib_1.__assign({ recipe: _this }, props)
+                                            __assign({ recipe: _this }, props)
                                         ),
                                     }
                                 )
@@ -114,12 +288,12 @@ var EmailPassword = /** @class */ (function (_super) {
             } else if (componentName === "resetpassword") {
                 return (0, jsx_runtime_1.jsx)(
                     userContextWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         { userContext: props.userContext },
                         {
                             children: (0, jsx_runtime_1.jsx)(
                                 resetPasswordUsingToken_1.default,
-                                tslib_1.__assign({ recipe: _this }, props)
+                                __assign({ recipe: _this }, props)
                             ),
                         }
                     )
@@ -143,7 +317,7 @@ var EmailPassword = /** @class */ (function (_super) {
     EmailPassword.init = function (config) {
         return function (appInfo) {
             EmailPassword.instance = new EmailPassword(
-                tslib_1.__assign(tslib_1.__assign({}, config), { appInfo: appInfo, recipeId: EmailPassword.RECIPE_ID }),
+                __assign(__assign({}, config), { appInfo: appInfo, recipeId: EmailPassword.RECIPE_ID }),
                 {
                     emailVerificationInstance: undefined,
                 }

--- a/lib/build/recipe/emailpassword/recipeImplementation.js
+++ b/lib/build/recipe/emailpassword/recipeImplementation.js
@@ -1,6 +1,136 @@
 "use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var recipeImplementation_1 = require("supertokens-web-js/recipe/emailpassword/recipeImplementation");
 function getRecipeImplementation(recipeInput) {
     var webJsImplementation = (0, recipeImplementation_1.getRecipeImplementation)({
@@ -11,9 +141,9 @@ function getRecipeImplementation(recipeInput) {
     });
     return {
         submitNewPassword: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
+            return __awaiter(this, void 0, void 0, function () {
                 var response;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [
@@ -37,9 +167,9 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         sendPasswordResetEmail: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
+            return __awaiter(this, void 0, void 0, function () {
                 var response;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [
@@ -63,9 +193,9 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         signUp: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
+            return __awaiter(this, void 0, void 0, function () {
                 var response;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [
@@ -91,9 +221,9 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         signIn: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
+            return __awaiter(this, void 0, void 0, function () {
                 var response;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [
@@ -119,8 +249,8 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         doesEmailExist: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [

--- a/lib/build/recipe/emailpassword/utils.js
+++ b/lib/build/recipe/emailpassword/utils.js
@@ -13,6 +13,163 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __spreadArray =
+    (this && this.__spreadArray) ||
+    function (to, from, pack) {
+        if (pack || arguments.length === 2)
+            for (var i = 0, l = from.length, ar; i < l; i++) {
+                if (ar || !(i in from)) {
+                    if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+                    ar[i] = from[i];
+                }
+            }
+        return to.concat(ar || Array.prototype.slice.call(from));
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getFormattedFormField =
     exports.mergeFormFields =
@@ -23,7 +180,6 @@ exports.getFormattedFormField =
     exports.normaliseSignInAndUpFeature =
     exports.normaliseEmailPasswordConfig =
         void 0;
-var tslib_1 = require("tslib");
 var constants_1 = require("./constants");
 var validators_1 = require("./validators");
 var utils_1 = require("../authRecipeWithEmailVerification/utils");
@@ -40,7 +196,7 @@ function normaliseEmailPasswordConfig(config) {
         signUpEmailField,
         config.resetPasswordUsingTokenFeature
     );
-    var override = tslib_1.__assign(
+    var override = __assign(
         {
             functions: function (originalImplementation) {
                 return originalImplementation;
@@ -49,7 +205,7 @@ function normaliseEmailPasswordConfig(config) {
         },
         config.override
     );
-    return tslib_1.__assign(tslib_1.__assign({}, (0, utils_1.normaliseAuthRecipeWithEmailVerificationConfig)(config)), {
+    return __assign(__assign({}, (0, utils_1.normaliseAuthRecipeWithEmailVerificationConfig)(config)), {
         signInAndUpFeature: signInAndUpFeature,
         resetPasswordUsingTokenFeature: resetPasswordUsingTokenFeature,
         override: override,
@@ -71,13 +227,13 @@ function normaliseSignInAndUpFeature(config) {
      */
     var defaultSignInFields = signUpForm.formFields.reduce(function (signInFieldsAccumulator, field) {
         if (field.id === "email") {
-            return tslib_1.__spreadArray(tslib_1.__spreadArray([], signInFieldsAccumulator, true), [field], false);
+            return __spreadArray(__spreadArray([], signInFieldsAccumulator, true), [field], false);
         }
         if (field.id === "password") {
-            return tslib_1.__spreadArray(
-                tslib_1.__spreadArray([], signInFieldsAccumulator, true),
+            return __spreadArray(
+                __spreadArray([], signInFieldsAccumulator, true),
                 [
-                    tslib_1.__assign(tslib_1.__assign({}, field), {
+                    __assign(__assign({}, field), {
                         autoComplete: "current-password",
                         validate: validators_1.defaultLoginPasswordValidator,
                     }),
@@ -130,7 +286,7 @@ function normaliseSignInFormFeatureConfig(defaultFormFields, config) {
             })
             // Sign In fields are never optional.
             .map(function (field) {
-                return tslib_1.__assign(tslib_1.__assign({}, field), { optional: false });
+                return __assign(__assign({}, field), { optional: false });
             });
     }
     var formFields = mergeFormFields(defaultFormFields, userFormFields);
@@ -202,7 +358,7 @@ function normaliseResetPasswordUsingTokenFeature(signUpPasswordFieldValidate, si
     var enterEmailForm = {
         style: enterEmailFormStyle,
         formFields: [
-            tslib_1.__assign(tslib_1.__assign({}, getDefaultEmailFormField()), {
+            __assign(__assign({}, getDefaultEmailFormField()), {
                 validate: signUpEmailField.validate,
                 placeholder: "",
                 autofocus: true,
@@ -242,10 +398,9 @@ function mergeFormFields(defaultFormFields, userFormFields) {
                     optional = false;
                 }
                 // Merge.
-                mergedFormFields[j] = tslib_1.__assign(
-                    tslib_1.__assign(tslib_1.__assign({}, mergedFormFields[j]), userField),
-                    { optional: optional }
-                );
+                mergedFormFields[j] = __assign(__assign(__assign({}, mergedFormFields[j]), userField), {
+                    optional: optional,
+                });
                 isNewField = false;
                 break;
             }
@@ -253,7 +408,7 @@ function mergeFormFields(defaultFormFields, userFormFields) {
         // If new field, push to mergeFormFields.
         if (isNewField) {
             mergedFormFields.push(
-                tslib_1.__assign(
+                __assign(
                     { optional: false, placeholder: userField.label, validate: validators_1.defaultValidate },
                     userField
                 )
@@ -267,10 +422,10 @@ function mergeFormFields(defaultFormFields, userFormFields) {
 exports.mergeFormFields = mergeFormFields;
 function getFormattedFormField(field) {
     var _this = this;
-    return tslib_1.__assign(tslib_1.__assign({}, field), {
+    return __assign(__assign({}, field), {
         validate: function (value) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             // Absent or not optional empty field

--- a/lib/build/recipe/emailpassword/validators.js
+++ b/lib/build/recipe/emailpassword/validators.js
@@ -13,20 +13,150 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.defaultValidate =
     exports.defaultLoginPasswordValidator =
     exports.defaultPasswordValidator =
     exports.defaultEmailValidator =
         void 0;
-var tslib_1 = require("tslib");
 /*
  * defaultEmailValidator.
  */
 function defaultEmailValidator(value) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
+    return __awaiter(this, void 0, void 0, function () {
         var defaultEmailValidatorRegexp;
-        return tslib_1.__generator(this, function (_a) {
+        return __generator(this, function (_a) {
             if (typeof value !== "string") {
                 return [2 /*return*/, "ERROR_EMAIL_NON_STRING"];
             }
@@ -50,8 +180,8 @@ exports.defaultEmailValidator = defaultEmailValidator;
  * Contains lowercase, uppercase, and numbers.
  */
 function defaultPasswordValidator(value) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
-        return tslib_1.__generator(this, function (_a) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
             if (typeof value !== "string") {
                 return [2 /*return*/, "ERROR_PASSWORD_NON_STRING"];
             }
@@ -80,8 +210,8 @@ exports.defaultPasswordValidator = defaultPasswordValidator;
  * type string
  */
 function defaultLoginPasswordValidator(value) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
-        return tslib_1.__generator(this, function (_a) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
             if (typeof value !== "string") {
                 return [2 /*return*/, "ERROR_PASSWORD_NON_STRING"];
             }
@@ -95,8 +225,8 @@ exports.defaultLoginPasswordValidator = defaultLoginPasswordValidator;
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function defaultValidate(_) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
-        return tslib_1.__generator(this, function (_a) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
             return [2 /*return*/, undefined];
         });
     });

--- a/lib/build/recipe/emailverification/components/features/emailVerification/index.js
+++ b/lib/build/recipe/emailverification/components/features/emailVerification/index.js
@@ -1,7 +1,196 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.EmailVerification = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -20,11 +209,11 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var React = tslib_1.__importStar(require("react"));
+var React = __importStar(require("react"));
 var react_1 = require("react");
 var utils_1 = require("../../../../../utils");
 var emailVerification_1 = require("../../themes/emailVerification");
-var featureWrapper_1 = tslib_1.__importDefault(require("../../../../../components/featureWrapper"));
+var featureWrapper_1 = __importDefault(require("../../../../../components/featureWrapper"));
 var componentOverrideContext_1 = require("../../../../../components/componentOverride/componentOverrideContext");
 var session_1 = require("../../../../session");
 var translations_1 = require("../../themes/translations");
@@ -38,11 +227,11 @@ var EmailVerification = function (props) {
     var userContext = (0, usercontext_1.useUserContext)();
     var modifiedRecipeImplementation = (0, react_1.useMemo)(
         function () {
-            return tslib_1.__assign(tslib_1.__assign({}, props.recipe.recipeImpl), {
+            return __assign(__assign({}, props.recipe.recipeImpl), {
                 sendVerificationEmail: function (input) {
-                    return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+                    return __awaiter(void 0, void 0, void 0, function () {
                         var response;
-                        return tslib_1.__generator(this, function (_a) {
+                        return __generator(this, function (_a) {
                             switch (_a.label) {
                                 case 0:
                                     return [4 /*yield*/, props.recipe.recipeImpl.sendVerificationEmail(input)];
@@ -60,10 +249,10 @@ var EmailVerification = function (props) {
     );
     var fetchIsEmailVerified = (0, react_1.useCallback)(
         function () {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+            return __awaiter(void 0, void 0, void 0, function () {
                 var token;
                 var _a;
-                return tslib_1.__generator(this, function (_b) {
+                return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
                             token =
@@ -89,8 +278,8 @@ var EmailVerification = function (props) {
     );
     var checkIsEmailVerified = (0, react_1.useCallback)(
         function (isVerified) {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(void 0, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     if (isVerified) {
                         return [2 /*return*/, props.recipe.config.postVerificationRedirect(props.history)];
                     }
@@ -104,8 +293,8 @@ var EmailVerification = function (props) {
     (0, utils_1.useOnMountAPICall)(fetchIsEmailVerified, checkIsEmailVerified);
     var signOut = (0, react_1.useCallback)(
         function () {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(void 0, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [4 /*yield*/, props.recipe.config.signOut()];
@@ -165,12 +354,12 @@ var EmailVerification = function (props) {
     };
     return (0, jsx_runtime_1.jsx)(
         componentOverrideContext_1.ComponentOverrideContext.Provider,
-        tslib_1.__assign(
+        __assign(
             { value: componentOverrides },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     featureWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             useShadowDom: props.recipe.config.useShadowDom,
                             defaultStore: translations_1.defaultTranslationsEmailVerification,
@@ -181,7 +370,7 @@ var EmailVerification = function (props) {
                                     props.children === undefined &&
                                         (0, jsx_runtime_1.jsx)(
                                             emailVerification_1.EmailVerificationTheme,
-                                            tslib_1.__assign({}, childProps)
+                                            __assign({}, childProps)
                                         ),
                                     props.children &&
                                         React.Children.map(props.children, function (child) {

--- a/lib/build/recipe/emailverification/components/themes/emailVerification/index.js
+++ b/lib/build/recipe/emailverification/components/themes/emailVerification/index.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.EmailVerificationTheme = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -22,7 +40,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  */
 var styleContext_1 = require("../../../../../styles/styleContext");
 var styles_1 = require("../../../../../styles/styles");
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../../../../usercontext/userContextWrapper"));
+var userContextWrapper_1 = __importDefault(require("../../../../../usercontext/userContextWrapper"));
 var styles_2 = require("../../../../emailpassword/components/themes/styles/styles");
 var themeBase_1 = require("../../../../emailpassword/components/themes/themeBase");
 var sendVerifyEmail_1 = require("./sendVerifyEmail");
@@ -38,7 +56,7 @@ function EmailVerificationTheme(props) {
     if (props.verifyEmailLinkClickedScreen === undefined) {
         return (0, jsx_runtime_1.jsx)(
             styleContext_1.StyleProvider,
-            tslib_1.__assign(
+            __assign(
                 {
                     rawPalette: props.config.palette,
                     defaultPalette: styles_1.defaultPalette,
@@ -49,7 +67,7 @@ function EmailVerificationTheme(props) {
                 {
                     children: (0, jsx_runtime_1.jsx)(
                         sendVerifyEmail_1.SendVerifyEmail,
-                        tslib_1.__assign({}, props.sendVerifyEmailScreen)
+                        __assign({}, props.sendVerifyEmailScreen)
                     ),
                 }
             )
@@ -58,7 +76,7 @@ function EmailVerificationTheme(props) {
     // Otherwise, return VerifyEmailLinkClicked.
     return (0, jsx_runtime_1.jsx)(
         styleContext_1.StyleProvider,
-        tslib_1.__assign(
+        __assign(
             {
                 rawPalette: props.config.palette,
                 defaultPalette: styles_1.defaultPalette,
@@ -69,7 +87,7 @@ function EmailVerificationTheme(props) {
             {
                 children: (0, jsx_runtime_1.jsx)(
                     verifyEmailLinkClicked_1.VerifyEmailLinkClicked,
-                    tslib_1.__assign({}, props.verifyEmailLinkClickedScreen)
+                    __assign({}, props.verifyEmailLinkClickedScreen)
                 ),
             }
         )
@@ -80,14 +98,14 @@ function EmailVerificationThemeWrapper(props) {
     var hasFont = (0, styles_1.hasFontDefined)(props.config.rootStyle);
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
-        tslib_1.__assign(
+        __assign(
             { userContext: props.userContext },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     themeBase_1.ThemeBase,
-                    tslib_1.__assign(
+                    __assign(
                         { loadDefaultFont: !hasFont },
-                        { children: (0, jsx_runtime_1.jsx)(EmailVerificationTheme, tslib_1.__assign({}, props)) }
+                        { children: (0, jsx_runtime_1.jsx)(EmailVerificationTheme, __assign({}, props)) }
                     )
                 ),
             }

--- a/lib/build/recipe/emailverification/components/themes/emailVerification/sendVerifyEmail.js
+++ b/lib/build/recipe/emailverification/components/themes/emailVerification/sendVerifyEmail.js
@@ -1,7 +1,156 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SendVerifyEmail = exports.EmailVerificationSendVerifyEmail = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,14 +170,14 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
-var arrowRightIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/arrowRightIcon"));
-var emailLargeIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/emailLargeIcon"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
+var arrowRightIcon_1 = __importDefault(require("../../../../../components/assets/arrowRightIcon"));
+var emailLargeIcon_1 = __importDefault(require("../../../../../components/assets/emailLargeIcon"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
-var generalError_1 = tslib_1.__importDefault(require("../../../../emailpassword/components/library/generalError"));
+var generalError_1 = __importDefault(require("../../../../emailpassword/components/library/generalError"));
 var usercontext_1 = require("../../../../../usercontext");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
 var utils_1 = require("../../../../../utils");
 var EmailVerificationSendVerifyEmail = function (props) {
     var styles = (0, react_1.useContext)(styleContext_1.default);
@@ -41,9 +190,9 @@ var EmailVerificationSendVerifyEmail = function (props) {
         errorMessage = _b[0],
         setErrorMessage = _b[1];
     var resendEmail = function () {
-        return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        return __awaiter(void 0, void 0, void 0, function () {
             var response, e_1;
-            return tslib_1.__generator(this, function (_a) {
+            return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
                         _a.trys.push([0, 5, , 6]);
@@ -81,9 +230,9 @@ var EmailVerificationSendVerifyEmail = function (props) {
         });
     };
     var logout = function () {
-        return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        return __awaiter(void 0, void 0, void 0, function () {
             var e_2;
-            return tslib_1.__generator(this, function (_a) {
+            return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
                         _a.trys.push([0, 2, , 3]);
@@ -114,8 +263,8 @@ var EmailVerificationSendVerifyEmail = function (props) {
     );
     var checkSendResponse = (0, react_1.useCallback)(
         function (response) {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(void 0, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             if (!(response.status === "EMAIL_ALREADY_VERIFIED_ERROR")) return [3 /*break*/, 2];
@@ -134,12 +283,12 @@ var EmailVerificationSendVerifyEmail = function (props) {
     (0, utils_1.useOnMountAPICall)(sendVerificationEmail, checkSendResponse);
     return (0, jsx_runtime_1.jsx)(
         "div",
-        tslib_1.__assign(
+        __assign(
             { "data-supertokens": "container", css: styles.container },
             {
                 children: (0, jsx_runtime_1.jsxs)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "row", css: styles.row },
                         {
                             children: [
@@ -150,21 +299,21 @@ var EmailVerificationSendVerifyEmail = function (props) {
                                 status === "EMAIL_RESENT" &&
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             { "data-supertokens": "generalSuccess", css: styles.generalSuccess },
                                             { children: t("EMAIL_VERIFICATION_RESEND_SUCCESS") }
                                         )
                                     ),
                                 (0, jsx_runtime_1.jsx)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         { "data-supertokens": "sendVerifyEmailIcon", css: styles.sendVerifyEmailIcon },
                                         { children: (0, jsx_runtime_1.jsx)(emailLargeIcon_1.default, {}) }
                                     )
                                 ),
                                 (0, jsx_runtime_1.jsx)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         {
                                             "data-supertokens": "headerTitle headerTinyTitle",
                                             css: [styles.headerTitle, styles.headerTinyTitle],
@@ -174,7 +323,7 @@ var EmailVerificationSendVerifyEmail = function (props) {
                                 ),
                                 (0, jsx_runtime_1.jsxs)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         {
                                             "data-supertokens": "primaryText sendVerifyEmailText",
                                             css: [styles.primaryText, styles.sendVerifyEmailText],
@@ -193,7 +342,7 @@ var EmailVerificationSendVerifyEmail = function (props) {
                                 status !== "EMAIL_RESENT" &&
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             {
                                                 "data-supertokens": "link sendVerifyEmailResend",
                                                 css: [styles.link, styles.sendVerifyEmailResend],
@@ -204,7 +353,7 @@ var EmailVerificationSendVerifyEmail = function (props) {
                                     ),
                                 (0, jsx_runtime_1.jsxs)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         {
                                             "data-supertokens": "secondaryText secondaryLinkWithArrow",
                                             css: [styles.secondaryText, styles.secondaryLinkWithArrow],

--- a/lib/build/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.js
+++ b/lib/build/recipe/emailverification/components/themes/emailVerification/verifyEmailLinkClicked.js
@@ -1,7 +1,156 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.VerifyEmailLinkClicked = exports.EmailVerificationVerifyEmailLinkClicked = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,18 +170,18 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var arrowRightIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/arrowRightIcon"));
-var checkedRoundIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/checkedRoundIcon"));
-var errorLargeIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/errorLargeIcon"));
-var spinnerIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/spinnerIcon"));
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var arrowRightIcon_1 = __importDefault(require("../../../../../components/assets/arrowRightIcon"));
+var checkedRoundIcon_1 = __importDefault(require("../../../../../components/assets/checkedRoundIcon"));
+var errorLargeIcon_1 = __importDefault(require("../../../../../components/assets/errorLargeIcon"));
+var spinnerIcon_1 = __importDefault(require("../../../../../components/assets/spinnerIcon"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var library_1 = require("../../../../emailpassword/components/library");
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
 var usercontext_1 = require("../../../../../usercontext");
 var utils_1 = require("../../../../../utils");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
-var useSessionContext_1 = tslib_1.__importDefault(require("../../../../session/useSessionContext"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
+var useSessionContext_1 = __importDefault(require("../../../../session/useSessionContext"));
 var EmailVerificationVerifyEmailLinkClicked = function (props) {
     var styles = (0, react_1.useContext)(styleContext_1.default);
     var t = (0, translationContext_1.useTranslation)();
@@ -49,8 +198,8 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
         setVerifyLoading = _c[1];
     var verifyEmailOnMount = (0, react_1.useCallback)(
         function () {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(void 0, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     // If there is no active session we know that the verification was started elsewhere, since it requires a session
                     // otherwise we assume it's the same session. The main purpose of this is to prevent mail scanners
                     // from accidentally validating an email address
@@ -70,8 +219,8 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
     );
     var handleVerifyResp = (0, react_1.useCallback)(
         function (response) {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(void 0, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     if (response === "INTERACTION_REQUIRED") {
                         setStatus("INTERACTION_REQUIRED");
                     } else if (response.status === "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR") {
@@ -100,17 +249,17 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
     if (status === "LOADING") {
         return (0, jsx_runtime_1.jsx)(
             "div",
-            tslib_1.__assign(
+            __assign(
                 { "data-supertokens": "container", css: styles.container },
                 {
                     children: (0, jsx_runtime_1.jsx)(
                         "div",
-                        tslib_1.__assign(
+                        __assign(
                             { "data-supertokens": "row", css: styles.row },
                             {
                                 children: (0, jsx_runtime_1.jsx)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         { "data-supertokens": "spinner", css: styles.spinner },
                                         {
                                             children: (0, jsx_runtime_1.jsx)(spinnerIcon_1.default, {
@@ -129,25 +278,25 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
     if (status === "INTERACTION_REQUIRED") {
         return (0, jsx_runtime_1.jsx)(
             "div",
-            tslib_1.__assign(
+            __assign(
                 { "data-supertokens": "container", css: styles.container },
                 {
                     children: (0, jsx_runtime_1.jsxs)(
                         "div",
-                        tslib_1.__assign(
+                        __assign(
                             { "data-supertokens": "row noFormRow", css: [styles.row, styles.noFormRow] },
                             {
                                 children: [
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             { "data-supertokens": "headerTitle", css: styles.headerTitle },
                                             { children: t("EMAIL_VERIFICATION_LINK_CLICKED_HEADER") }
                                         )
                                     ),
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             {
                                                 "data-supertokens": "headerSubtitle secondaryText",
                                                 css: [styles.headerSubtitle, styles.secondaryText],
@@ -158,9 +307,9 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
                                     (0, jsx_runtime_1.jsx)(library_1.Button, {
                                         isLoading: verifyLoading,
                                         onClick: function () {
-                                            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+                                            return __awaiter(void 0, void 0, void 0, function () {
                                                 var resp, err_1;
-                                                return tslib_1.__generator(this, function (_a) {
+                                                return __generator(this, function (_a) {
                                                     switch (_a.label) {
                                                         case 0:
                                                             setVerifyLoading(true);
@@ -203,12 +352,12 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
     if (status === "SUCCESSFUL") {
         return (0, jsx_runtime_1.jsx)(
             "div",
-            tslib_1.__assign(
+            __assign(
                 { "data-supertokens": "container", css: styles.container },
                 {
                     children: (0, jsx_runtime_1.jsxs)(
                         "div",
-                        tslib_1.__assign(
+                        __assign(
                             { "data-supertokens": "row noFormRow", css: [styles.row, styles.noFormRow] },
                             {
                                 children: [
@@ -217,7 +366,7 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
                                     }),
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             {
                                                 "data-supertokens": "headerTitle headerTinyTitle",
                                                 css: [styles.headerTitle, styles.headerTinyTitle],
@@ -227,7 +376,7 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
                                     ),
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             {
                                                 "data-supertokens": "emailVerificationButtonWrapper",
                                                 css: styles.emailVerificationButtonWrapper,
@@ -253,18 +402,18 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
     if (status === "INVALID") {
         return (0, jsx_runtime_1.jsx)(
             "div",
-            tslib_1.__assign(
+            __assign(
                 { "data-supertokens": "container", css: styles.container },
                 {
                     children: (0, jsx_runtime_1.jsxs)(
                         "div",
-                        tslib_1.__assign(
+                        __assign(
                             { "data-supertokens": "row noFormRow", css: [styles.row, styles.noFormRow] },
                             {
                                 children: [
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             {
                                                 "data-supertokens": "headerTitle headerTinyTitle",
                                                 css: [styles.headerTitle, styles.headerTinyTitle],
@@ -274,7 +423,7 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
                                     ),
                                     (0, jsx_runtime_1.jsxs)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             {
                                                 onClick: onTokenInvalidRedirect,
                                                 "data-supertokens": "secondaryText secondaryLinkWithArrow",
@@ -300,18 +449,18 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
     }
     return (0, jsx_runtime_1.jsx)(
         "div",
-        tslib_1.__assign(
+        __assign(
             { "data-supertokens": "container", css: styles.container },
             {
                 children: (0, jsx_runtime_1.jsxs)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "row noFormRow", css: [styles.row, styles.noFormRow] },
                         {
                             children: [
                                 (0, jsx_runtime_1.jsxs)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         {
                                             "data-supertokens": "headerTitle error",
                                             css: [styles.headerTitle, styles.error],
@@ -328,7 +477,7 @@ var EmailVerificationVerifyEmailLinkClicked = function (props) {
                                 ),
                                 (0, jsx_runtime_1.jsx)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         { "data-supertokens": "primaryText", css: styles.primaryText },
                                         {
                                             children: t(

--- a/lib/build/recipe/emailverification/components/themes/translations.js
+++ b/lib/build/recipe/emailverification/components/themes/translations.js
@@ -1,10 +1,23 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.defaultTranslationsEmailVerification = void 0;
-var tslib_1 = require("tslib");
 var translations_1 = require("../../../../translation/translations");
 exports.defaultTranslationsEmailVerification = {
-    en: tslib_1.__assign(tslib_1.__assign({}, translations_1.defaultTranslationsCommon.en), {
+    en: __assign(__assign({}, translations_1.defaultTranslationsCommon.en), {
         EMAIL_VERIFICATION_RESEND_SUCCESS: "Email resent",
         EMAIL_VERIFICATION_SEND_TITLE: "Verify your email address",
         EMAIL_VERIFICATION_SEND_DESC_START: "",

--- a/lib/build/recipe/emailverification/emailVerificationAuth.js
+++ b/lib/build/recipe/emailverification/emailVerificationAuth.js
@@ -1,6 +1,206 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __rest =
+    (this && this.__rest) ||
+    function (s, e) {
+        var t = {};
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0) t[p] = s[p];
+        if (s != null && typeof Object.getOwnPropertySymbols === "function")
+            for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+                if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i])) t[p[i]] = s[p[i]];
+            }
+        return t;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -16,14 +216,14 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var react_1 = tslib_1.__importStar(require("react"));
+var react_1 = __importStar(require("react"));
 var session_1 = require("../session");
 var usercontext_1 = require("../../usercontext");
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../usercontext/userContextWrapper"));
+var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
 var utils_1 = require("../../utils");
 var EmailVerificationAuth = function (_a) {
     var children = _a.children,
-        props = tslib_1.__rest(_a, ["children"]);
+        props = __rest(_a, ["children"]);
     var sessionContext = (0, react_1.useContext)(session_1.SessionContext);
     var _b = (0, react_1.useState)(false),
         isEmailVerified = _b[0],
@@ -38,8 +238,8 @@ var EmailVerificationAuth = function (_a) {
     var userContext = (0, usercontext_1.useUserContext)();
     var checkIsEmailVerified = (0, react_1.useCallback)(
         function () {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(void 0, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             if (!(doesSessionExist && emailVerificationMode === "REQUIRED")) return [3 /*break*/, 2];
@@ -56,8 +256,8 @@ var EmailVerificationAuth = function (_a) {
     );
     var useIsEmailVerified = (0, react_1.useCallback)(
         function (isEmailVerified) {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(void 0, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             if (!(doesSessionExist && emailVerificationMode === "REQUIRED")) return [3 /*break*/, 3];
@@ -92,9 +292,9 @@ var EmailVerificationAuth = function (_a) {
 var EmailVerificationAuthWrapper = function (props) {
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
-        tslib_1.__assign(
+        __assign(
             { userContext: props.userContext },
-            { children: (0, jsx_runtime_1.jsx)(EmailVerificationAuth, tslib_1.__assign({}, props)) }
+            { children: (0, jsx_runtime_1.jsx)(EmailVerificationAuth, __assign({}, props)) }
         )
     );
 };

--- a/lib/build/recipe/emailverification/index.js
+++ b/lib/build/recipe/emailverification/index.js
@@ -13,6 +13,156 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.EmailVerificationTheme =
     exports.EmailVerification =
@@ -22,9 +172,8 @@ exports.EmailVerificationTheme =
     exports.isEmailVerified =
     exports.init =
         void 0;
-var tslib_1 = require("tslib");
-var recipe_1 = tslib_1.__importDefault(require("./recipe"));
-var emailVerification_1 = tslib_1.__importDefault(require("./components/themes/emailVerification"));
+var recipe_1 = __importDefault(require("./recipe"));
+var emailVerification_1 = __importDefault(require("./components/themes/emailVerification"));
 exports.EmailVerificationTheme = emailVerification_1.default;
 var utils_1 = require("../../utils");
 var Wrapper = /** @class */ (function () {
@@ -33,12 +182,12 @@ var Wrapper = /** @class */ (function () {
         return recipe_1.default.init(config);
     };
     Wrapper.isEmailVerified = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.isEmailVerified(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -49,12 +198,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.verifyEmail = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.verifyEmail(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -65,12 +214,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.sendVerificationEmail = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.sendVerificationEmail(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -82,7 +231,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getEmailVerificationTokenFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getEmailVerificationTokenFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),

--- a/lib/build/recipe/emailverification/recipe.js
+++ b/lib/build/recipe/emailverification/recipe.js
@@ -1,6 +1,180 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,20 +193,20 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var recipeModule_1 = tslib_1.__importDefault(require("../recipeModule"));
-var emailVerification_1 = tslib_1.__importDefault(require("./components/features/emailVerification"));
-var normalisedURLPath_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
+var recipeModule_1 = __importDefault(require("../recipeModule"));
+var emailVerification_1 = __importDefault(require("./components/features/emailVerification"));
+var normalisedURLPath_1 = __importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
 var constants_1 = require("./constants");
 var utils_1 = require("../../utils");
 var utils_2 = require("./utils");
 var constants_2 = require("../../constants");
-var recipeImplementation_1 = tslib_1.__importDefault(require("./recipeImplementation"));
+var recipeImplementation_1 = __importDefault(require("./recipeImplementation"));
 var session_1 = require("../session");
-var supertokens_js_override_1 = tslib_1.__importDefault(require("supertokens-js-override"));
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../usercontext/userContextWrapper"));
+var supertokens_js_override_1 = __importDefault(require("supertokens-js-override"));
+var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
 var usercontext_1 = require("../../usercontext");
 var EmailVerification = /** @class */ (function (_super) {
-    tslib_1.__extends(EmailVerification, _super);
+    __extends(EmailVerification, _super);
     function EmailVerification(config) {
         var _this = _super.call(this, (0, utils_2.normaliseEmailVerificationFeature)(config)) || this;
         _this.getFeatures = function () {
@@ -54,21 +228,21 @@ var EmailVerification = /** @class */ (function (_super) {
         _this.getFeatureComponent = function (_, props) {
             return (0, jsx_runtime_1.jsx)(
                 userContextWrapper_1.default,
-                tslib_1.__assign(
+                __assign(
                     { userContext: props.userContext },
                     {
                         children: (0, jsx_runtime_1.jsx)(
                             session_1.SessionAuth,
-                            tslib_1.__assign(
+                            __assign(
                                 { requireAuth: false },
                                 {
                                     children: (0, jsx_runtime_1.jsx)(usercontext_1.UserContextContext.Consumer, {
                                         children: function (value) {
                                             return (0, jsx_runtime_1.jsx)(
                                                 emailVerification_1.default,
-                                                tslib_1.__assign(
+                                                __assign(
                                                     { recipe: _this },
-                                                    tslib_1.__assign(tslib_1.__assign({}, props), {
+                                                    __assign(__assign({}, props), {
                                                         // We do this to make sure it does not add another provider
                                                         userContext: value,
                                                     })
@@ -84,9 +258,9 @@ var EmailVerification = /** @class */ (function (_super) {
             );
         };
         _this.getDefaultRedirectionURL = function (context) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
+            return __awaiter(_this, void 0, void 0, function () {
                 var verifyEmailPath;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     if (context.action === "VERIFY_EMAIL") {
                         verifyEmailPath = new normalisedURLPath_1.default(constants_1.DEFAULT_VERIFY_EMAIL_PATH);
                         return [
@@ -124,10 +298,7 @@ var EmailVerification = /** @class */ (function (_super) {
     EmailVerification.init = function (config) {
         return function (appInfo) {
             EmailVerification.instance = new EmailVerification(
-                tslib_1.__assign(tslib_1.__assign({}, config), {
-                    appInfo: appInfo,
-                    recipeId: EmailVerification.RECIPE_ID,
-                })
+                __assign(__assign({}, config), { appInfo: appInfo, recipeId: EmailVerification.RECIPE_ID })
             );
             return EmailVerification.instance;
         };
@@ -144,8 +315,8 @@ var EmailVerification = /** @class */ (function (_super) {
         return EmailVerification.instance;
     };
     EmailVerification.prototype.isEmailVerified = function (userContext) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
                         return [

--- a/lib/build/recipe/emailverification/recipeImplementation.js
+++ b/lib/build/recipe/emailverification/recipeImplementation.js
@@ -1,14 +1,144 @@
 "use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var recipeImplementation_1 = require("supertokens-web-js/recipe/emailverification/recipeImplementation");
 function getRecipeImplementation(recipeInput) {
     var webJsImplementation = (0, recipeImplementation_1.getRecipeImplementation)(recipeInput);
     return {
         verifyEmail: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
+            return __awaiter(this, void 0, void 0, function () {
                 var response;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [
@@ -31,9 +161,9 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         sendVerificationEmail: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
+            return __awaiter(this, void 0, void 0, function () {
                 var response;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [
@@ -56,9 +186,9 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         isEmailVerified: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
+            return __awaiter(this, void 0, void 0, function () {
                 var response;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [

--- a/lib/build/recipe/emailverification/utils.js
+++ b/lib/build/recipe/emailverification/utils.js
@@ -13,9 +13,22 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.normaliseEmailVerificationFeature = void 0;
-var tslib_1 = require("tslib");
 var utils_1 = require("../recipeModule/utils");
 function normaliseEmailVerificationFeature(config) {
     var disableDefaultUI = config.disableDefaultUI === true;
@@ -34,7 +47,7 @@ function normaliseEmailVerificationFeature(config) {
     var verifyEmailLinkClickedScreen = {
         style: verifyEmailLinkClickedScreenStyle,
     };
-    var override = tslib_1.__assign(
+    var override = __assign(
         {
             functions: function (originalImplementation) {
                 return originalImplementation;
@@ -43,7 +56,7 @@ function normaliseEmailVerificationFeature(config) {
         },
         config.override
     );
-    return tslib_1.__assign(tslib_1.__assign({}, (0, utils_1.normaliseRecipeModuleConfig)(config)), {
+    return __assign(__assign({}, (0, utils_1.normaliseRecipeModuleConfig)(config)), {
         disableDefaultUI: disableDefaultUI,
         mode: mode,
         sendVerifyEmailScreen: sendVerifyEmailScreen,

--- a/lib/build/recipe/passwordless/components/features/linkClickedScreen/index.js
+++ b/lib/build/recipe/passwordless/components/features/linkClickedScreen/index.js
@@ -1,6 +1,155 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,7 +170,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  */
 var react_1 = require("react");
 var utils_1 = require("../../../../../utils");
-var featureWrapper_1 = tslib_1.__importDefault(require("../../../../../components/featureWrapper"));
+var featureWrapper_1 = __importDefault(require("../../../../../components/featureWrapper"));
 var styleContext_1 = require("../../../../../styles/styleContext");
 var styles_1 = require("../../../../../styles/styles");
 var styles_2 = require("../../themes/styles");
@@ -30,7 +179,7 @@ var componentOverrideContext_1 = require("../../../../../components/componentOve
 var translations_1 = require("../../themes/translations");
 var usercontext_1 = require("../../../../../usercontext");
 var utils_2 = require("../../../utils");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
 var LinkClickedScreen = function (props) {
     var userContext = (0, usercontext_1.useUserContext)();
     var _a = (0, react_1.useState)(false),
@@ -38,9 +187,9 @@ var LinkClickedScreen = function (props) {
         setRequireUserInteraction = _a[1];
     var consumeCodeAtMount = (0, react_1.useCallback)(
         function () {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+            return __awaiter(void 0, void 0, void 0, function () {
                 var preAuthSessionId, linkCode, loginAttemptInfo;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             preAuthSessionId = (0, utils_1.getQueryParams)("preAuthSessionId");
@@ -86,9 +235,9 @@ var LinkClickedScreen = function (props) {
     );
     var handleConsumeResp = (0, react_1.useCallback)(
         function (response) {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+            return __awaiter(void 0, void 0, void 0, function () {
                 var loginAttemptInfo;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             if (response === "REQUIRES_INTERACTION") {
@@ -170,9 +319,9 @@ var LinkClickedScreen = function (props) {
         config: props.recipe.config,
         requireUserInteraction: requireUserInteraction,
         consumeCode: function () {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+            return __awaiter(void 0, void 0, void 0, function () {
                 var preAuthSessionId, linkCode, consumeResp, err_1;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             preAuthSessionId = (0, utils_1.getQueryParams)("preAuthSessionId");
@@ -211,12 +360,12 @@ var LinkClickedScreen = function (props) {
     };
     return (0, jsx_runtime_1.jsx)(
         componentOverrideContext_1.ComponentOverrideContext.Provider,
-        tslib_1.__assign(
+        __assign(
             { value: componentOverrides },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     featureWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             useShadowDom: props.recipe.config.useShadowDom,
                             defaultStore: translations_1.defaultTranslationsPasswordless,
@@ -224,7 +373,7 @@ var LinkClickedScreen = function (props) {
                         {
                             children: (0, jsx_runtime_1.jsx)(
                                 styleContext_1.StyleProvider,
-                                tslib_1.__assign(
+                                __assign(
                                     {
                                         rawPalette: props.recipe.config.palette,
                                         defaultPalette: styles_1.defaultPalette,
@@ -238,7 +387,7 @@ var LinkClickedScreen = function (props) {
                                                 props.children === undefined &&
                                                     (0, jsx_runtime_1.jsx)(
                                                         linkClickedScreen_1.LinkClickedScreen,
-                                                        tslib_1.__assign({}, childProps)
+                                                        __assign({}, childProps)
                                                     ),
                                                 props.children,
                                             ],

--- a/lib/build/recipe/passwordless/components/features/signInAndUp/index.js
+++ b/lib/build/recipe/passwordless/components/features/signInAndUp/index.js
@@ -1,11 +1,200 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignInUpFeature =
     exports.useChildProps =
     exports.useFeatureReducer =
     exports.useSuccessInAnotherTabChecker =
         void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -24,14 +213,14 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var React = tslib_1.__importStar(require("react"));
+var React = __importStar(require("react"));
 var react_1 = require("react");
-var signInUp_1 = tslib_1.__importDefault(require("../../themes/signInUp"));
-var featureWrapper_1 = tslib_1.__importDefault(require("../../../../../components/featureWrapper"));
+var signInUp_1 = __importDefault(require("../../themes/signInUp"));
+var featureWrapper_1 = __importDefault(require("../../../../../components/featureWrapper"));
 var utils_1 = require("../../../../../utils");
 var componentOverrideContext_1 = require("../../../../../components/componentOverride/componentOverrideContext");
 var min_1 = require("react-phone-number-input/min");
-var session_1 = tslib_1.__importDefault(require("../../../../session"));
+var session_1 = __importDefault(require("../../../../session"));
 var translations_1 = require("../../themes/translations");
 var react_2 = require("react");
 var react_3 = require("react");
@@ -45,9 +234,9 @@ var useSuccessInAnotherTabChecker = function (state, dispatch) {
             // We only need to start checking this if we have an active login attempt
             if (state.loginAttemptInfo && !state.successInAnotherTab) {
                 var checkSessionIntervalHandle_1 = setInterval(function () {
-                    return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+                    return __awaiter(void 0, void 0, void 0, function () {
                         var hasSession;
-                        return tslib_1.__generator(this, function (_a) {
+                        return __generator(this, function (_a) {
                             switch (_a.label) {
                                 case 0:
                                     if (!(callingConsumeCodeRef.current === false)) return [3 /*break*/, 2];
@@ -91,26 +280,23 @@ var useFeatureReducer = function (recipeImpl, userContext) {
                         if (!oldState.loginAttemptInfo) {
                             return oldState;
                         }
-                        return tslib_1.__assign(tslib_1.__assign({}, oldState), {
+                        return __assign(__assign({}, oldState), {
                             error: undefined,
-                            loginAttemptInfo: tslib_1.__assign(tslib_1.__assign({}, oldState.loginAttemptInfo), {
+                            loginAttemptInfo: __assign(__assign({}, oldState.loginAttemptInfo), {
                                 lastResend: action.timestamp,
                             }),
                         });
                     case "restartFlow":
-                        return tslib_1.__assign(tslib_1.__assign({}, oldState), {
-                            error: action.error,
-                            loginAttemptInfo: undefined,
-                        });
+                        return __assign(__assign({}, oldState), { error: action.error, loginAttemptInfo: undefined });
                     case "setError":
-                        return tslib_1.__assign(tslib_1.__assign({}, oldState), { error: action.error });
+                        return __assign(__assign({}, oldState), { error: action.error });
                     case "startLogin":
-                        return tslib_1.__assign(tslib_1.__assign({}, oldState), {
+                        return __assign(__assign({}, oldState), {
                             loginAttemptInfo: action.loginAttemptInfo,
                             error: undefined,
                         });
                     case "successInAnotherTab":
-                        return tslib_1.__assign(tslib_1.__assign({}, oldState), { successInAnotherTab: true });
+                        return __assign(__assign({}, oldState), { successInAnotherTab: true });
                     default:
                         return oldState;
                 }
@@ -134,7 +320,7 @@ var useFeatureReducer = function (recipeImpl, userContext) {
                         error = messageQueryParam;
                     }
                 }
-                return tslib_1.__assign(tslib_1.__assign({}, initArg), { error: error });
+                return __assign(__assign({}, initArg), { error: error });
             }
         ),
         state = _a[0],
@@ -145,9 +331,9 @@ var useFeatureReducer = function (recipeImpl, userContext) {
                 return;
             }
             function load() {
-                return tslib_1.__awaiter(this, void 0, void 0, function () {
+                return __awaiter(this, void 0, void 0, function () {
                     var error, errorQueryParam, messageQueryParam, loginAttemptInfo;
-                    return tslib_1.__generator(this, function (_a) {
+                    return __generator(this, function (_a) {
                         switch (_a.label) {
                             case 0:
                                 error = undefined;
@@ -235,12 +421,12 @@ var SignInUpFeature = function (props) {
     var childProps = useChildProps(props.recipe, dispatch, state, callingConsumeCodeRef, props.history);
     return (0, jsx_runtime_1.jsx)(
         componentOverrideContext_1.ComponentOverrideContext.Provider,
-        tslib_1.__assign(
+        __assign(
             { value: componentOverrides },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     featureWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             useShadowDom: props.recipe.config.useShadowDom,
                             defaultStore: translations_1.defaultTranslationsPasswordless,
@@ -251,10 +437,7 @@ var SignInUpFeature = function (props) {
                                     props.children === undefined &&
                                         (0, jsx_runtime_1.jsx)(
                                             signInUp_1.default,
-                                            tslib_1.__assign({}, childProps, {
-                                                featureState: state,
-                                                dispatch: dispatch,
-                                            })
+                                            __assign({}, childProps, { featureState: state, dispatch: dispatch })
                                         ),
                                     props.children &&
                                         React.Children.map(props.children, function (child) {
@@ -276,11 +459,11 @@ exports.SignInUpFeature = SignInUpFeature;
 exports.default = exports.SignInUpFeature;
 function getModifiedRecipeImplementation(originalImpl, dispatch, callingConsumeCodeRef) {
     var _this = this;
-    return tslib_1.__assign(tslib_1.__assign({}, originalImpl), {
+    return __assign(__assign({}, originalImpl), {
         createCode: function (input) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
+            return __awaiter(_this, void 0, void 0, function () {
                 var contactInfo, res, contactMethod, loginAttemptInfo;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             if ("email" in input) {
@@ -321,9 +504,9 @@ function getModifiedRecipeImplementation(originalImpl, dispatch, callingConsumeC
             });
         },
         resendCode: function (input) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
+            return __awaiter(_this, void 0, void 0, function () {
                 var res, loginAttemptInfo, timestamp;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [4 /*yield*/, originalImpl.resendCode(input)];
@@ -347,9 +530,7 @@ function getModifiedRecipeImplementation(originalImpl, dispatch, callingConsumeC
                                 (0, utils_2.setLoginAttemptInfo)({
                                     recipeImplementation: originalImpl,
                                     userContext: input.userContext,
-                                    attemptInfo: tslib_1.__assign(tslib_1.__assign({}, loginAttemptInfo), {
-                                        lastResend: timestamp,
-                                    }),
+                                    attemptInfo: __assign(__assign({}, loginAttemptInfo), { lastResend: timestamp }),
                                 }),
                             ];
                         case 3:
@@ -377,9 +558,9 @@ function getModifiedRecipeImplementation(originalImpl, dispatch, callingConsumeC
             });
         },
         consumeCode: function (input) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
+            return __awaiter(_this, void 0, void 0, function () {
                 var res;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             // We need to call consume code while callingConsume, so we don't detect
@@ -418,8 +599,8 @@ function getModifiedRecipeImplementation(originalImpl, dispatch, callingConsumeC
             });
         },
         clearLoginAttemptInfo: function (input) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [

--- a/lib/build/recipe/passwordless/components/themes/linkClickedScreen/index.js
+++ b/lib/build/recipe/passwordless/components/themes/linkClickedScreen/index.js
@@ -1,7 +1,65 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.LinkClickedScreen = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -20,9 +78,9 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var react_1 = tslib_1.__importStar(require("react"));
-var spinnerIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/spinnerIcon"));
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var react_1 = __importStar(require("react"));
+var spinnerIcon_1 = __importDefault(require("../../../../../components/assets/spinnerIcon"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
 var library_1 = require("../../../../emailpassword/components/library");
@@ -34,12 +92,12 @@ var PasswordlessLinkClickedScreen = function (props) {
         setLoading = _a[1];
     return (0, jsx_runtime_1.jsx)(
         "div",
-        tslib_1.__assign(
+        __assign(
             { "data-supertokens": "container", css: styles.container },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "row", css: styles.row },
                         {
                             children:
@@ -48,14 +106,14 @@ var PasswordlessLinkClickedScreen = function (props) {
                                           children: [
                                               (0, jsx_runtime_1.jsx)(
                                                   "div",
-                                                  tslib_1.__assign(
+                                                  __assign(
                                                       { "data-supertokens": "headerTitle", css: styles.headerTitle },
                                                       { children: t("PWLESS_LINK_CLICKED_CONTINUE_HEADER") }
                                                   )
                                               ),
                                               (0, jsx_runtime_1.jsx)(
                                                   "div",
-                                                  tslib_1.__assign(
+                                                  __assign(
                                                       {
                                                           "data-supertokens": "headerSubtitle secondaryText",
                                                           css: [styles.headerSubtitle, styles.secondaryText],
@@ -65,7 +123,7 @@ var PasswordlessLinkClickedScreen = function (props) {
                                               ),
                                               (0, jsx_runtime_1.jsx)(
                                                   "div",
-                                                  tslib_1.__assign(
+                                                  __assign(
                                                       {
                                                           "data-supertokens": "continueButtonWrapper",
                                                           css: styles.continueButtonWrapper,
@@ -87,7 +145,7 @@ var PasswordlessLinkClickedScreen = function (props) {
                                       })
                                     : (0, jsx_runtime_1.jsx)(
                                           "div",
-                                          tslib_1.__assign(
+                                          __assign(
                                               { "data-supertokens": "spinner", css: styles.spinner },
                                               {
                                                   children: (0, jsx_runtime_1.jsx)(spinnerIcon_1.default, {

--- a/lib/build/recipe/passwordless/components/themes/signInUp/closeTabScreen.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/closeTabScreen.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.CloseTabScreen = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,21 +39,21 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
-var checkedRoundIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/checkedRoundIcon"));
+var checkedRoundIcon_1 = __importDefault(require("../../../../../components/assets/checkedRoundIcon"));
 var translationContext_1 = require("../../../../../translation/translationContext");
 var PasswordlessCloseTabScreen = function () {
     var styles = (0, react_1.useContext)(styleContext_1.default);
     var t = (0, translationContext_1.useTranslation)();
     return (0, jsx_runtime_1.jsx)(
         "div",
-        tslib_1.__assign(
+        __assign(
             { "data-supertokens": "container", css: styles.container },
             {
                 children: (0, jsx_runtime_1.jsxs)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "row noFormRow", css: [styles.row, styles.noFormRow] },
                         {
                             children: [
@@ -44,7 +62,7 @@ var PasswordlessCloseTabScreen = function () {
                                 }),
                                 (0, jsx_runtime_1.jsx)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         { "data-supertokens": "headerTitle", css: styles.headerTitle },
                                         { children: t("PWLESS_CLOSE_TAB_TITLE") }
                                     )
@@ -52,7 +70,7 @@ var PasswordlessCloseTabScreen = function () {
                                 (0, jsx_runtime_1.jsx)("div", { "data-supertokens": "divider", css: styles.divider }),
                                 (0, jsx_runtime_1.jsxs)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         {
                                             "data-supertokens": "headerSubtitle secondaryText",
                                             css: [styles.headerSubtitle, styles.secondaryText],

--- a/lib/build/recipe/passwordless/components/themes/signInUp/emailForm.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/emailForm.js
@@ -1,13 +1,148 @@
 "use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.EmailForm = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
-var formBase_1 = tslib_1.__importDefault(require("../../../../emailpassword/components/library/formBase"));
+var formBase_1 = __importDefault(require("../../../../emailpassword/components/library/formBase"));
 var validators_1 = require("../../../../emailpassword/validators");
 var signInUpFooter_1 = require("./signInUpFooter");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
 var usercontext_1 = require("../../../../../usercontext");
 exports.EmailForm = (0, withOverride_1.withOverride)("PasswordlessEmailForm", function PasswordlessEmailForm(props) {
     var _this = this;
@@ -29,10 +164,10 @@ exports.EmailForm = (0, withOverride_1.withOverride)("PasswordlessEmailForm", fu
         buttonLabel: "PWLESS_SIGN_IN_UP_CONTINUE_BUTTON",
         onSuccess: props.onSuccess,
         callAPI: function (formFields) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
+            return __awaiter(_this, void 0, void 0, function () {
                 var email, validationRes, response;
                 var _a;
-                return tslib_1.__generator(this, function (_b) {
+                return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
                             email =

--- a/lib/build/recipe/passwordless/components/themes/signInUp/emailOrPhoneForm.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/emailOrPhoneForm.js
@@ -1,14 +1,149 @@
 "use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.EmailOrPhoneForm = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
-var formBase_1 = tslib_1.__importDefault(require("../../../../emailpassword/components/library/formBase"));
+var formBase_1 = __importDefault(require("../../../../emailpassword/components/library/formBase"));
 var phoneNumberInput_1 = require("./phoneNumberInput");
 var validators_1 = require("../../../../emailpassword/validators");
 var react_1 = require("react");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
 var usercontext_1 = require("../../../../../usercontext");
 var signInUpFooter_1 = require("./signInUpFooter");
 exports.EmailOrPhoneForm = (0, withOverride_1.withOverride)(
@@ -40,10 +175,10 @@ exports.EmailOrPhoneForm = (0, withOverride_1.withOverride)(
             buttonLabel: "PWLESS_SIGN_IN_UP_CONTINUE_BUTTON",
             onSuccess: props.onSuccess,
             callAPI: function (formFields, setValue) {
-                return tslib_1.__awaiter(_this, void 0, void 0, function () {
+                return __awaiter(_this, void 0, void 0, function () {
                     var emailOrPhone, emailValidationRes, response, phoneValidationRes, response, intPhoneNumber;
                     var _a;
-                    return tslib_1.__generator(this, function (_b) {
+                    return __generator(this, function (_b) {
                         switch (_b.label) {
                             case 0:
                                 emailOrPhone =

--- a/lib/build/recipe/passwordless/components/themes/signInUp/index.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/index.js
@@ -1,7 +1,76 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __rest =
+    (this && this.__rest) ||
+    function (s, e) {
+        var t = {};
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0) t[p] = s[p];
+        if (s != null && typeof Object.getOwnPropertySymbols === "function")
+            for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+                if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i])) t[p[i]] = s[p[i]];
+            }
+        return t;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getActiveScreen = exports.SignInUpScreens = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -20,12 +89,12 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var react_1 = tslib_1.__importStar(require("react"));
+var react_1 = __importStar(require("react"));
 var SuperTokensBranding_1 = require("../../../../../components/SuperTokensBranding");
-var styleContext_1 = tslib_1.__importStar(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importStar(require("../../../../../styles/styleContext"));
 var styles_1 = require("../../../../../styles/styles");
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../../../../usercontext/userContextWrapper"));
-var generalError_1 = tslib_1.__importDefault(require("../../../../emailpassword/components/library/generalError"));
+var userContextWrapper_1 = __importDefault(require("../../../../../usercontext/userContextWrapper"));
+var generalError_1 = __importDefault(require("../../../../emailpassword/components/library/generalError"));
 var styles_2 = require("../styles");
 var themeBase_1 = require("../themeBase");
 var closeTabScreen_1 = require("./closeTabScreen");
@@ -51,7 +120,7 @@ var SignInUpScreens;
 var SignInUpTheme = function (_a) {
     var activeScreen = _a.activeScreen,
         featureState = _a.featureState,
-        props = tslib_1.__rest(_a, ["activeScreen", "featureState"]);
+        props = __rest(_a, ["activeScreen", "featureState"]);
     var styles = (0, react_1.useContext)(styleContext_1.default);
     var commonProps = {
         recipeImplementation: props.recipeImplementation,
@@ -65,21 +134,21 @@ var SignInUpTheme = function (_a) {
         error: featureState.error,
     };
     return activeScreen === SignInUpScreens.CloseTab
-        ? (0, jsx_runtime_1.jsx)(closeTabScreen_1.CloseTabScreen, tslib_1.__assign({}, commonProps))
+        ? (0, jsx_runtime_1.jsx)(closeTabScreen_1.CloseTabScreen, __assign({}, commonProps))
         : activeScreen === SignInUpScreens.LinkSent
         ? (0, jsx_runtime_1.jsx)(
               linkSent_1.LinkSent,
-              tslib_1.__assign({}, commonProps, { loginAttemptInfo: featureState.loginAttemptInfo })
+              __assign({}, commonProps, { loginAttemptInfo: featureState.loginAttemptInfo })
           )
         : (0, jsx_runtime_1.jsxs)(
               "div",
-              tslib_1.__assign(
+              __assign(
                   { "data-supertokens": "container", css: styles.container },
                   {
                       children: [
                           (0, jsx_runtime_1.jsx)(
                               "div",
-                              tslib_1.__assign(
+                              __assign(
                                   { "data-supertokens": "row", css: styles.row },
                                   {
                                       children:
@@ -89,7 +158,7 @@ var SignInUpTheme = function (_a) {
                                                   activeScreen === SignInUpScreens.UserInputCodeForm
                                                       ? (0, jsx_runtime_1.jsx)(
                                                             userInputCodeFormHeader_1.UserInputCodeFormHeader,
-                                                            tslib_1.__assign({}, commonProps, {
+                                                            __assign({}, commonProps, {
                                                                 loginAttemptInfo: featureState.loginAttemptInfo,
                                                             })
                                                         )
@@ -101,22 +170,22 @@ var SignInUpTheme = function (_a) {
                                                   activeScreen === SignInUpScreens.EmailForm
                                                       ? (0, jsx_runtime_1.jsx)(
                                                             emailForm_1.EmailForm,
-                                                            tslib_1.__assign({}, commonProps)
+                                                            __assign({}, commonProps)
                                                         )
                                                       : activeScreen === SignInUpScreens.PhoneForm
                                                       ? (0, jsx_runtime_1.jsx)(
                                                             phoneForm_1.PhoneForm,
-                                                            tslib_1.__assign({}, commonProps)
+                                                            __assign({}, commonProps)
                                                         )
                                                       : activeScreen === SignInUpScreens.EmailOrPhoneForm
                                                       ? (0, jsx_runtime_1.jsx)(
                                                             emailOrPhoneForm_1.EmailOrPhoneForm,
-                                                            tslib_1.__assign({}, commonProps)
+                                                            __assign({}, commonProps)
                                                         )
                                                       : activeScreen === SignInUpScreens.UserInputCodeForm
                                                       ? (0, jsx_runtime_1.jsx)(
                                                             userInputCodeForm_1.UserInputCodeForm,
-                                                            tslib_1.__assign({}, commonProps, {
+                                                            __assign({}, commonProps, {
                                                                 loginAttemptInfo: featureState.loginAttemptInfo,
                                                                 onSuccess: props.onSuccess,
                                                             })
@@ -152,17 +221,17 @@ function SignInUpThemeWrapper(props) {
     }
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
-        tslib_1.__assign(
+        __assign(
             { userContext: props.userContext },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     themeBase_1.ThemeBase,
-                    tslib_1.__assign(
+                    __assign(
                         { loadDefaultFont: !hasFont },
                         {
                             children: (0, jsx_runtime_1.jsx)(
                                 styleContext_1.StyleProvider,
-                                tslib_1.__assign(
+                                __assign(
                                     {
                                         rawPalette: props.config.palette,
                                         defaultPalette: styles_1.defaultPalette,
@@ -173,7 +242,7 @@ function SignInUpThemeWrapper(props) {
                                     {
                                         children: (0, jsx_runtime_1.jsx)(
                                             SignInUpTheme,
-                                            tslib_1.__assign({}, props, { activeScreen: activeScreen })
+                                            __assign({}, props, { activeScreen: activeScreen })
                                         ),
                                     }
                                 )

--- a/lib/build/recipe/passwordless/components/themes/signInUp/linkSent.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/linkSent.js
@@ -1,7 +1,156 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.LinkSent = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,16 +170,16 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
-var arrowLeftIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/arrowLeftIcon"));
-var emailLargeIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/emailLargeIcon"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
+var arrowLeftIcon_1 = __importDefault(require("../../../../../components/assets/arrowLeftIcon"));
+var emailLargeIcon_1 = __importDefault(require("../../../../../components/assets/emailLargeIcon"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var resendButton_1 = require("./resendButton");
-var smsLargeIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/smsLargeIcon"));
+var smsLargeIcon_1 = __importDefault(require("../../../../../components/assets/smsLargeIcon"));
 var translationContext_1 = require("../../../../../translation/translationContext");
-var generalError_1 = tslib_1.__importDefault(require("../../../../emailpassword/components/library/generalError"));
+var generalError_1 = __importDefault(require("../../../../emailpassword/components/library/generalError"));
 var usercontext_1 = require("../../../../../usercontext");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
 var PasswordlessLinkSent = function (props) {
     var styles = (0, react_1.useContext)(styleContext_1.default);
     var t = (0, translationContext_1.useTranslation)();
@@ -50,9 +199,9 @@ var PasswordlessLinkSent = function (props) {
     }, []);
     var resendEmail = (0, react_1.useCallback)(
         function () {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+            return __awaiter(void 0, void 0, void 0, function () {
                 var response, generalError, e_1, e_2;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             _a.trys.push([0, 5, , 6]);
@@ -112,12 +261,12 @@ var PasswordlessLinkSent = function (props) {
     var resendActive = status === "LINK_RESENT";
     return (0, jsx_runtime_1.jsx)(
         "div",
-        tslib_1.__assign(
+        __assign(
             { "data-supertokens": "container", css: styles.container },
             {
                 children: (0, jsx_runtime_1.jsxs)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "row", css: styles.row },
                         {
                             children: [
@@ -128,14 +277,14 @@ var PasswordlessLinkSent = function (props) {
                                 resendActive &&
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             { "data-supertokens": "generalSuccess", css: styles.generalSuccess },
                                             { children: t("PWLESS_LINK_SENT_RESEND_SUCCESS") }
                                         )
                                     ),
                                 (0, jsx_runtime_1.jsx)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         { "data-supertokens": "sendCodeIcon", css: styles.sendCodeIcon },
                                         {
                                             children:
@@ -147,7 +296,7 @@ var PasswordlessLinkSent = function (props) {
                                 ),
                                 (0, jsx_runtime_1.jsx)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         {
                                             "data-supertokens": "headerTitle headerTinyTitle",
                                             css: [styles.headerTitle, styles.headerTinyTitle],
@@ -157,7 +306,7 @@ var PasswordlessLinkSent = function (props) {
                                 ),
                                 (0, jsx_runtime_1.jsxs)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         {
                                             "data-supertokens": "primaryText sendCodeText",
                                             css: [styles.primaryText, styles.sendCodeText],
@@ -185,7 +334,7 @@ var PasswordlessLinkSent = function (props) {
                                 }),
                                 (0, jsx_runtime_1.jsxs)(
                                     "div",
-                                    tslib_1.__assign(
+                                    __assign(
                                         {
                                             "data-supertokens": "secondaryText secondaryLinkWithLeftArrow",
                                             css: [styles.secondaryText, styles.secondaryLinkWithLeftArrow],

--- a/lib/build/recipe/passwordless/components/themes/signInUp/phoneForm.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/phoneForm.js
@@ -1,14 +1,149 @@
 "use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.PhoneForm = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
-var formBase_1 = tslib_1.__importDefault(require("../../../../emailpassword/components/library/formBase"));
+var formBase_1 = __importDefault(require("../../../../emailpassword/components/library/formBase"));
 var phoneNumberInput_1 = require("./phoneNumberInput");
 var validators_1 = require("../../../../emailpassword/validators");
 var signInUpFooter_1 = require("./signInUpFooter");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
 var usercontext_1 = require("../../../../../usercontext");
 exports.PhoneForm = (0, withOverride_1.withOverride)("PasswordlessPhoneForm", function PasswordlessPhoneForm(props) {
     var _this = this;
@@ -32,10 +167,10 @@ exports.PhoneForm = (0, withOverride_1.withOverride)("PasswordlessPhoneForm", fu
         buttonLabel: "PWLESS_SIGN_IN_UP_CONTINUE_BUTTON",
         onSuccess: props.onSuccess,
         callAPI: function (formFields) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
+            return __awaiter(_this, void 0, void 0, function () {
                 var phoneNumber, validationRes, response;
                 var _a;
-                return tslib_1.__generator(this, function (_b) {
+                return __generator(this, function (_b) {
                     switch (_b.label) {
                         case 0:
                             phoneNumber =

--- a/lib/build/recipe/passwordless/components/themes/signInUp/phoneNumberInput.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/phoneNumberInput.js
@@ -1,13 +1,82 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __rest =
+    (this && this.__rest) ||
+    function (s, e) {
+        var t = {};
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0) t[p] = s[p];
+        if (s != null && typeof Object.getOwnPropertySymbols === "function")
+            for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+                if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i])) t[p[i]] = s[p[i]];
+            }
+        return t;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.phoneNumberInputWithInjectedProps = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
-var react_select_1 = tslib_1.__importStar(require("react-select"));
+var react_select_1 = __importStar(require("react-select"));
 var react_1 = require("react");
-var min_1 = tslib_1.__importStar(require("react-phone-number-input/min"));
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
-var errorIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/errorIcon"));
+var min_1 = __importStar(require("react-phone-number-input/min"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
+var errorIcon_1 = __importDefault(require("../../../../../components/assets/errorIcon"));
 /*
  * Component.
  */
@@ -53,12 +122,12 @@ function PhoneNumberInput(_a) {
      */
     return (0, jsx_runtime_1.jsx)(
         "div",
-        tslib_1.__assign(
+        __assign(
             { "data-supertokens": "inputContainer", css: styles.inputContainer },
             {
                 children: (0, jsx_runtime_1.jsxs)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "inputWrapper inputError", css: [styles.inputWrapper, errorStyle] },
                         {
                             children: [
@@ -81,7 +150,7 @@ function PhoneNumberInput(_a) {
                                 hasError === true &&
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             {
                                                 "data-supertokens": "inputAdornment inputAdornmentError",
                                                 css: [styles.inputAdornment, styles.inputAdornmentError],
@@ -118,7 +187,7 @@ function CountrySelectWithIcon(_a) {
         return !isDisabled
             ? (0, jsx_runtime_1.jsxs)(
                   "div",
-                  tslib_1.__assign(
+                  __assign(
                       {},
                       innerProps,
                       {
@@ -131,7 +200,7 @@ function CountrySelectWithIcon(_a) {
                               (0, jsx_runtime_1.jsx)(Icon, { country: data.value, label: data.label }),
                               (0, jsx_runtime_1.jsx)(
                                   "span",
-                                  tslib_1.__assign(
+                                  __assign(
                                       {
                                           "data-supertokens": "phoneInputCountryOptionLabel",
                                           css: style.phoneInputCountryOptionLabel,
@@ -142,7 +211,7 @@ function CountrySelectWithIcon(_a) {
                               data.value &&
                                   (0, jsx_runtime_1.jsxs)(
                                       "span",
-                                      tslib_1.__assign(
+                                      __assign(
                                           {
                                               "data-supertokens": "phoneInputCountryOptionCallingCode",
                                               css: style.phoneInputCountryOptionCallingCode,
@@ -158,35 +227,31 @@ function CountrySelectWithIcon(_a) {
     };
     var Control = function (_a) {
         var children = _a.children,
-            rest = tslib_1.__rest(_a, ["children"]);
+            rest = __rest(_a, ["children"]);
         return (0, jsx_runtime_1.jsx)(
             react_select_1.components.SingleValue,
-            tslib_1.__assign(
-                { "data-supertokens": "phoneInputCountrySelect", css: style.phoneInputCountrySelect },
-                rest,
-                {
-                    children: (0, jsx_runtime_1.jsx)(Icon, {
-                        country: selectedOption === null || selectedOption === void 0 ? void 0 : selectedOption.value,
-                        label: children,
-                    }),
-                }
-            )
+            __assign({ "data-supertokens": "phoneInputCountrySelect", css: style.phoneInputCountrySelect }, rest, {
+                children: (0, jsx_runtime_1.jsx)(Icon, {
+                    country: selectedOption === null || selectedOption === void 0 ? void 0 : selectedOption.value,
+                    label: children,
+                }),
+            })
         );
     };
     return (0, jsx_runtime_1.jsx)(react_select_1.default, {
         options: options,
         styles: {
             menu: function (provided) {
-                return tslib_1.__assign(tslib_1.__assign({}, provided), style.phoneInputCountryDropdown);
+                return __assign(__assign({}, provided), style.phoneInputCountryDropdown);
             },
             control: function (provided) {
-                return tslib_1.__assign(tslib_1.__assign({}, provided), style.phoneInputCountryControl);
+                return __assign(__assign({}, provided), style.phoneInputCountryControl);
             },
             valueContainer: function (provided) {
-                return tslib_1.__assign(tslib_1.__assign({}, provided), style.phoneInputCountryValueContainer);
+                return __assign(__assign({}, provided), style.phoneInputCountryValueContainer);
             },
             dropdownIndicator: function (provided) {
-                return tslib_1.__assign(tslib_1.__assign({}, provided), style.phoneInputCountryDropdownIndicator);
+                return __assign(__assign({}, provided), style.phoneInputCountryDropdownIndicator);
             },
         },
         value: selectedOption,
@@ -200,7 +265,7 @@ exports.default = PhoneNumberInput;
 // TODO: type props
 var phoneNumberInputWithInjectedProps = function (injectedProps) {
     return function (props) {
-        return (0, jsx_runtime_1.jsx)(PhoneNumberInput, tslib_1.__assign({}, injectedProps, props));
+        return (0, jsx_runtime_1.jsx)(PhoneNumberInput, __assign({}, injectedProps, props));
     };
 };
 exports.phoneNumberInputWithInjectedProps = phoneNumberInputWithInjectedProps;

--- a/lib/build/recipe/passwordless/components/themes/signInUp/resendButton.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/resendButton.js
@@ -1,7 +1,65 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ResendButton = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -20,8 +78,8 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var react_1 = tslib_1.__importStar(require("react"));
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var react_1 = __importStar(require("react"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
 exports.ResendButton = (0, withOverride_1.withOverride)(
@@ -61,7 +119,7 @@ exports.ResendButton = (0, withOverride_1.withOverride)(
         );
         return (0, jsx_runtime_1.jsx)(
             "button",
-            tslib_1.__assign(
+            __assign(
                 {
                     type: "button",
                     disabled: secsUntilResend !== undefined,

--- a/lib/build/recipe/passwordless/components/themes/signInUp/signInUpFooter.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/signInUpFooter.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignInUpFooter = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,7 +39,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
 exports.SignInUpFooter = (0, withOverride_1.withOverride)(
@@ -36,7 +54,7 @@ exports.SignInUpFooter = (0, withOverride_1.withOverride)(
         }
         return (0, jsx_runtime_1.jsxs)(
             "div",
-            tslib_1.__assign(
+            __assign(
                 {
                     "data-supertokens": "secondaryText privacyPolicyAndTermsAndConditions",
                     css: [styles.secondaryText, styles.privacyPolicyAndTermsAndConditions],
@@ -47,7 +65,7 @@ exports.SignInUpFooter = (0, withOverride_1.withOverride)(
                         termsOfServiceLink !== undefined &&
                             (0, jsx_runtime_1.jsx)(
                                 "a",
-                                tslib_1.__assign(
+                                __assign(
                                     {
                                         "data-supertokens": "link",
                                         css: styles.link,
@@ -64,7 +82,7 @@ exports.SignInUpFooter = (0, withOverride_1.withOverride)(
                         privacyPolicyLink !== undefined &&
                             (0, jsx_runtime_1.jsx)(
                                 "a",
-                                tslib_1.__assign(
+                                __assign(
                                     {
                                         "data-supertokens": "link",
                                         css: styles.link,

--- a/lib/build/recipe/passwordless/components/themes/signInUp/signInUpHeader.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/signInUpHeader.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignInUpHeader = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -18,7 +36,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * under the License.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
 exports.SignInUpHeader = (0, withOverride_1.withOverride)(
@@ -30,7 +48,7 @@ exports.SignInUpHeader = (0, withOverride_1.withOverride)(
             children: [
                 (0, jsx_runtime_1.jsx)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "headerTitle", css: styles.headerTitle },
                         { children: t("PWLESS_SIGN_IN_UP_HEADER_TITLE") }
                     )

--- a/lib/build/recipe/passwordless/components/themes/signInUp/userInputCodeForm.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/userInputCodeForm.js
@@ -1,17 +1,206 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.UserInputCodeForm = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
-var formBase_1 = tslib_1.__importDefault(require("../../../../emailpassword/components/library/formBase"));
+var formBase_1 = __importDefault(require("../../../../emailpassword/components/library/formBase"));
 var validators_1 = require("../../../validators");
 var library_1 = require("../../../../emailpassword/components/library");
-var react_1 = tslib_1.__importStar(require("react"));
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var react_1 = __importStar(require("react"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var resendButton_1 = require("./resendButton");
 var translationContext_1 = require("../../../../../translation/translationContext");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
 var usercontext_1 = require("../../../../../usercontext");
 var userInputCodeFormFooter_1 = require("./userInputCodeFormFooter");
 exports.UserInputCodeForm = (0, withOverride_1.withOverride)(
@@ -35,9 +224,9 @@ exports.UserInputCodeForm = (0, withOverride_1.withOverride)(
             [clearResendNotifTimeout]
         );
         function resend() {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
+            return __awaiter(this, void 0, void 0, function () {
                 var response, generalError, e_1, e_2;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             _a.trys.push([0, 5, , 6]);
@@ -96,7 +285,7 @@ exports.UserInputCodeForm = (0, withOverride_1.withOverride)(
                 clearResendNotifTimeout !== undefined &&
                     (0, jsx_runtime_1.jsx)(
                         "div",
-                        tslib_1.__assign(
+                        __assign(
                             { "data-supertokens": "generalSuccess", css: [styles.generalSuccess] },
                             {
                                 children:
@@ -115,7 +304,7 @@ exports.UserInputCodeForm = (0, withOverride_1.withOverride)(
                             label: "",
                             labelComponent: (0, jsx_runtime_1.jsxs)(
                                 "div",
-                                tslib_1.__assign(
+                                __assign(
                                     { css: styles.codeInputLabelWrapper, "data-supertokens": "codeInputLabelWrapper" },
                                     {
                                         children: [
@@ -143,10 +332,10 @@ exports.UserInputCodeForm = (0, withOverride_1.withOverride)(
                     onSuccess: props.onSuccess,
                     buttonLabel: "PWLESS_SIGN_IN_UP_CONTINUE_BUTTON",
                     callAPI: function (formFields) {
-                        return tslib_1.__awaiter(_this, void 0, void 0, function () {
+                        return __awaiter(_this, void 0, void 0, function () {
                             var userInputCode, response;
                             var _a;
-                            return tslib_1.__generator(this, function (_b) {
+                            return __generator(this, function (_b) {
                                 switch (_b.label) {
                                     case 0:
                                         userInputCode =
@@ -187,7 +376,7 @@ exports.UserInputCodeForm = (0, withOverride_1.withOverride)(
                     showLabels: true,
                     footer: (0, jsx_runtime_1.jsx)(
                         userInputCodeFormFooter_1.UserInputCodeFormFooter,
-                        tslib_1.__assign({}, props, { loginAttemptInfo: props.loginAttemptInfo })
+                        __assign({}, props, { loginAttemptInfo: props.loginAttemptInfo })
                     ),
                 }),
             ],

--- a/lib/build/recipe/passwordless/components/themes/signInUp/userInputCodeFormFooter.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/userInputCodeFormFooter.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.UserInputCodeFormFooter = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -18,9 +36,9 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * under the License.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
-var arrowLeftIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/arrowLeftIcon"));
+var arrowLeftIcon_1 = __importDefault(require("../../../../../components/assets/arrowLeftIcon"));
 var translationContext_1 = require("../../../../../translation/translationContext");
 var usercontext_1 = require("../../../../../usercontext");
 exports.UserInputCodeFormFooter = (0, withOverride_1.withOverride)(
@@ -34,7 +52,7 @@ exports.UserInputCodeFormFooter = (0, withOverride_1.withOverride)(
         return (0, jsx_runtime_1.jsx)(react_1.Fragment, {
             children: (0, jsx_runtime_1.jsxs)(
                 "div",
-                tslib_1.__assign(
+                __assign(
                     {
                         "data-supertokens": "secondaryText secondaryLinkWithLeftArrow",
                         css: [styles.secondaryText, styles.secondaryLinkWithLeftArrow],

--- a/lib/build/recipe/passwordless/components/themes/signInUp/userInputCodeFormHeader.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/userInputCodeFormHeader.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.UserInputCodeFormHeader = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -18,7 +36,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * under the License.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
 exports.UserInputCodeFormHeader = (0, withOverride_1.withOverride)(
@@ -31,14 +49,14 @@ exports.UserInputCodeFormHeader = (0, withOverride_1.withOverride)(
             children: [
                 (0, jsx_runtime_1.jsx)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "headerTitle", css: styles.headerTitle },
                         { children: t("PWLESS_USER_INPUT_CODE_HEADER_TITLE") }
                     )
                 ),
                 (0, jsx_runtime_1.jsxs)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         {
                             "data-supertokens": "headerSubtitle secondaryText",
                             css: [styles.headerSubtitle, styles.secondaryText],

--- a/lib/build/recipe/passwordless/components/themes/translations.js
+++ b/lib/build/recipe/passwordless/components/themes/translations.js
@@ -1,10 +1,23 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.defaultTranslationsPasswordless = void 0;
-var tslib_1 = require("tslib");
 var translations_1 = require("../../../../translation/translations");
 exports.defaultTranslationsPasswordless = {
-    en: tslib_1.__assign(tslib_1.__assign({}, translations_1.defaultTranslationsCommon.en), {
+    en: __assign(__assign({}, translations_1.defaultTranslationsCommon.en), {
         GENERAL_ERROR_EMAIL_UNDEFINED: "Please set your email",
         GENERAL_ERROR_EMAIL_NON_STRING: "Email must be of type string",
         GENERAL_ERROR_EMAIL_INVALID: "Email is invalid",

--- a/lib/build/recipe/passwordless/index.js
+++ b/lib/build/recipe/passwordless/index.js
@@ -13,6 +13,196 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.redirectToAuth =
     exports.signOut =
@@ -32,21 +222,20 @@ exports.redirectToAuth =
     exports.SignInUp =
     exports.PasswordlessAuth =
         void 0;
-var tslib_1 = require("tslib");
-var recipe_1 = tslib_1.__importDefault(require("./recipe"));
-var passwordlessAuth_1 = tslib_1.__importDefault(require("./passwordlessAuth"));
+var recipe_1 = __importDefault(require("./recipe"));
+var passwordlessAuth_1 = __importDefault(require("./passwordlessAuth"));
 exports.PasswordlessAuth = passwordlessAuth_1.default;
-var signInUp_1 = tslib_1.__importDefault(require("./components/themes/signInUp"));
+var signInUp_1 = __importDefault(require("./components/themes/signInUp"));
 var utils_1 = require("../../utils");
-var UtilFunctions = tslib_1.__importStar(require("./utils"));
+var UtilFunctions = __importStar(require("./utils"));
 var Wrapper = /** @class */ (function () {
     function Wrapper() {}
     Wrapper.init = function (config) {
         return recipe_1.default.init(config);
     };
     Wrapper.signOut = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().signOut({
@@ -60,8 +249,8 @@ var Wrapper = /** @class */ (function () {
     };
     // have backwards compatibility to allow input as "signin" | "signup"
     Wrapper.redirectToAuth = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 if (input === undefined || typeof input === "string") {
                     return [
                         2 /*return*/,
@@ -85,12 +274,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.createCode = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     UtilFunctions.createCode(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             recipeImplementation: recipe_1.default.getInstanceOrThrow().recipeImpl,
                         })
                     ),
@@ -99,12 +288,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.resendCode = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     UtilFunctions.resendCode(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             recipeImplementation: recipe_1.default.getInstanceOrThrow().recipeImpl,
                         })
                     ),
@@ -113,12 +302,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.consumeCode = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     UtilFunctions.consumeCode(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             recipeImplementation: recipe_1.default.getInstanceOrThrow().recipeImpl,
                         })
                     ),
@@ -128,7 +317,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getLinkCodeFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getLinkCodeFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -137,7 +326,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getPreAuthSessionIdFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getPreAuthSessionIdFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -145,12 +334,12 @@ var Wrapper = /** @class */ (function () {
         );
     };
     Wrapper.doesEmailExist = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.doesEmailExist(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -159,12 +348,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.doesPhoneNumberExist = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.doesPhoneNumberExist(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -173,12 +362,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.getLoginAttemptInfo = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.getLoginAttemptInfo(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -189,12 +378,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.setLoginAttemptInfo = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.setLoginAttemptInfo(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -203,12 +392,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.clearLoginAttemptInfo = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.clearLoginAttemptInfo(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),

--- a/lib/build/recipe/passwordless/passwordlessAuth.js
+++ b/lib/build/recipe/passwordless/passwordlessAuth.js
@@ -1,22 +1,40 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var react_1 = require("react");
-var superTokens_1 = tslib_1.__importDefault(require("../../superTokens"));
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../usercontext/userContextWrapper"));
-var sessionAuth_1 = tslib_1.__importDefault(require("../session/sessionAuth"));
-var recipe_1 = tslib_1.__importDefault(require("./recipe"));
+var superTokens_1 = __importDefault(require("../../superTokens"));
+var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
+var sessionAuth_1 = __importDefault(require("../session/sessionAuth"));
+var recipe_1 = __importDefault(require("./recipe"));
 function PasswordlessAuth(props) {
     if (props.requireAuth === false) {
         return (0, jsx_runtime_1.jsx)(
             sessionAuth_1.default,
-            tslib_1.__assign({ onSessionExpired: props.onSessionExpired }, { children: props.children })
+            __assign({ onSessionExpired: props.onSessionExpired }, { children: props.children })
         );
     }
     return (0, jsx_runtime_1.jsx)(
         sessionAuth_1.default,
-        tslib_1.__assign(
+        __assign(
             {
                 redirectToLogin: function () {
                     return recipe_1.default
@@ -40,12 +58,12 @@ function PasswordlessAuthWrapper(_a) {
     var history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
-        tslib_1.__assign(
+        __assign(
             { userContext: userContext },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     PasswordlessAuthMemo,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             history: history,
                             onSessionExpired: onSessionExpired,

--- a/lib/build/recipe/passwordless/recipe.js
+++ b/lib/build/recipe/passwordless/recipe.js
@@ -1,23 +1,197 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var utils_1 = require("../../utils");
 var utils_2 = require("./utils");
-var recipeImplementation_1 = tslib_1.__importDefault(require("./recipeImplementation"));
-var supertokens_js_override_1 = tslib_1.__importDefault(require("supertokens-js-override"));
-var authRecipe_1 = tslib_1.__importDefault(require("../authRecipe"));
+var recipeImplementation_1 = __importDefault(require("./recipeImplementation"));
+var supertokens_js_override_1 = __importDefault(require("supertokens-js-override"));
+var authRecipe_1 = __importDefault(require("../authRecipe"));
 var constants_1 = require("../../constants");
-var signInAndUp_1 = tslib_1.__importDefault(require("./components/features/signInAndUp"));
-var authWidgetWrapper_1 = tslib_1.__importDefault(require("../authRecipe/authWidgetWrapper"));
-var linkClickedScreen_1 = tslib_1.__importDefault(require("./components/features/linkClickedScreen"));
-var normalisedURLPath_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../usercontext/userContextWrapper"));
+var signInAndUp_1 = __importDefault(require("./components/features/signInAndUp"));
+var authWidgetWrapper_1 = __importDefault(require("../authRecipe/authWidgetWrapper"));
+var linkClickedScreen_1 = __importDefault(require("./components/features/linkClickedScreen"));
+var normalisedURLPath_1 = __importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
+var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
 /*
  * Class.
  */
 var Passwordless = /** @class */ (function (_super) {
-    tslib_1.__extends(Passwordless, _super);
+    __extends(Passwordless, _super);
     function Passwordless(config) {
         var _this = _super.call(this, (0, utils_2.normalisePasswordlessConfig)(config)) || this;
         _this.getFeatures = function () {
@@ -47,8 +221,8 @@ var Passwordless = /** @class */ (function (_super) {
             return features;
         };
         _this.getDefaultRedirectionURL = function (context) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [2 /*return*/, this.getAuthRecipeDefaultRedirectionURL(context)];
                 });
             });
@@ -57,17 +231,17 @@ var Passwordless = /** @class */ (function (_super) {
             if (componentName === "signInUp") {
                 return (0, jsx_runtime_1.jsx)(
                     userContextWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         { userContext: props.userContext },
                         {
                             children: (0, jsx_runtime_1.jsx)(
                                 authWidgetWrapper_1.default,
-                                tslib_1.__assign(
+                                __assign(
                                     { authRecipe: _this, history: props.history },
                                     {
                                         children: (0, jsx_runtime_1.jsx)(
                                             signInAndUp_1.default,
-                                            tslib_1.__assign({ recipe: _this }, props)
+                                            __assign({ recipe: _this }, props)
                                         ),
                                     }
                                 )
@@ -79,12 +253,12 @@ var Passwordless = /** @class */ (function (_super) {
             if (componentName === "linkClickedScreen") {
                 return (0, jsx_runtime_1.jsx)(
                     userContextWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         { userContext: props.userContext },
                         {
                             children: (0, jsx_runtime_1.jsx)(
                                 linkClickedScreen_1.default,
-                                tslib_1.__assign({ recipe: _this }, props)
+                                __assign({ recipe: _this }, props)
                             ),
                         }
                     )
@@ -107,7 +281,7 @@ var Passwordless = /** @class */ (function (_super) {
     Passwordless.init = function (config) {
         return function (appInfo) {
             Passwordless.instance = new Passwordless(
-                tslib_1.__assign(tslib_1.__assign({}, config), { appInfo: appInfo, recipeId: Passwordless.RECIPE_ID })
+                __assign(__assign({}, config), { appInfo: appInfo, recipeId: Passwordless.RECIPE_ID })
             );
             return Passwordless.instance;
         };

--- a/lib/build/recipe/passwordless/recipeImplementation.js
+++ b/lib/build/recipe/passwordless/recipeImplementation.js
@@ -1,6 +1,136 @@
 "use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var recipeImplementation_1 = require("supertokens-web-js/recipe/passwordless/recipeImplementation");
 function getRecipeImplementation(recipeInput) {
     var webJsImplementation = (0, recipeImplementation_1.getRecipeImplementation)({
@@ -11,9 +141,9 @@ function getRecipeImplementation(recipeInput) {
     });
     return {
         createCode: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
+            return __awaiter(this, void 0, void 0, function () {
                 var response;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [4 /*yield*/, webJsImplementation.createCode.bind(this)(input)];
@@ -31,9 +161,9 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         resendCode: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
+            return __awaiter(this, void 0, void 0, function () {
                 var response;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [4 /*yield*/, webJsImplementation.resendCode.bind(this)(input)];
@@ -55,9 +185,9 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         consumeCode: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
+            return __awaiter(this, void 0, void 0, function () {
                 var response;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [4 /*yield*/, webJsImplementation.consumeCode.bind(this)(input)];
@@ -86,8 +216,8 @@ function getRecipeImplementation(recipeInput) {
             return webJsImplementation.getPreAuthSessionIdFromURL.bind(this)(input);
         },
         doesEmailExist: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [4 /*yield*/, webJsImplementation.doesEmailExist.bind(this)(input)];
@@ -98,8 +228,8 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         doesPhoneNumberExist: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [4 /*yield*/, webJsImplementation.doesPhoneNumberExist.bind(this)(input)];
@@ -113,8 +243,8 @@ function getRecipeImplementation(recipeInput) {
             return webJsImplementation.getLoginAttemptInfo.bind(this)(input);
         },
         setLoginAttemptInfo: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [2 /*return*/, webJsImplementation.setLoginAttemptInfo.bind(this)(input)];
                 });
             });

--- a/lib/build/recipe/passwordless/utils.js
+++ b/lib/build/recipe/passwordless/utils.js
@@ -13,6 +13,196 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.consumeCode =
     exports.resendCode =
@@ -22,17 +212,16 @@ exports.consumeCode =
     exports.defaultGuessInternationPhoneNumberFromInputPhoneNumber =
     exports.normalisePasswordlessConfig =
         void 0;
-var tslib_1 = require("tslib");
-var min_1 = tslib_1.__importStar(require("libphonenumber-js/min"));
+var min_1 = __importStar(require("libphonenumber-js/min"));
 var utils_1 = require("../authRecipe/utils");
 var validators_1 = require("./validators");
-var utils_2 = tslib_1.__importDefault(require("supertokens-web-js/recipe/passwordless/utils"));
+var utils_2 = __importDefault(require("supertokens-web-js/recipe/passwordless/utils"));
 function normalisePasswordlessConfig(config) {
     if (!["EMAIL", "PHONE", "EMAIL_OR_PHONE"].includes(config.contactMethod)) {
         throw new Error("Please pass one of 'PHONE', 'EMAIL' or 'EMAIL_OR_PHONE' as the contactMethod");
     }
     var signInUpFeature = normalizeSignInUpFeatureConfig(config.signInUpFeature, config);
-    var override = tslib_1.__assign(
+    var override = __assign(
         {
             functions: function (originalImplementation) {
                 return originalImplementation;
@@ -59,7 +248,7 @@ function normalisePasswordlessConfig(config) {
     } else if (config.contactMethod === "EMAIL_OR_PHONE") {
         validatePhoneNumber = validators_1.defaultPhoneNumberValidatorForCombinedInput;
     }
-    return tslib_1.__assign(tslib_1.__assign({}, (0, utils_1.normaliseAuthRecipe)(config)), {
+    return __assign(__assign({}, (0, utils_1.normaliseAuthRecipe)(config)), {
         validateEmailAddress: validateEmailAddress,
         validatePhoneNumber: validatePhoneNumber,
         signInUpFeature: signInUpFeature,
@@ -77,7 +266,7 @@ function normalizeSignInUpFeatureConfig(signInUpInput, config) {
     ) {
         throw new Error("Please pass a positive number as resendEmailOrSMSGapInSeconds");
     }
-    var signInUpFeature = tslib_1.__assign(tslib_1.__assign({}, signInUpInput), {
+    var signInUpFeature = __assign(__assign({}, signInUpInput), {
         resendEmailOrSMSGapInSeconds:
             (signInUpInput === null || signInUpInput === void 0
                 ? void 0
@@ -122,7 +311,7 @@ function normalizeSignInUpFeatureConfig(signInUpInput, config) {
 }
 function normalisePasswordlessBaseConfig(config) {
     var style = config && config.style !== undefined ? config.style : {};
-    return tslib_1.__assign(tslib_1.__assign({}, config), { style: style });
+    return __assign(__assign({}, config), { style: style });
 }
 function defaultGuessInternationPhoneNumberFromInputPhoneNumber(value, defaultCountryFromConfig) {
     var _a;
@@ -149,8 +338,8 @@ function defaultGuessInternationPhoneNumberFromInputPhoneNumber(value, defaultCo
 }
 exports.defaultGuessInternationPhoneNumberFromInputPhoneNumber = defaultGuessInternationPhoneNumberFromInputPhoneNumber;
 function getLoginAttemptInfo(input) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
-        return tslib_1.__generator(this, function (_a) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
                     return [
@@ -167,8 +356,8 @@ function getLoginAttemptInfo(input) {
 }
 exports.getLoginAttemptInfo = getLoginAttemptInfo;
 function setLoginAttemptInfo(input) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
-        return tslib_1.__generator(this, function (_a) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
                     return [
@@ -190,24 +379,24 @@ exports.setLoginAttemptInfo = setLoginAttemptInfo;
  * passwordless and thirdpartypasswordless recipes without having to duplicate code
  */
 function createCode(input) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
-        return tslib_1.__generator(this, function (_a) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
             return [2 /*return*/, utils_2.default.createCode(input)];
         });
     });
 }
 exports.createCode = createCode;
 function resendCode(input) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
-        return tslib_1.__generator(this, function (_a) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
             return [2 /*return*/, utils_2.default.resendCode(input)];
         });
     });
 }
 exports.resendCode = resendCode;
 function consumeCode(input) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
-        return tslib_1.__generator(this, function (_a) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
             return [2 /*return*/, utils_2.default.consumeCode(input)];
         });
     });

--- a/lib/build/recipe/passwordless/validators.js
+++ b/lib/build/recipe/passwordless/validators.js
@@ -13,6 +13,137 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.userInputCodeValidate =
     exports.defaultPhoneNumberValidatorForCombinedInput =
@@ -20,7 +151,6 @@ exports.userInputCodeValidate =
     exports.defaultPhoneNumberValidator =
     exports.defaultEmailValidator =
         void 0;
-var tslib_1 = require("tslib");
 var min_1 = require("react-phone-number-input/min");
 function defaultEmailValidator(value) {
     if (typeof value !== "string") {
@@ -75,8 +205,8 @@ function defaultPhoneNumberValidatorForCombinedInput(value) {
 }
 exports.defaultPhoneNumberValidatorForCombinedInput = defaultPhoneNumberValidatorForCombinedInput;
 function userInputCodeValidate(value) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
-        return tslib_1.__generator(this, function (_a) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
             if (typeof value !== "string") {
                 return [2 /*return*/, "GENERAL_ERROR_OTP_NON_STRING"];
             }

--- a/lib/build/recipe/recipeModule/index.js
+++ b/lib/build/recipe/recipeModule/index.js
@@ -13,8 +13,138 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var utils_1 = require("../../utils");
 /*
  * Class.
@@ -26,9 +156,9 @@ var RecipeModule = /** @class */ (function () {
     function RecipeModule(config) {
         var _this = this;
         this.redirect = function (context, history, queryParams) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
+            return __awaiter(_this, void 0, void 0, function () {
                 var redirectUrl, origin_1;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [4 /*yield*/, this.getRedirectUrl(context)];
@@ -61,9 +191,9 @@ var RecipeModule = /** @class */ (function () {
         };
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
         this.getRedirectUrl = function (context) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
+            return __awaiter(_this, void 0, void 0, function () {
                 var redirectUrl;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [4 /*yield*/, this.config.getRedirectionURL(context)];
@@ -84,8 +214,8 @@ var RecipeModule = /** @class */ (function () {
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     RecipeModule.prototype.getDefaultRedirectionURL = function (_) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 throw new Error("getDefaultRedirectionURL is not implemented.");
             });
         });

--- a/lib/build/recipe/recipeModule/utils.js
+++ b/lib/build/recipe/recipeModule/utils.js
@@ -1,7 +1,151 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.normaliseRecipeModuleConfig = void 0;
-var tslib_1 = require("tslib");
 var utils_1 = require("../../utils");
 function normaliseRecipeModuleConfig(config) {
     var _this = this;
@@ -16,8 +160,8 @@ function normaliseRecipeModuleConfig(config) {
     if (getRedirectionURL === undefined) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         getRedirectionURL = function (_) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [2 /*return*/, undefined];
                 });
             });
@@ -26,8 +170,8 @@ function normaliseRecipeModuleConfig(config) {
     if (preAPIHook === undefined) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         preAPIHook = function (context) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [2 /*return*/, context];
                 });
             });
@@ -36,8 +180,8 @@ function normaliseRecipeModuleConfig(config) {
     if (postAPIHook === undefined) {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         postAPIHook = function () {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [2 /*return*/];
                 });
             });
@@ -47,7 +191,7 @@ function normaliseRecipeModuleConfig(config) {
     useShadowDom = getShouldUseShadowDomBasedOnBrowser(useShadowDom);
     var palette = config.palette === undefined ? {} : config.palette;
     var rootStyle = config.style === undefined ? {} : config.style;
-    return tslib_1.__assign(tslib_1.__assign({}, config), {
+    return __assign(__assign({}, config), {
         getRedirectionURL: getRedirectionURL,
         onHandleEvent: onHandleEvent,
         preAPIHook: preAPIHook,

--- a/lib/build/recipe/session/index.js
+++ b/lib/build/recipe/session/index.js
@@ -13,6 +13,142 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SessionContext =
     exports.signOut =
@@ -25,11 +161,10 @@ exports.SessionContext =
     exports.SessionAuth =
     exports.useSessionContext =
         void 0;
-var tslib_1 = require("tslib");
-var recipe_1 = tslib_1.__importDefault(require("./recipe"));
-var sessionAuth_1 = tslib_1.__importDefault(require("./sessionAuth"));
-var useSessionContext_1 = tslib_1.__importDefault(require("./useSessionContext"));
-var sessionContext_1 = tslib_1.__importDefault(require("./sessionContext"));
+var recipe_1 = __importDefault(require("./recipe"));
+var sessionAuth_1 = __importDefault(require("./sessionAuth"));
+var useSessionContext_1 = __importDefault(require("./useSessionContext"));
+var sessionContext_1 = __importDefault(require("./sessionContext"));
 exports.SessionContext = sessionContext_1.default;
 var utils_1 = require("../../utils");
 var SessionAPIWrapper = /** @class */ (function () {
@@ -38,8 +173,8 @@ var SessionAPIWrapper = /** @class */ (function () {
         return recipe_1.default.init(config);
     };
     SessionAPIWrapper.getUserId = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().getUserId({
@@ -52,8 +187,8 @@ var SessionAPIWrapper = /** @class */ (function () {
         });
     };
     SessionAPIWrapper.getAccessTokenPayloadSecurely = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().getAccessTokenPayloadSecurely({
@@ -66,15 +201,15 @@ var SessionAPIWrapper = /** @class */ (function () {
         });
     };
     SessionAPIWrapper.attemptRefreshingSession = function () {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [2 /*return*/, recipe_1.default.getInstanceOrThrow().attemptRefreshingSession()];
             });
         });
     };
     SessionAPIWrapper.doesSessionExist = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().doesSessionExist({
@@ -90,8 +225,8 @@ var SessionAPIWrapper = /** @class */ (function () {
         return recipe_1.default.addAxiosInterceptors(axiosInstance, (0, utils_1.getNormalisedUserContext)(userContext));
     };
     SessionAPIWrapper.signOut = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().signOut({

--- a/lib/build/recipe/session/recipe.js
+++ b/lib/build/recipe/session/recipe.js
@@ -13,16 +13,190 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 /*
  * Imports.
  */
-var recipeModule_1 = tslib_1.__importDefault(require("../recipeModule"));
+var recipeModule_1 = __importDefault(require("../recipeModule"));
 var utils_1 = require("../../utils");
 var recipe_1 = require("supertokens-web-js/recipe/session/recipe");
 var Session = /** @class */ (function (_super) {
-    tslib_1.__extends(Session, _super);
+    __extends(Session, _super);
     function Session(config) {
         var _this = _super.call(this, config) || this;
         _this.eventListeners = new Set();
@@ -37,8 +211,8 @@ var Session = /** @class */ (function (_super) {
             return _this.webJsRecipe.getUserId(input);
         };
         _this.getAccessTokenPayloadSecurely = function (input) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [2 /*return*/, this.webJsRecipe.getAccessTokenPayloadSecurely(input)];
                 });
             });
@@ -50,8 +224,8 @@ var Session = /** @class */ (function (_super) {
             return _this.webJsRecipe.signOut(input);
         };
         _this.attemptRefreshingSession = function () {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [2 /*return*/, this.webJsRecipe.attemptRefreshingSession()];
                 });
             });
@@ -66,16 +240,16 @@ var Session = /** @class */ (function (_super) {
             };
         };
         _this.notifyListeners = function (event) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
+            return __awaiter(_this, void 0, void 0, function () {
                 var sessionContext;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [4 /*yield*/, this.getSessionContext(event)];
                         case 1:
                             sessionContext = _a.sent();
                             this.eventListeners.forEach(function (listener) {
-                                return listener(tslib_1.__assign({ sessionContext: sessionContext }, event));
+                                return listener(__assign({ sessionContext: sessionContext }, event));
                             });
                             return [2 /*return*/];
                     }
@@ -83,7 +257,7 @@ var Session = /** @class */ (function (_super) {
             });
         };
         _this.webJsRecipe = new recipe_1.Recipe(
-            tslib_1.__assign(tslib_1.__assign({}, config), {
+            __assign(__assign({}, config), {
                 onHandleEvent: function (event) {
                     if (config.onHandleEvent !== undefined) {
                         config.onHandleEvent(event);
@@ -91,12 +265,12 @@ var Session = /** @class */ (function (_super) {
                     void _this.notifyListeners(event);
                 },
                 preAPIHook: function (context) {
-                    return tslib_1.__awaiter(_this, void 0, void 0, function () {
+                    return __awaiter(_this, void 0, void 0, function () {
                         var response;
-                        return tslib_1.__generator(this, function (_a) {
-                            response = tslib_1.__assign(tslib_1.__assign({}, context), {
-                                requestInit: tslib_1.__assign(tslib_1.__assign({}, context.requestInit), {
-                                    headers: tslib_1.__assign(tslib_1.__assign({}, context.requestInit.headers), {
+                        return __generator(this, function (_a) {
+                            response = __assign(__assign({}, context), {
+                                requestInit: __assign(__assign({}, context.requestInit), {
+                                    headers: __assign(__assign({}, context.requestInit.headers), {
                                         rid: config.recipeId,
                                     }),
                                 }),
@@ -117,9 +291,9 @@ var Session = /** @class */ (function (_super) {
     Session.prototype.getSessionContext = function (_a) {
         var action = _a.action,
             userContext = _a.userContext;
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
+        return __awaiter(this, void 0, void 0, function () {
             var _b, userId, accessTokenPayload;
-            return tslib_1.__generator(this, function (_c) {
+            return __generator(this, function (_c) {
                 switch (_c.label) {
                     case 0:
                         if (
@@ -174,7 +348,7 @@ var Session = /** @class */ (function (_super) {
     Session.init = function (config) {
         return function (appInfo, enableDebugLogs) {
             Session.instance = new Session(
-                tslib_1.__assign(tslib_1.__assign({}, config), {
+                __assign(__assign({}, config), {
                     appInfo: appInfo,
                     recipeId: Session.RECIPE_ID,
                     enableDebugLogs: enableDebugLogs,

--- a/lib/build/recipe/session/sessionAuth.js
+++ b/lib/build/recipe/session/sessionAuth.js
@@ -1,6 +1,206 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __rest =
+    (this && this.__rest) ||
+    function (s, e) {
+        var t = {};
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0) t[p] = s[p];
+        if (s != null && typeof Object.getOwnPropertySymbols === "function")
+            for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+                if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i])) t[p[i]] = s[p[i]];
+            }
+        return t;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -20,10 +220,10 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var sessionContext_1 = tslib_1.__importStar(require("./sessionContext"));
-var recipe_1 = tslib_1.__importDefault(require("./recipe"));
+var sessionContext_1 = __importStar(require("./sessionContext"));
+var recipe_1 = __importDefault(require("./recipe"));
 var usercontext_1 = require("../../usercontext");
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../usercontext/userContextWrapper"));
+var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
 var utils_1 = require("../../utils");
 // if it's not the default context, it means SessionAuth from top has
 // given us a sessionContext.
@@ -32,7 +232,7 @@ var hasParentProvider = function (ctx) {
 };
 var SessionAuth = function (_a) {
     var children = _a.children,
-        props = tslib_1.__rest(_a, ["children"]);
+        props = __rest(_a, ["children"]);
     if (props.requireAuth === true && props.redirectToLogin === undefined) {
         throw new Error("You have to provide redirectToLogin or onSessionExpired function when requireAuth is true");
     }
@@ -51,10 +251,10 @@ var SessionAuth = function (_a) {
     var session = (0, react_1.useRef)(recipe_1.default.getInstanceOrThrow());
     var userContext = (0, usercontext_1.useUserContext)();
     var buildContext = (0, react_1.useCallback)(function () {
-        return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        return __awaiter(void 0, void 0, void 0, function () {
             var sessionExists;
             var _a;
-            return tslib_1.__generator(this, function (_b) {
+            return __generator(this, function (_b) {
                 switch (_b.label) {
                     case 0:
                         if (hasParentProvider(parentSessionContext)) {
@@ -106,8 +306,8 @@ var SessionAuth = function (_a) {
     }, []);
     var setInitialContextAndMaybeRedirect = (0, react_1.useCallback)(
         function (toSetContext) {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(void 0, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     // if this component is unmounting, or the context has already
                     // been set, then we don't need to proceed...
                     if (!toSetContext.doesSessionExist && props.requireAuth === true) {
@@ -177,15 +377,15 @@ var SessionAuth = function (_a) {
     }
     return (0, jsx_runtime_1.jsx)(
         sessionContext_1.default.Provider,
-        tslib_1.__assign({ value: context }, { children: children })
+        __assign({ value: context }, { children: children })
     );
 };
 var SessionAuthWrapper = function (props) {
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
-        tslib_1.__assign(
+        __assign(
             { userContext: props.userContext },
-            { children: (0, jsx_runtime_1.jsx)(SessionAuth, tslib_1.__assign({}, props)) }
+            { children: (0, jsx_runtime_1.jsx)(SessionAuth, __assign({}, props)) }
         )
     );
 };

--- a/lib/build/recipe/session/sessionContext.js
+++ b/lib/build/recipe/session/sessionContext.js
@@ -1,8 +1,12 @@
 "use strict";
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.isDefaultContext = void 0;
-var tslib_1 = require("tslib");
-var react_1 = tslib_1.__importDefault(require("react"));
+var react_1 = __importDefault(require("react"));
 var SessionContext = react_1.default.createContext({
     doesSessionExist: false,
     userId: "DEFAULT_USER_ID",

--- a/lib/build/recipe/session/useSessionContext.js
+++ b/lib/build/recipe/session/useSessionContext.js
@@ -1,8 +1,12 @@
 "use strict";
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
-var react_1 = tslib_1.__importDefault(require("react"));
-var sessionContext_1 = tslib_1.__importDefault(require("./sessionContext"));
+var react_1 = __importDefault(require("react"));
+var sessionContext_1 = __importDefault(require("./sessionContext"));
 var useSessionContext = function () {
     return react_1.default.useContext(sessionContext_1.default);
 };

--- a/lib/build/recipe/thirdparty/components/features/signInAndUp/index.js
+++ b/lib/build/recipe/thirdparty/components/features/signInAndUp/index.js
@@ -1,7 +1,65 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignInAndUpFeature = exports.useChildProps = exports.useFeatureReducer = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -20,10 +78,10 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var React = tslib_1.__importStar(require("react"));
+var React = __importStar(require("react"));
 var react_1 = require("react");
-var signInAndUp_1 = tslib_1.__importDefault(require("../../themes/signInAndUp"));
-var featureWrapper_1 = tslib_1.__importDefault(require("../../../../../components/featureWrapper"));
+var signInAndUp_1 = __importDefault(require("../../themes/signInAndUp"));
+var featureWrapper_1 = __importDefault(require("../../../../../components/featureWrapper"));
 var utils_1 = require("../../../../../utils");
 var componentOverrideContext_1 = require("../../../../../components/componentOverride/componentOverrideContext");
 var translations_1 = require("../../themes/translations");
@@ -33,7 +91,7 @@ var useFeatureReducer = function () {
         function (oldState, action) {
             switch (action.type) {
                 case "setError":
-                    return tslib_1.__assign(tslib_1.__assign({}, oldState), { error: action.error });
+                    return __assign(__assign({}, oldState), { error: action.error });
                 default:
                     return oldState;
             }
@@ -100,12 +158,12 @@ var SignInAndUpFeature = function (props) {
     var componentOverrides = props.recipe.config.override.components;
     return (0, jsx_runtime_1.jsx)(
         componentOverrideContext_1.ComponentOverrideContext.Provider,
-        tslib_1.__assign(
+        __assign(
             { value: componentOverrides },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     featureWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             useShadowDom: props.recipe.config.useShadowDom,
                             defaultStore: translations_1.defaultTranslationsThirdParty,
@@ -116,17 +174,14 @@ var SignInAndUpFeature = function (props) {
                                     props.children === undefined &&
                                         (0, jsx_runtime_1.jsx)(
                                             signInAndUp_1.default,
-                                            tslib_1.__assign({}, childProps, {
-                                                featureState: state,
-                                                dispatch: dispatch,
-                                            })
+                                            __assign({}, childProps, { featureState: state, dispatch: dispatch })
                                         ),
                                     props.children &&
                                         React.Children.map(props.children, function (child) {
                                             if (React.isValidElement(child)) {
                                                 return React.cloneElement(
                                                     child,
-                                                    tslib_1.__assign(tslib_1.__assign({}, childProps), {
+                                                    __assign(__assign({}, childProps), {
                                                         featureState: state,
                                                         dispatch: dispatch,
                                                     })
@@ -146,5 +201,5 @@ var SignInAndUpFeature = function (props) {
 exports.SignInAndUpFeature = SignInAndUpFeature;
 exports.default = exports.SignInAndUpFeature;
 var getModifiedRecipeImplementation = function (origImpl) {
-    return tslib_1.__assign({}, origImpl);
+    return __assign({}, origImpl);
 };

--- a/lib/build/recipe/thirdparty/components/features/signInAndUpCallback/index.js
+++ b/lib/build/recipe/thirdparty/components/features/signInAndUpCallback/index.js
@@ -1,6 +1,155 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,14 +170,14 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  */
 var react_1 = require("react");
 var utils_1 = require("../../../../../utils");
-var featureWrapper_1 = tslib_1.__importDefault(require("../../../../../components/featureWrapper"));
+var featureWrapper_1 = __importDefault(require("../../../../../components/featureWrapper"));
 var styleContext_1 = require("../../../../../styles/styleContext");
 var styles_1 = require("../../../../../styles/styles");
 var styles_2 = require("../../themes/styles");
 var signInAndUpCallback_1 = require("../../themes/signInAndUpCallback");
 var componentOverrideContext_1 = require("../../../../../components/componentOverride/componentOverrideContext");
 var translations_1 = require("../../themes/translations");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
 var usercontext_1 = require("../../../../../usercontext");
 var SignInAndUpCallback = function (props) {
     var userContext = (0, usercontext_1.useUserContext)();
@@ -42,9 +191,9 @@ var SignInAndUpCallback = function (props) {
     );
     var handleVerifyResponse = (0, react_1.useCallback)(
         function (response) {
-            return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+            return __awaiter(void 0, void 0, void 0, function () {
                 var stateResponse, redirectToPath, isEmailVerified, ignored_1;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             if (response.status === "NO_EMAIL_GIVEN_BY_PROVIDER") {
@@ -137,12 +286,12 @@ var SignInAndUpCallback = function (props) {
     var oAuthCallbackScreen = props.recipe.config.oAuthCallbackScreen;
     return (0, jsx_runtime_1.jsx)(
         componentOverrideContext_1.ComponentOverrideContext.Provider,
-        tslib_1.__assign(
+        __assign(
             { value: componentOverrides },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     featureWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             useShadowDom: props.recipe.config.useShadowDom,
                             defaultStore: translations_1.defaultTranslationsThirdParty,
@@ -150,7 +299,7 @@ var SignInAndUpCallback = function (props) {
                         {
                             children: (0, jsx_runtime_1.jsx)(
                                 styleContext_1.StyleProvider,
-                                tslib_1.__assign(
+                                __assign(
                                     {
                                         rawPalette: props.recipe.config.palette,
                                         defaultPalette: styles_1.defaultPalette,

--- a/lib/build/recipe/thirdparty/components/library/providerButton.js
+++ b/lib/build/recipe/thirdparty/components/library/providerButton.js
@@ -1,6 +1,24 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,7 +39,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  */
 var react_1 = require("react");
 var translationContext_1 = require("../../../../translation/translationContext");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../styles/styleContext"));
 /*
  * Component.
  */
@@ -37,7 +55,7 @@ function ProviderButton(_a) {
     var providerStyleName = "provider".concat(providerName);
     return (0, jsx_runtime_1.jsxs)(
         "button",
-        tslib_1.__assign(
+        __assign(
             {
                 css: [styles.providerButton, styles[providerStyleName]],
                 "data-supertokens": "providerButton ".concat(providerStyleName),
@@ -47,12 +65,12 @@ function ProviderButton(_a) {
                     logo !== undefined &&
                         (0, jsx_runtime_1.jsx)(
                             "div",
-                            tslib_1.__assign(
+                            __assign(
                                 { css: styles.providerButtonLeft, "data-supertokens": "providerButtonLeft" },
                                 {
                                     children: (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             {
                                                 css: styles.providerButtonLogo,
                                                 "data-supertokens": "providerButtonLogo",
@@ -60,7 +78,7 @@ function ProviderButton(_a) {
                                             {
                                                 children: (0, jsx_runtime_1.jsx)(
                                                     "div",
-                                                    tslib_1.__assign(
+                                                    __assign(
                                                         {
                                                             css: styles.providerButtonLogoCenter,
                                                             "data-supertokens": "providerButtonLogoCenter",
@@ -76,7 +94,7 @@ function ProviderButton(_a) {
                         ),
                     (0, jsx_runtime_1.jsxs)(
                         "div",
-                        tslib_1.__assign(
+                        __assign(
                             { css: styles.providerButtonText, "data-supertokens": "providerButtonText" },
                             {
                                 children: [

--- a/lib/build/recipe/thirdparty/components/themes/signInAndUp/index.js
+++ b/lib/build/recipe/thirdparty/components/themes/signInAndUp/index.js
@@ -1,6 +1,64 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -20,7 +78,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importStar(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importStar(require("../../../../../styles/styleContext"));
 var styles_1 = require("../../../../../styles/styles");
 var styles_2 = require("../../../components/themes/styles");
 var styles_3 = require("../../../../../styles/styles");
@@ -29,26 +87,26 @@ var themeBase_1 = require("../themeBase");
 var providersForm_1 = require("./providersForm");
 var SuperTokensBranding_1 = require("../../../../../components/SuperTokensBranding");
 var __1 = require("../../../../..");
-var generalError_1 = tslib_1.__importDefault(require("../../../../emailpassword/components/library/generalError"));
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../../../../usercontext/userContextWrapper"));
+var generalError_1 = __importDefault(require("../../../../emailpassword/components/library/generalError"));
+var userContextWrapper_1 = __importDefault(require("../../../../../usercontext/userContextWrapper"));
 var SignInAndUpTheme = function (props) {
     var t = (0, __1.useTranslation)();
     var styles = (0, react_1.useContext)(styleContext_1.default);
     return (0, jsx_runtime_1.jsxs)(
         "div",
-        tslib_1.__assign(
+        __assign(
             { "data-supertokens": "container", css: styles.container },
             {
                 children: [
                     (0, jsx_runtime_1.jsxs)(
                         "div",
-                        tslib_1.__assign(
+                        __assign(
                             { "data-supertokens": "row", css: styles.row },
                             {
                                 children: [
                                     (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             { "data-supertokens": "headerTitle", css: styles.headerTitle },
                                             { children: t("THIRD_PARTY_SIGN_IN_AND_UP_HEADER_TITLE") }
                                         )
@@ -61,7 +119,7 @@ var SignInAndUpTheme = function (props) {
                                         (0, jsx_runtime_1.jsx)(generalError_1.default, {
                                             error: props.featureState.error,
                                         }),
-                                    (0, jsx_runtime_1.jsx)(providersForm_1.ProvidersForm, tslib_1.__assign({}, props)),
+                                    (0, jsx_runtime_1.jsx)(providersForm_1.ProvidersForm, __assign({}, props)),
                                     (0, jsx_runtime_1.jsx)(signUpFooter_1.SignUpFooter, {
                                         privacyPolicyLink: props.config.signInAndUpFeature.privacyPolicyLink,
                                         termsOfServiceLink: props.config.signInAndUpFeature.termsOfServiceLink,
@@ -80,17 +138,17 @@ var SignInAndUpThemeWrapper = function (props) {
     var hasFont = (0, styles_3.hasFontDefined)(props.config.rootStyle);
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
-        tslib_1.__assign(
+        __assign(
             { userContext: props.userContext },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     themeBase_1.ThemeBase,
-                    tslib_1.__assign(
+                    __assign(
                         { loadDefaultFont: !hasFont },
                         {
                             children: (0, jsx_runtime_1.jsx)(
                                 styleContext_1.StyleProvider,
-                                tslib_1.__assign(
+                                __assign(
                                     {
                                         rawPalette: props.config.palette,
                                         defaultPalette: styles_1.defaultPalette,
@@ -98,7 +156,7 @@ var SignInAndUpThemeWrapper = function (props) {
                                         rootStyleFromInit: props.config.rootStyle,
                                         getDefaultStyles: styles_2.getStyles,
                                     },
-                                    { children: (0, jsx_runtime_1.jsx)(SignInAndUpTheme, tslib_1.__assign({}, props)) }
+                                    { children: (0, jsx_runtime_1.jsx)(SignInAndUpTheme, __assign({}, props)) }
                                 )
                             ),
                         }

--- a/lib/build/recipe/thirdparty/components/themes/signInAndUp/providersForm.js
+++ b/lib/build/recipe/thirdparty/components/themes/signInAndUp/providersForm.js
@@ -1,7 +1,156 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ProvidersForm = exports.ThirdPartySignInAndUpProvidersForm = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -18,18 +167,18 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * under the License.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var utils_1 = require("../../../utils");
-var error_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/error"));
+var error_1 = __importDefault(require("supertokens-web-js/utils/error"));
 var usercontext_1 = require("../../../../../usercontext");
 var ThirdPartySignInAndUpProvidersForm = function (props) {
     var styles = (0, react_1.useContext)(styleContext_1.default);
     var userContext = (0, usercontext_1.useUserContext)();
     var signInClick = function (providerId) {
-        return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        return __awaiter(void 0, void 0, void 0, function () {
             var response, generalError, e_1, err_1;
-            return tslib_1.__generator(this, function (_a) {
+            return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
                         _a.trys.push([0, 5, , 6]);
@@ -87,12 +236,12 @@ var ThirdPartySignInAndUpProvidersForm = function (props) {
         children: props.providers.map(function (provider) {
             return (0, jsx_runtime_1.jsx)(
                 "div",
-                tslib_1.__assign(
+                __assign(
                     { css: styles.providerContainer, "data-supertokens": "providerContainer" },
                     {
                         children: (0, jsx_runtime_1.jsx)(
                             "span",
-                            tslib_1.__assign(
+                            __assign(
                                 {
                                     onClick: function () {
                                         return signInClick(provider.id);

--- a/lib/build/recipe/thirdparty/components/themes/signInAndUp/signUpFooter.js
+++ b/lib/build/recipe/thirdparty/components/themes/signInAndUp/signUpFooter.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignUpFooter = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,7 +39,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 var translationContext_1 = require("../../../../../translation/translationContext");
 exports.SignUpFooter = (0, withOverride_1.withOverride)("ThirdPartySignUpFooter", function ThirdPartySignUpFooter(_a) {
@@ -33,5 +51,5 @@ exports.SignUpFooter = (0, withOverride_1.withOverride)("ThirdPartySignUpFooter"
         return null;
     }
     return (0,
-    jsx_runtime_1.jsxs)("div", tslib_1.__assign({ "data-supertokens": "secondaryText privacyPolicyAndTermsAndConditions", css: [styles.secondaryText, styles.privacyPolicyAndTermsAndConditions] }, { children: [t("THIRD_PARTY_SIGN_IN_UP_FOOTER_START"), termsOfServiceLink !== undefined && (0, jsx_runtime_1.jsx)("a", tslib_1.__assign({ "data-supertokens": "link", css: styles.link, href: termsOfServiceLink, target: "_blank", rel: "noopener noreferer" }, { children: t("THIRD_PARTY_SIGN_IN_UP_FOOTER_TOS") })), termsOfServiceLink !== undefined && privacyPolicyLink !== undefined && t("THIRD_PARTY_SIGN_IN_UP_FOOTER_AND"), privacyPolicyLink !== undefined && (0, jsx_runtime_1.jsx)("a", tslib_1.__assign({ "data-supertokens": "link", css: styles.link, href: privacyPolicyLink, target: "_blank", rel: "noopener noreferer" }, { children: t("THIRD_PARTY_SIGN_IN_UP_FOOTER_PP") })), t("THIRD_PARTY_SIGN_IN_UP_FOOTER_END")] }));
+    jsx_runtime_1.jsxs)("div", __assign({ "data-supertokens": "secondaryText privacyPolicyAndTermsAndConditions", css: [styles.secondaryText, styles.privacyPolicyAndTermsAndConditions] }, { children: [t("THIRD_PARTY_SIGN_IN_UP_FOOTER_START"), termsOfServiceLink !== undefined && (0, jsx_runtime_1.jsx)("a", __assign({ "data-supertokens": "link", css: styles.link, href: termsOfServiceLink, target: "_blank", rel: "noopener noreferer" }, { children: t("THIRD_PARTY_SIGN_IN_UP_FOOTER_TOS") })), termsOfServiceLink !== undefined && privacyPolicyLink !== undefined && t("THIRD_PARTY_SIGN_IN_UP_FOOTER_AND"), privacyPolicyLink !== undefined && (0, jsx_runtime_1.jsx)("a", __assign({ "data-supertokens": "link", css: styles.link, href: privacyPolicyLink, target: "_blank", rel: "noopener noreferer" }, { children: t("THIRD_PARTY_SIGN_IN_UP_FOOTER_PP") })), t("THIRD_PARTY_SIGN_IN_UP_FOOTER_END")] }));
 });

--- a/lib/build/recipe/thirdparty/components/themes/signInAndUpCallback/index.js
+++ b/lib/build/recipe/thirdparty/components/themes/signInAndUpCallback/index.js
@@ -1,7 +1,50 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SignInAndUpCallbackTheme = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -21,14 +64,14 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var spinnerIcon_1 = tslib_1.__importDefault(require("../../../../../components/assets/spinnerIcon"));
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var spinnerIcon_1 = __importDefault(require("../../../../../components/assets/spinnerIcon"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
 /*
  * Component.
  */
 var ThirdPartySignInAndUpCallbackTheme = /** @class */ (function (_super) {
-    tslib_1.__extends(ThirdPartySignInAndUpCallbackTheme, _super);
+    __extends(ThirdPartySignInAndUpCallbackTheme, _super);
     function ThirdPartySignInAndUpCallbackTheme() {
         var _this = (_super !== null && _super.apply(this, arguments)) || this;
         /*
@@ -38,17 +81,17 @@ var ThirdPartySignInAndUpCallbackTheme = /** @class */ (function (_super) {
             var styles = _this.context;
             return (0, jsx_runtime_1.jsx)(
                 "div",
-                tslib_1.__assign(
+                __assign(
                     { "data-supertokens": "container", css: styles.container },
                     {
                         children: (0, jsx_runtime_1.jsx)(
                             "div",
-                            tslib_1.__assign(
+                            __assign(
                                 { "data-supertokens": "row", css: styles.row },
                                 {
                                     children: (0, jsx_runtime_1.jsx)(
                                         "div",
-                                        tslib_1.__assign(
+                                        __assign(
                                             { "data-supertokens": "spinner", css: styles.spinner },
                                             {
                                                 children: (0, jsx_runtime_1.jsx)(spinnerIcon_1.default, {

--- a/lib/build/recipe/thirdparty/components/themes/styles.js
+++ b/lib/build/recipe/thirdparty/components/themes/styles.js
@@ -13,10 +13,28 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getStyles = void 0;
-var tslib_1 = require("tslib");
-var chroma_js_1 = tslib_1.__importDefault(require("chroma-js"));
+var chroma_js_1 = __importDefault(require("chroma-js"));
 var styles_1 = require("../../../../styles/styles");
 var providerColors = {
     google: "#ea3721",
@@ -70,24 +88,21 @@ function getStyles(palette) {
         providerTwitter: (0, styles_1.getButtonStyle)(providerColors.twitter, "white"),
         providerFacebook: (0, styles_1.getButtonStyle)(providerColors.facebook, "white"),
         providerApple: (0, styles_1.getButtonStyle)(providerColors.apple, "white", true),
-        providerCustom: tslib_1.__assign(
-            tslib_1.__assign({}, (0, styles_1.getButtonStyle)(providerColors.custom, "white")),
-            {
-                color: "#000",
+        providerCustom: __assign(__assign({}, (0, styles_1.getButtonStyle)(providerColors.custom, "white")), {
+            color: "#000",
+            border: "1px solid #000",
+            "&:active": {
+                outline: "none",
                 border: "1px solid #000",
-                "&:active": {
-                    outline: "none",
-                    border: "1px solid #000",
-                    backgroundColor: (0, chroma_js_1.default)(providerColors.custom).darken(0.1).hex(),
-                    transition: "background 0s",
-                    backgroundSize: "100%",
-                },
-                "&:focus": {
-                    outline: "none",
-                    border: "1px solid #000",
-                },
-            }
-        ),
+                backgroundColor: (0, chroma_js_1.default)(providerColors.custom).darken(0.1).hex(),
+                transition: "background 0s",
+                backgroundSize: "100%",
+            },
+            "&:focus": {
+                outline: "none",
+                border: "1px solid #000",
+            },
+        }),
     };
     return (0, styles_1.getMergedStyles)(baseStyles, recipeStyles);
 }

--- a/lib/build/recipe/thirdparty/components/themes/translations.js
+++ b/lib/build/recipe/thirdparty/components/themes/translations.js
@@ -1,13 +1,26 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.defaultTranslationsThirdParty = void 0;
-var tslib_1 = require("tslib");
 var translations_1 = require("../../../../translation/translations");
 var translations_2 = require("../../../emailverification/components/themes/translations");
 exports.defaultTranslationsThirdParty = {
-    en: tslib_1.__assign(
-        tslib_1.__assign(
-            tslib_1.__assign({}, translations_1.defaultTranslationsCommon.en),
+    en: __assign(
+        __assign(
+            __assign({}, translations_1.defaultTranslationsCommon.en),
             translations_2.defaultTranslationsEmailVerification.en
         ),
         {

--- a/lib/build/recipe/thirdparty/index.js
+++ b/lib/build/recipe/thirdparty/index.js
@@ -13,6 +13,156 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.EmailVerificationTheme =
     exports.EmailVerification =
@@ -44,17 +194,16 @@ exports.EmailVerificationTheme =
     exports.init =
     exports.ThirdPartyAuth =
         void 0;
-var tslib_1 = require("tslib");
 /*
  * Import
  */
 // /!\ ThirdParty must be imported before any of the providers to prevent circular dependencies.
-var recipe_1 = tslib_1.__importDefault(require("./recipe"));
-var emailVerification_1 = tslib_1.__importDefault(require("../emailverification/components/themes/emailVerification"));
+var recipe_1 = __importDefault(require("./recipe"));
+var emailVerification_1 = __importDefault(require("../emailverification/components/themes/emailVerification"));
 exports.EmailVerificationTheme = emailVerification_1.default;
-var thirdpartyAuth_1 = tslib_1.__importDefault(require("./thirdpartyAuth"));
+var thirdpartyAuth_1 = __importDefault(require("./thirdpartyAuth"));
 exports.ThirdPartyAuth = thirdpartyAuth_1.default;
-var signInAndUp_1 = tslib_1.__importDefault(require("./components/themes/signInAndUp"));
+var signInAndUp_1 = __importDefault(require("./components/themes/signInAndUp"));
 exports.SignInAndUpTheme = signInAndUp_1.default;
 var signInAndUpCallback_1 = require("./components/themes/signInAndUpCallback");
 Object.defineProperty(exports, "SignInAndUpCallbackTheme", {
@@ -63,13 +212,13 @@ Object.defineProperty(exports, "SignInAndUpCallbackTheme", {
         return signInAndUpCallback_1.SignInAndUpCallbackTheme;
     },
 });
-var apple_1 = tslib_1.__importDefault(require("./providers/apple"));
+var apple_1 = __importDefault(require("./providers/apple"));
 exports.Apple = apple_1.default;
-var google_1 = tslib_1.__importDefault(require("./providers/google"));
+var google_1 = __importDefault(require("./providers/google"));
 exports.Google = google_1.default;
-var facebook_1 = tslib_1.__importDefault(require("./providers/facebook"));
+var facebook_1 = __importDefault(require("./providers/facebook"));
 exports.Facebook = facebook_1.default;
-var github_1 = tslib_1.__importDefault(require("./providers/github"));
+var github_1 = __importDefault(require("./providers/github"));
 exports.Github = github_1.default;
 var utils_1 = require("../../utils");
 var utils_2 = require("./utils");
@@ -82,8 +231,8 @@ var Wrapper = /** @class */ (function () {
         return recipe_1.default.init(config);
     };
     Wrapper.signOut = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().signOut({
@@ -96,12 +245,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.isEmailVerified = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.isEmailVerified(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -112,12 +261,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.verifyEmail = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.verifyEmail(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -128,12 +277,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.sendVerificationEmail = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.sendVerificationEmail(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -145,7 +294,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getEmailVerificationTokenFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.getEmailVerificationTokenFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -154,8 +303,8 @@ var Wrapper = /** @class */ (function () {
     };
     // have backwards compatibility to allow input as "signin" | "signup"
     Wrapper.redirectToAuth = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 if (input === undefined || typeof input === "string") {
                     return [
                         2 /*return*/,
@@ -179,9 +328,9 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.redirectToThirdPartyLogin = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
+        return __awaiter(this, void 0, void 0, function () {
             var recipeInstance;
-            return tslib_1.__generator(this, function (_a) {
+            return __generator(this, function (_a) {
                 recipeInstance = recipe_1.default.getInstanceOrThrow();
                 return [
                     2 /*return*/,
@@ -197,7 +346,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getStateAndOtherInfoFromStorage = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getStateAndOtherInfoFromStorage(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -205,12 +354,12 @@ var Wrapper = /** @class */ (function () {
         );
     };
     Wrapper.setStateAndOtherInfoToStorage = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.setStateAndOtherInfoToStorage(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -219,12 +368,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.getAuthorisationURLWithQueryParamsAndSetState = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.getAuthorisationURLWithQueryParamsAndSetState(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -233,12 +382,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.getAuthorisationURLFromBackend = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.getAuthorisationURLFromBackend(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -247,12 +396,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.signInAndUp = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.signInAndUp(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -264,7 +413,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.generateStateToSendToOAuthProvider = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.generateStateToSendToOAuthProvider(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -272,12 +421,12 @@ var Wrapper = /** @class */ (function () {
         );
     };
     Wrapper.verifyAndGetStateOrThrowError = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.verifyAndGetStateOrThrowError(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -287,7 +436,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getAuthCodeFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getAuthCodeFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -296,7 +445,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getAuthErrorFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getAuthErrorFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -305,7 +454,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getAuthStateFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getAuthStateFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),

--- a/lib/build/recipe/thirdparty/providers/apple.js
+++ b/lib/build/recipe/thirdparty/providers/apple.js
@@ -1,6 +1,49 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,13 +62,13 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var _1 = tslib_1.__importDefault(require("."));
+var _1 = __importDefault(require("."));
 var utils_1 = require("../../../utils");
 /*
  * Class.
  */
 var Apple = /** @class */ (function (_super) {
-    tslib_1.__extends(Apple, _super);
+    __extends(Apple, _super);
     /*
      * Constructor.
      */
@@ -45,7 +88,7 @@ var Apple = /** @class */ (function (_super) {
         _this.getLogo = function () {
             return (0, jsx_runtime_1.jsx)(
                 "svg",
-                tslib_1.__assign(
+                __assign(
                     {
                         xmlns: "http://www.w3.org/2000/svg",
                         width: "15.614",
@@ -55,7 +98,7 @@ var Apple = /** @class */ (function (_super) {
                     {
                         children: (0, jsx_runtime_1.jsxs)(
                             "g",
-                            tslib_1.__assign(
+                            __assign(
                                 {
                                     id: "iconfinder_logo_brand_brands_logos_apple_ios_2993701",
                                     transform: "translate(-2)",

--- a/lib/build/recipe/thirdparty/providers/custom.js
+++ b/lib/build/recipe/thirdparty/providers/custom.js
@@ -1,6 +1,35 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
  * This software is licensed under the Apache License, Version 2.0 (the
@@ -18,12 +47,12 @@ var tslib_1 = require("tslib");
 /*
  * Imports.
  */
-var _1 = tslib_1.__importDefault(require("."));
+var _1 = __importDefault(require("."));
 /*
  * Class.
  */
 var Custom = /** @class */ (function (_super) {
-    tslib_1.__extends(Custom, _super);
+    __extends(Custom, _super);
     /*
      * Constructor.
      */

--- a/lib/build/recipe/thirdparty/providers/facebook.js
+++ b/lib/build/recipe/thirdparty/providers/facebook.js
@@ -1,6 +1,49 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,13 +62,13 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var _1 = tslib_1.__importDefault(require("."));
+var _1 = __importDefault(require("."));
 var utils_1 = require("../../../utils");
 /*
  * Class.
  */
 var Facebook = /** @class */ (function (_super) {
-    tslib_1.__extends(Facebook, _super);
+    __extends(Facebook, _super);
     /*
      * Constructor.
      */
@@ -45,7 +88,7 @@ var Facebook = /** @class */ (function (_super) {
         _this.getLogo = function () {
             return (0, jsx_runtime_1.jsx)(
                 "svg",
-                tslib_1.__assign(
+                __assign(
                     {
                         xmlns: "http://www.w3.org/2000/svg",
                         width: "7.956",

--- a/lib/build/recipe/thirdparty/providers/github.js
+++ b/lib/build/recipe/thirdparty/providers/github.js
@@ -1,6 +1,49 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,13 +62,13 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var _1 = tslib_1.__importDefault(require("."));
+var _1 = __importDefault(require("."));
 var utils_1 = require("../../../utils");
 /*
  * Class.
  */
 var Github = /** @class */ (function (_super) {
-    tslib_1.__extends(Github, _super);
+    __extends(Github, _super);
     /*
      * Constructor.
      */
@@ -45,7 +88,7 @@ var Github = /** @class */ (function (_super) {
         _this.getLogo = function () {
             return (0, jsx_runtime_1.jsx)(
                 "svg",
-                tslib_1.__assign(
+                __assign(
                     { xmlns: "http://www.w3.org/2000/svg", width: "18", height: "17.556", viewBox: "0 0 18 17.556" },
                     {
                         children: (0, jsx_runtime_1.jsx)("path", {

--- a/lib/build/recipe/thirdparty/providers/google.js
+++ b/lib/build/recipe/thirdparty/providers/google.js
@@ -1,6 +1,49 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,13 +62,13 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var _1 = tslib_1.__importDefault(require("."));
+var _1 = __importDefault(require("."));
 var utils_1 = require("../../../utils");
 /*
  * Class.
  */
 var Google = /** @class */ (function (_super) {
-    tslib_1.__extends(Google, _super);
+    __extends(Google, _super);
     /*
      * Constructor.
      */
@@ -45,12 +88,12 @@ var Google = /** @class */ (function (_super) {
         _this.getLogo = function () {
             return (0, jsx_runtime_1.jsx)(
                 "svg",
-                tslib_1.__assign(
+                __assign(
                     { xmlns: "http://www.w3.org/2000/svg", width: "18.001", height: "18", viewBox: "0 0 18.001 18" },
                     {
                         children: (0, jsx_runtime_1.jsxs)(
                             "g",
-                            tslib_1.__assign(
+                            __assign(
                                 { id: "Group_9292", transform: "translate(-534 -389)" },
                                 {
                                     children: [

--- a/lib/build/recipe/thirdparty/providers/index.js
+++ b/lib/build/recipe/thirdparty/providers/index.js
@@ -1,6 +1,10 @@
 "use strict";
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -16,9 +20,9 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var normalisedURLPath_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
-var superTokens_1 = tslib_1.__importDefault(require("../../../superTokens"));
-var providerButton_1 = tslib_1.__importDefault(require("../components/library/providerButton"));
+var normalisedURLPath_1 = __importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
+var superTokens_1 = __importDefault(require("../../../superTokens"));
+var providerButton_1 = __importDefault(require("../components/library/providerButton"));
 /*
  * Imports.
  */

--- a/lib/build/recipe/thirdparty/providers/twitter.js
+++ b/lib/build/recipe/thirdparty/providers/twitter.js
@@ -1,6 +1,49 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,13 +62,13 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var _1 = tslib_1.__importDefault(require("."));
+var _1 = __importDefault(require("."));
 var utils_1 = require("../../../utils");
 /*
  * Class.
  */
 var Twitter = /** @class */ (function (_super) {
-    tslib_1.__extends(Twitter, _super);
+    __extends(Twitter, _super);
     /*
      * Constructor.
      */
@@ -45,7 +88,7 @@ var Twitter = /** @class */ (function (_super) {
         _this.getLogo = function () {
             return (0, jsx_runtime_1.jsx)(
                 "svg",
-                tslib_1.__assign(
+                __assign(
                     {
                         xmlns: "http://www.w3.org/2000/svg",
                         width: "20.129",

--- a/lib/build/recipe/thirdparty/recipe.js
+++ b/lib/build/recipe/thirdparty/recipe.js
@@ -1,6 +1,180 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,22 +193,22 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var authRecipeWithEmailVerification_1 = tslib_1.__importDefault(require("../authRecipeWithEmailVerification"));
+var authRecipeWithEmailVerification_1 = __importDefault(require("../authRecipeWithEmailVerification"));
 var utils_1 = require("../../utils");
 var utils_2 = require("./utils");
-var normalisedURLPath_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
+var normalisedURLPath_1 = __importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
 var constants_1 = require("../../constants");
-var signInAndUp_1 = tslib_1.__importDefault(require("./components/features/signInAndUp"));
-var signInAndUpCallback_1 = tslib_1.__importDefault(require("./components/features/signInAndUpCallback"));
-var recipeImplementation_1 = tslib_1.__importDefault(require("./recipeImplementation"));
-var authWidgetWrapper_1 = tslib_1.__importDefault(require("../authRecipe/authWidgetWrapper"));
-var supertokens_js_override_1 = tslib_1.__importDefault(require("supertokens-js-override"));
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../usercontext/userContextWrapper"));
+var signInAndUp_1 = __importDefault(require("./components/features/signInAndUp"));
+var signInAndUpCallback_1 = __importDefault(require("./components/features/signInAndUpCallback"));
+var recipeImplementation_1 = __importDefault(require("./recipeImplementation"));
+var authWidgetWrapper_1 = __importDefault(require("../authRecipe/authWidgetWrapper"));
+var supertokens_js_override_1 = __importDefault(require("supertokens-js-override"));
+var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
 /*
  * Class.
  */
 var ThirdParty = /** @class */ (function (_super) {
-    tslib_1.__extends(ThirdParty, _super);
+    __extends(ThirdParty, _super);
     function ThirdParty(config, recipes) {
         var _this =
             _super.call(this, (0, utils_2.normaliseThirdPartyConfig)(config), {
@@ -70,23 +244,23 @@ var ThirdParty = /** @class */ (function (_super) {
                     },
                 };
             });
-            return tslib_1.__assign(tslib_1.__assign({}, features), _this.getAuthRecipeWithEmailVerificationFeatures());
+            return __assign(__assign({}, features), _this.getAuthRecipeWithEmailVerificationFeatures());
         };
         _this.getFeatureComponent = function (componentName, props) {
             if (componentName === "signinup") {
                 return (0, jsx_runtime_1.jsx)(
                     userContextWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         { userContext: props.userContext },
                         {
                             children: (0, jsx_runtime_1.jsx)(
                                 authWidgetWrapper_1.default,
-                                tslib_1.__assign(
+                                __assign(
                                     { authRecipe: _this, history: props.history },
                                     {
                                         children: (0, jsx_runtime_1.jsx)(
                                             signInAndUp_1.default,
-                                            tslib_1.__assign({ recipe: _this }, props)
+                                            __assign({ recipe: _this }, props)
                                         ),
                                     }
                                 )
@@ -97,12 +271,12 @@ var ThirdParty = /** @class */ (function (_super) {
             } else if (componentName === "signinupcallback") {
                 return (0, jsx_runtime_1.jsx)(
                     userContextWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         { userContext: props.userContext },
                         {
                             children: (0, jsx_runtime_1.jsx)(
                                 signInAndUpCallback_1.default,
-                                tslib_1.__assign({ recipe: _this }, props)
+                                __assign({ recipe: _this }, props)
                             ),
                         }
                     )
@@ -112,8 +286,8 @@ var ThirdParty = /** @class */ (function (_super) {
             }
         };
         _this.getDefaultRedirectionURL = function (context) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [2 /*return*/, this.getAuthRecipeWithEmailVerificationDefaultRedirectionURL(context)];
                 });
             });
@@ -133,7 +307,7 @@ var ThirdParty = /** @class */ (function (_super) {
     ThirdParty.init = function (config) {
         return function (appInfo) {
             ThirdParty.instance = new ThirdParty(
-                tslib_1.__assign(tslib_1.__assign({}, config), { appInfo: appInfo, recipeId: ThirdParty.RECIPE_ID }),
+                __assign(__assign({}, config), { appInfo: appInfo, recipeId: ThirdParty.RECIPE_ID }),
                 {
                     emailVerificationInstance: undefined,
                 }

--- a/lib/build/recipe/thirdparty/recipeImplementation.js
+++ b/lib/build/recipe/thirdparty/recipeImplementation.js
@@ -1,6 +1,150 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var utils_1 = require("../../utils");
 var recipeImplementation_1 = require("supertokens-web-js/recipe/thirdparty/recipeImplementation");
 function getRecipeImplementation(recipeInput) {
@@ -12,9 +156,9 @@ function getRecipeImplementation(recipeInput) {
     });
     return {
         getAuthorisationURLFromBackend: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
+            return __awaiter(this, void 0, void 0, function () {
                 var response;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [
@@ -32,9 +176,9 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         signInAndUp: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
+            return __awaiter(this, void 0, void 0, function () {
                 var response;
-                return tslib_1.__generator(this, function (_a) {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [
@@ -65,7 +209,7 @@ function getRecipeImplementation(recipeInput) {
         },
         setStateAndOtherInfoToStorage: function (input) {
             return webJsImplementation.setStateAndOtherInfoToStorage.bind(this)({
-                state: tslib_1.__assign(tslib_1.__assign({}, input.state), {
+                state: __assign(__assign({}, input.state), {
                     rid: recipeInput.recipeId,
                     redirectToPath: (0, utils_1.getRedirectToPathFromURL)(),
                 }),
@@ -73,12 +217,12 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         getAuthorisationURLWithQueryParamsAndSetState: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [
                         2 /*return*/,
                         webJsImplementation.getAuthorisationURLWithQueryParamsAndSetState.bind(this)(
-                            tslib_1.__assign({}, input)
+                            __assign({}, input)
                         ),
                     ];
                 });
@@ -88,7 +232,7 @@ function getRecipeImplementation(recipeInput) {
             return webJsImplementation.getAuthStateFromURL.bind(this)(input);
         },
         generateStateToSendToOAuthProvider: function (input) {
-            return webJsImplementation.generateStateToSendToOAuthProvider.bind(this)(tslib_1.__assign({}, input));
+            return webJsImplementation.generateStateToSendToOAuthProvider.bind(this)(__assign({}, input));
         },
         verifyAndGetStateOrThrowError: function (input) {
             return webJsImplementation.verifyAndGetStateOrThrowError.bind(this)({

--- a/lib/build/recipe/thirdparty/thirdpartyAuth.js
+++ b/lib/build/recipe/thirdparty/thirdpartyAuth.js
@@ -1,30 +1,45 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var react_1 = require("react");
-var recipe_1 = tslib_1.__importDefault(require("./recipe"));
-var sessionAuth_1 = tslib_1.__importDefault(require("../session/sessionAuth"));
-var emailVerificationAuth_1 = tslib_1.__importDefault(require("../emailverification/emailVerificationAuth"));
-var superTokens_1 = tslib_1.__importDefault(require("../../superTokens"));
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../usercontext/userContextWrapper"));
+var recipe_1 = __importDefault(require("./recipe"));
+var sessionAuth_1 = __importDefault(require("../session/sessionAuth"));
+var emailVerificationAuth_1 = __importDefault(require("../emailverification/emailVerificationAuth"));
+var superTokens_1 = __importDefault(require("../../superTokens"));
+var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
 function ThirdPartyAuth(props) {
     var emailVerification = (0, jsx_runtime_1.jsx)(
         emailVerificationAuth_1.default,
-        tslib_1.__assign(
-            { recipe: props.recipe.emailVerification, history: props.history },
-            { children: props.children }
-        )
+        __assign({ recipe: props.recipe.emailVerification, history: props.history }, { children: props.children })
     );
     if (props.requireAuth === false) {
         return (0, jsx_runtime_1.jsx)(
             sessionAuth_1.default,
-            tslib_1.__assign({ onSessionExpired: props.onSessionExpired }, { children: emailVerification })
+            __assign({ onSessionExpired: props.onSessionExpired }, { children: emailVerification })
         );
     }
     return (0, jsx_runtime_1.jsx)(
         sessionAuth_1.default,
-        tslib_1.__assign(
+        __assign(
             {
                 redirectToLogin: function () {
                     void recipe_1.default
@@ -48,12 +63,12 @@ var ThirdPartyAuthWrapper = function (_a) {
     var history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
-        tslib_1.__assign(
+        __assign(
             { userContext: userContext },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     ThirdPartyAuthMemo,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             history: history,
                             onSessionExpired: onSessionExpired,

--- a/lib/build/recipe/thirdparty/utils.js
+++ b/lib/build/recipe/thirdparty/utils.js
@@ -13,18 +13,167 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.redirectToThirdPartyLogin =
     exports.matchRecipeIdUsingState =
     exports.normaliseSignInAndUpFeature =
     exports.normaliseThirdPartyConfig =
         void 0;
-var tslib_1 = require("tslib");
 /*
  * Imports.
  */
-var providers_1 = tslib_1.__importDefault(require("./providers"));
-var custom_1 = tslib_1.__importDefault(require("./providers/custom"));
+var providers_1 = __importDefault(require("./providers"));
+var custom_1 = __importDefault(require("./providers/custom"));
 var utils_1 = require("../authRecipeWithEmailVerification/utils");
 var utils_2 = require("../../utils");
 /*
@@ -34,7 +183,7 @@ function normaliseThirdPartyConfig(config) {
     var signInAndUpFeature = normaliseSignInAndUpFeature(config.signInAndUpFeature);
     var oAuthCallbackScreen =
         config.oAuthCallbackScreen === undefined ? {} : { style: config.oAuthCallbackScreen.style };
-    var override = tslib_1.__assign(
+    var override = __assign(
         {
             functions: function (originalImplementation) {
                 return originalImplementation;
@@ -43,7 +192,7 @@ function normaliseThirdPartyConfig(config) {
         },
         config.override
     );
-    return tslib_1.__assign(tslib_1.__assign({}, (0, utils_1.normaliseAuthRecipeWithEmailVerificationConfig)(config)), {
+    return __assign(__assign({}, (0, utils_1.normaliseAuthRecipeWithEmailVerificationConfig)(config)), {
         signInAndUpFeature: signInAndUpFeature,
         oAuthCallbackScreen: oAuthCallbackScreen,
         override: override,
@@ -112,9 +261,9 @@ function matchRecipeIdUsingState(recipe, userContext) {
 }
 exports.matchRecipeIdUsingState = matchRecipeIdUsingState;
 function redirectToThirdPartyLogin(input) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
+    return __awaiter(this, void 0, void 0, function () {
         var provider, response;
-        return tslib_1.__generator(this, function (_a) {
+        return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
                     provider = input.config.signInAndUpFeature.providers.find(function (p) {

--- a/lib/build/recipe/thirdpartyemailpassword/components/features/signInAndUp/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/components/features/signInAndUp/index.js
@@ -1,6 +1,64 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,11 +77,11 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var React = tslib_1.__importStar(require("react"));
+var React = __importStar(require("react"));
 var react_1 = require("react");
-var featureWrapper_1 = tslib_1.__importDefault(require("../../../../../components/featureWrapper"));
+var featureWrapper_1 = __importDefault(require("../../../../../components/featureWrapper"));
 var componentOverrideContext_1 = require("../../../../../components/componentOverride/componentOverrideContext");
-var signInAndUp_1 = tslib_1.__importDefault(require("../../themes/signInAndUp"));
+var signInAndUp_1 = __importDefault(require("../../themes/signInAndUp"));
 var translations_1 = require("../../themes/translations");
 var signInAndUp_2 = require("../../../../thirdparty/components/features/signInAndUp");
 var signInAndUp_3 = require("../../../../emailpassword/components/features/signInAndUp");
@@ -38,7 +96,7 @@ var SignInAndUp = function (props) {
             function (state, action) {
                 switch (action.type) {
                     case "setError":
-                        return tslib_1.__assign(tslib_1.__assign({}, state), { error: action.error });
+                        return __assign(__assign({}, state), { error: action.error });
                     default:
                         return state;
                 }
@@ -84,12 +142,12 @@ var SignInAndUp = function (props) {
     };
     return (0, jsx_runtime_1.jsx)(
         componentOverrideContext_1.ComponentOverrideContext.Provider,
-        tslib_1.__assign(
+        __assign(
             { value: componentOverrides },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     featureWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             useShadowDom: props.recipe.config.useShadowDom,
                             defaultStore: translations_1.defaultTranslationsThirdPartyEmailPassword,
@@ -98,7 +156,7 @@ var SignInAndUp = function (props) {
                             children: (0, jsx_runtime_1.jsxs)(react_1.Fragment, {
                                 children: [
                                     props.children === undefined &&
-                                        (0, jsx_runtime_1.jsx)(signInAndUp_1.default, tslib_1.__assign({}, childProps)),
+                                        (0, jsx_runtime_1.jsx)(signInAndUp_1.default, __assign({}, childProps)),
                                     props.children &&
                                         React.Children.map(props.children, function (child) {
                                             if (React.isValidElement(child)) {

--- a/lib/build/recipe/thirdpartyemailpassword/components/themes/signInAndUp/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/components/themes/signInAndUp/index.js
@@ -1,6 +1,64 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -20,7 +78,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * Imports.
  */
 var react_1 = require("react");
-var styleContext_1 = tslib_1.__importStar(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importStar(require("../../../../../styles/styleContext"));
 var themeBase_1 = require("../themeBase");
 var header_1 = require("./header");
 var providersForm_1 = require("../../../../thirdparty/components/themes/signInAndUp/providersForm");
@@ -28,24 +86,24 @@ var styles_1 = require("../../../../../styles/styles");
 var styles_2 = require("../styles");
 var SuperTokensBranding_1 = require("../../../../../components/SuperTokensBranding");
 var translationContext_1 = require("../../../../../translation/translationContext");
-var generalError_1 = tslib_1.__importDefault(require("../../../../emailpassword/components/library/generalError"));
+var generalError_1 = __importDefault(require("../../../../emailpassword/components/library/generalError"));
 var signUpFooter_1 = require("../../../../emailpassword/components/themes/signInAndUp/signUpFooter");
 var signInForm_1 = require("../../../../emailpassword/components/themes/signInAndUp/signInForm");
 var signUpForm_1 = require("../../../../emailpassword/components/themes/signInAndUp/signUpForm");
 var signInFooter_1 = require("../../../../emailpassword/components/themes/signInAndUp/signInFooter");
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../../../../usercontext/userContextWrapper"));
+var userContextWrapper_1 = __importDefault(require("../../../../../usercontext/userContextWrapper"));
 var SignInAndUpTheme = function (props) {
     var t = (0, translationContext_1.useTranslation)();
     var styles = (0, react_1.useContext)(styleContext_1.default);
     return (0, jsx_runtime_1.jsxs)(
         "div",
-        tslib_1.__assign(
+        __assign(
             { "data-supertokens": "container", css: styles.container },
             {
                 children: [
                     (0, jsx_runtime_1.jsxs)(
                         "div",
-                        tslib_1.__assign(
+                        __assign(
                             { "data-supertokens": "row", css: styles.row },
                             {
                                 children: [
@@ -62,7 +120,7 @@ var SignInAndUpTheme = function (props) {
                                     props.tpChildProps !== undefined &&
                                         (0, jsx_runtime_1.jsx)(
                                             providersForm_1.ProvidersForm,
-                                            tslib_1.__assign({}, props.tpChildProps, {
+                                            __assign({}, props.tpChildProps, {
                                                 featureState: props.tpState,
                                                 dispatch: props.tpDispatch,
                                             })
@@ -71,7 +129,7 @@ var SignInAndUpTheme = function (props) {
                                         props.thirdPartyRecipe !== undefined &&
                                         (0, jsx_runtime_1.jsxs)(
                                             "div",
-                                            tslib_1.__assign(
+                                            __assign(
                                                 {
                                                     "data-supertokens": "thirdPartyEmailPasswordDivider",
                                                     css: styles.thirdPartyEmailPasswordDivider,
@@ -84,7 +142,7 @@ var SignInAndUpTheme = function (props) {
                                                         }),
                                                         (0, jsx_runtime_1.jsx)(
                                                             "div",
-                                                            tslib_1.__assign(
+                                                            __assign(
                                                                 {
                                                                     "data-supertokens":
                                                                         "thirdPartyEmailPasswordDividerOr",
@@ -109,7 +167,7 @@ var SignInAndUpTheme = function (props) {
                                         (props.epState.isSignUp
                                             ? (0, jsx_runtime_1.jsx)(
                                                   signUpForm_1.SignUpForm,
-                                                  tslib_1.__assign({}, props.epChildProps.signUpForm, {
+                                                  __assign({}, props.epChildProps.signUpForm, {
                                                       footer: (0, jsx_runtime_1.jsx)(signUpFooter_1.SignUpFooter, {
                                                           privacyPolicyLink:
                                                               props.epChildProps.config.signInAndUpFeature.signUpForm
@@ -122,7 +180,7 @@ var SignInAndUpTheme = function (props) {
                                               )
                                             : (0, jsx_runtime_1.jsx)(
                                                   signInForm_1.SignInForm,
-                                                  tslib_1.__assign({}, props.epChildProps.signInForm, {
+                                                  __assign({}, props.epChildProps.signInForm, {
                                                       footer: (0, jsx_runtime_1.jsx)(signInFooter_1.SignInFooter, {
                                                           onClick: props.epChildProps.signInForm.forgotPasswordClick,
                                                       }),
@@ -142,17 +200,17 @@ function SignInAndUpThemeWrapper(props) {
     var hasFont = (0, styles_1.hasFontDefined)(props.config.rootStyle);
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
-        tslib_1.__assign(
+        __assign(
             { userContext: props.userContext },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     themeBase_1.ThemeBase,
-                    tslib_1.__assign(
+                    __assign(
                         { loadDefaultFont: !hasFont },
                         {
                             children: (0, jsx_runtime_1.jsx)(
                                 styleContext_1.StyleProvider,
-                                tslib_1.__assign(
+                                __assign(
                                     {
                                         rawPalette: props.config.palette,
                                         defaultPalette: styles_1.defaultPalette,
@@ -160,7 +218,7 @@ function SignInAndUpThemeWrapper(props) {
                                         rootStyleFromInit: props.config.rootStyle,
                                         getDefaultStyles: styles_2.getStyles,
                                     },
-                                    { children: (0, jsx_runtime_1.jsx)(SignInAndUpTheme, tslib_1.__assign({}, props)) }
+                                    { children: (0, jsx_runtime_1.jsx)(SignInAndUpTheme, __assign({}, props)) }
                                 )
                             ),
                         }

--- a/lib/build/recipe/thirdpartyemailpassword/components/themes/translations.js
+++ b/lib/build/recipe/thirdpartyemailpassword/components/themes/translations.js
@@ -1,13 +1,26 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.defaultTranslationsThirdPartyEmailPassword = void 0;
-var tslib_1 = require("tslib");
 var translations_1 = require("../../../emailpassword/components/themes/translations");
 var translations_2 = require("../../../thirdparty/components/themes/translations");
 exports.defaultTranslationsThirdPartyEmailPassword = {
-    en: tslib_1.__assign(
-        tslib_1.__assign(
-            tslib_1.__assign({}, translations_2.defaultTranslationsThirdParty.en),
+    en: __assign(
+        __assign(
+            __assign({}, translations_2.defaultTranslationsThirdParty.en),
             translations_1.defaultTranslationsEmailPassword.en
         ),
         { THIRD_PARTY_EMAIL_PASSWORD_SIGN_IN_AND_UP_DIVIDER_OR: "or" }

--- a/lib/build/recipe/thirdpartyemailpassword/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/index.js
@@ -1,4 +1,154 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ResetPasswordUsingTokenTheme =
     exports.ResetPasswordUsingToken =
@@ -38,7 +188,6 @@ exports.ResetPasswordUsingTokenTheme =
     exports.init =
     exports.ThirdPartyEmailPasswordAuth =
         void 0;
-var tslib_1 = require("tslib");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
  * This software is licensed under the Apache License, Version 2.0 (the
@@ -53,16 +202,14 @@ var tslib_1 = require("tslib");
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var recipe_1 = tslib_1.__importDefault(require("./recipe"));
-var emailVerification_1 = tslib_1.__importDefault(require("../emailverification/components/themes/emailVerification"));
+var recipe_1 = __importDefault(require("./recipe"));
+var emailVerification_1 = __importDefault(require("../emailverification/components/themes/emailVerification"));
 exports.EmailVerificationTheme = emailVerification_1.default;
-var resetPasswordUsingToken_1 = tslib_1.__importDefault(
-    require("../emailpassword/components/themes/resetPasswordUsingToken")
-);
+var resetPasswordUsingToken_1 = __importDefault(require("../emailpassword/components/themes/resetPasswordUsingToken"));
 exports.ResetPasswordUsingTokenTheme = resetPasswordUsingToken_1.default;
-var thirdpartyEmailpasswordAuth_1 = tslib_1.__importDefault(require("./thirdpartyEmailpasswordAuth"));
+var thirdpartyEmailpasswordAuth_1 = __importDefault(require("./thirdpartyEmailpasswordAuth"));
 exports.ThirdPartyEmailPasswordAuth = thirdpartyEmailpasswordAuth_1.default;
-var signInAndUp_1 = tslib_1.__importDefault(require("./components/themes/signInAndUp"));
+var signInAndUp_1 = __importDefault(require("./components/themes/signInAndUp"));
 exports.SignInAndUpTheme = signInAndUp_1.default;
 var thirdparty_1 = require("../thirdparty/");
 Object.defineProperty(exports, "Apple", {
@@ -104,8 +251,8 @@ var Wrapper = /** @class */ (function () {
         return recipe_1.default.init(config);
     };
     Wrapper.signOut = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().signOut({
@@ -118,12 +265,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.isEmailVerified = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.isEmailVerified(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -134,12 +281,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.verifyEmail = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.verifyEmail(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -150,12 +297,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.sendVerificationEmail = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.sendVerificationEmail(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -167,7 +314,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getEmailVerificationTokenFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.getEmailVerificationTokenFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -176,8 +323,8 @@ var Wrapper = /** @class */ (function () {
     };
     // have backwards compatibility to allow input as "signin" | "signup"
     Wrapper.redirectToAuth = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 if (input === undefined || typeof input === "string") {
                     return [
                         2 /*return*/,
@@ -201,12 +348,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.submitNewPassword = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.submitNewPassword(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -215,12 +362,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.sendPasswordResetEmail = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.sendPasswordResetEmail(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -229,12 +376,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.emailPasswordSignUp = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.emailPasswordSignUp(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -243,12 +390,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.emailPasswordSignIn = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.emailPasswordSignIn(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -257,12 +404,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.doesEmailExist = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.doesEmailExist(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -272,7 +419,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getResetPasswordTokenFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getResetPasswordTokenFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -280,9 +427,9 @@ var Wrapper = /** @class */ (function () {
         );
     };
     Wrapper.redirectToThirdPartyLogin = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
+        return __awaiter(this, void 0, void 0, function () {
             var recipeInstance;
-            return tslib_1.__generator(this, function (_a) {
+            return __generator(this, function (_a) {
                 recipeInstance = recipe_1.default.getInstanceOrThrow();
                 if (recipeInstance.thirdPartyRecipe === undefined) {
                     throw new Error(
@@ -302,12 +449,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.getAuthorisationURLFromBackend = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.getAuthorisationURLFromBackend(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -316,12 +463,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.thirdPartySignInAndUp = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.thirdPartySignInAndUp(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -333,7 +480,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getStateAndOtherInfoFromStorage = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getStateAndOtherInfoFromStorage(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -341,12 +488,12 @@ var Wrapper = /** @class */ (function () {
         );
     };
     Wrapper.setStateAndOtherInfoToStorage = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.setStateAndOtherInfoToStorage(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -355,12 +502,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.getAuthorisationURLWithQueryParamsAndSetState = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.getAuthorisationURLWithQueryParamsAndSetState(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -370,7 +517,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.generateStateToSendToOAuthProvider = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.generateStateToSendToOAuthProvider(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -378,12 +525,12 @@ var Wrapper = /** @class */ (function () {
         );
     };
     Wrapper.verifyAndGetStateOrThrowError = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.verifyAndGetStateOrThrowError(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -393,7 +540,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getAuthCodeFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getAuthCodeFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -402,7 +549,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getAuthErrorFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getAuthErrorFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -411,7 +558,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getAuthStateFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getAuthStateFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),

--- a/lib/build/recipe/thirdpartyemailpassword/recipe.js
+++ b/lib/build/recipe/thirdpartyemailpassword/recipe.js
@@ -1,6 +1,180 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,24 +193,22 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var authRecipeWithEmailVerification_1 = tslib_1.__importDefault(require("../authRecipeWithEmailVerification"));
+var authRecipeWithEmailVerification_1 = __importDefault(require("../authRecipeWithEmailVerification"));
 var utils_1 = require("../../utils");
 var utils_2 = require("./utils");
-var normalisedURLPath_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
+var normalisedURLPath_1 = __importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
 var constants_1 = require("../../constants");
-var signInAndUp_1 = tslib_1.__importDefault(require("./components/features/signInAndUp"));
-var recipe_1 = tslib_1.__importDefault(require("../emailpassword/recipe"));
-var recipe_2 = tslib_1.__importDefault(require("../thirdparty/recipe"));
-var recipeImplementation_1 = tslib_1.__importDefault(require("./recipeImplementation"));
-var authWidgetWrapper_1 = tslib_1.__importDefault(require("../authRecipe/authWidgetWrapper"));
-var supertokens_js_override_1 = tslib_1.__importDefault(require("supertokens-js-override"));
-var emailPasswordImplementation_1 = tslib_1.__importDefault(
-    require("./recipeImplementation/emailPasswordImplementation")
-);
-var thirdPartyImplementation_1 = tslib_1.__importDefault(require("./recipeImplementation/thirdPartyImplementation"));
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../usercontext/userContextWrapper"));
+var signInAndUp_1 = __importDefault(require("./components/features/signInAndUp"));
+var recipe_1 = __importDefault(require("../emailpassword/recipe"));
+var recipe_2 = __importDefault(require("../thirdparty/recipe"));
+var recipeImplementation_1 = __importDefault(require("./recipeImplementation"));
+var authWidgetWrapper_1 = __importDefault(require("../authRecipe/authWidgetWrapper"));
+var supertokens_js_override_1 = __importDefault(require("supertokens-js-override"));
+var emailPasswordImplementation_1 = __importDefault(require("./recipeImplementation/emailPasswordImplementation"));
+var thirdPartyImplementation_1 = __importDefault(require("./recipeImplementation/thirdPartyImplementation"));
+var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
 var ThirdPartyEmailPassword = /** @class */ (function (_super) {
-    tslib_1.__extends(ThirdPartyEmailPassword, _super);
+    __extends(ThirdPartyEmailPassword, _super);
     function ThirdPartyEmailPassword(config, recipes) {
         var _this =
             _super.call(this, (0, utils_2.normaliseThirdPartyEmailPasswordConfig)(config), {
@@ -45,10 +217,10 @@ var ThirdPartyEmailPassword = /** @class */ (function (_super) {
         _this.getFeatures = function () {
             var features = {};
             if (_this.emailPasswordRecipe !== undefined) {
-                features = tslib_1.__assign(tslib_1.__assign({}, features), _this.emailPasswordRecipe.getFeatures());
+                features = __assign(__assign({}, features), _this.emailPasswordRecipe.getFeatures());
             }
             if (_this.thirdPartyRecipe !== undefined) {
-                features = tslib_1.__assign(tslib_1.__assign({}, features), _this.thirdPartyRecipe.getFeatures());
+                features = __assign(__assign({}, features), _this.thirdPartyRecipe.getFeatures());
             }
             if (_this.config.signInAndUpFeature.disableDefaultUI !== true) {
                 var normalisedFullPath = _this.config.appInfo.websiteBasePath.appendPath(
@@ -61,11 +233,11 @@ var ThirdPartyEmailPassword = /** @class */ (function (_super) {
                     },
                 };
             }
-            return tslib_1.__assign(tslib_1.__assign({}, features), _this.getAuthRecipeWithEmailVerificationFeatures());
+            return __assign(__assign({}, features), _this.getAuthRecipeWithEmailVerificationFeatures());
         };
         _this.getDefaultRedirectionURL = function (context) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     if (context.action === "RESET_PASSWORD") {
                         if (this.emailPasswordRecipe === undefined) {
                             throw new Error("Should not come here...");
@@ -82,17 +254,17 @@ var ThirdPartyEmailPassword = /** @class */ (function (_super) {
             if (componentName === "signinup") {
                 return (0, jsx_runtime_1.jsx)(
                     userContextWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         { userContext: props.userContext },
                         {
                             children: (0, jsx_runtime_1.jsx)(
                                 authWidgetWrapper_1.default,
-                                tslib_1.__assign(
+                                __assign(
                                     { authRecipe: _this, history: props.history },
                                     {
                                         children: (0, jsx_runtime_1.jsx)(
                                             signInAndUp_1.default,
-                                            tslib_1.__assign({ recipe: _this }, props)
+                                            __assign({ recipe: _this }, props)
                                         ),
                                     }
                                 )
@@ -197,10 +369,7 @@ var ThirdPartyEmailPassword = /** @class */ (function (_super) {
     ThirdPartyEmailPassword.init = function (config) {
         return function (appInfo) {
             ThirdPartyEmailPassword.instance = new ThirdPartyEmailPassword(
-                tslib_1.__assign(tslib_1.__assign({}, config), {
-                    appInfo: appInfo,
-                    recipeId: ThirdPartyEmailPassword.RECIPE_ID,
-                }),
+                __assign(__assign({}, config), { appInfo: appInfo, recipeId: ThirdPartyEmailPassword.RECIPE_ID }),
                 {
                     emailPasswordInstance: undefined,
                     emailVerificationInstance: undefined,

--- a/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/recipeImplementation/index.js
@@ -1,17 +1,166 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
-var recipeImplementation_1 = tslib_1.__importDefault(require("../../emailpassword/recipeImplementation"));
-var recipeImplementation_2 = tslib_1.__importDefault(require("../../thirdparty/recipeImplementation"));
-var emailPasswordImplementation_1 = tslib_1.__importDefault(require("./emailPasswordImplementation"));
-var thirdPartyImplementation_1 = tslib_1.__importDefault(require("./thirdPartyImplementation"));
+var recipeImplementation_1 = __importDefault(require("../../emailpassword/recipeImplementation"));
+var recipeImplementation_2 = __importDefault(require("../../thirdparty/recipeImplementation"));
+var emailPasswordImplementation_1 = __importDefault(require("./emailPasswordImplementation"));
+var thirdPartyImplementation_1 = __importDefault(require("./thirdPartyImplementation"));
 function getRecipeImplementation(recipeInput) {
-    var emailpasswordImpl = (0, recipeImplementation_1.default)(tslib_1.__assign({}, recipeInput));
-    var thirdPartyImpl = (0, recipeImplementation_2.default)(tslib_1.__assign({}, recipeInput));
+    var emailpasswordImpl = (0, recipeImplementation_1.default)(__assign({}, recipeInput));
+    var thirdPartyImpl = (0, recipeImplementation_2.default)(__assign({}, recipeInput));
     return {
         submitNewPassword: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [
                         2 /*return*/,
                         emailpasswordImpl.submitNewPassword.bind((0, emailPasswordImplementation_1.default)(this))(
@@ -22,8 +171,8 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         sendPasswordResetEmail: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [
                         2 /*return*/,
                         emailpasswordImpl.sendPasswordResetEmail.bind((0, emailPasswordImplementation_1.default)(this))(
@@ -34,8 +183,8 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         doesEmailExist: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [
                         2 /*return*/,
                         emailpasswordImpl.doesEmailExist.bind((0, emailPasswordImplementation_1.default)(this))(input),
@@ -49,8 +198,8 @@ function getRecipeImplementation(recipeInput) {
             )(input);
         },
         emailPasswordSignIn: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [
@@ -64,8 +213,8 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         emailPasswordSignUp: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [
                         2 /*return*/,
                         emailpasswordImpl.signUp.bind((0, emailPasswordImplementation_1.default)(this))(input),
@@ -74,8 +223,8 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         getAuthorisationURLFromBackend: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [
                         2 /*return*/,
                         thirdPartyImpl.getAuthorisationURLFromBackend.bind(
@@ -86,8 +235,8 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         getAuthorisationURLWithQueryParamsAndSetState: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [
                         2 /*return*/,
                         thirdPartyImpl.getAuthorisationURLWithQueryParamsAndSetState.bind(
@@ -98,8 +247,8 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         thirdPartySignInAndUp: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [

--- a/lib/build/recipe/thirdpartyemailpassword/thirdpartyEmailpasswordAuth.js
+++ b/lib/build/recipe/thirdpartyemailpassword/thirdpartyEmailpasswordAuth.js
@@ -1,30 +1,45 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var react_1 = require("react");
-var recipe_1 = tslib_1.__importDefault(require("./recipe"));
-var sessionAuth_1 = tslib_1.__importDefault(require("../session/sessionAuth"));
-var emailVerificationAuth_1 = tslib_1.__importDefault(require("../emailverification/emailVerificationAuth"));
-var superTokens_1 = tslib_1.__importDefault(require("../../superTokens"));
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../usercontext/userContextWrapper"));
+var recipe_1 = __importDefault(require("./recipe"));
+var sessionAuth_1 = __importDefault(require("../session/sessionAuth"));
+var emailVerificationAuth_1 = __importDefault(require("../emailverification/emailVerificationAuth"));
+var superTokens_1 = __importDefault(require("../../superTokens"));
+var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
 function ThirdPartyEmailPasswordAuth(props) {
     var emailVerification = (0, jsx_runtime_1.jsx)(
         emailVerificationAuth_1.default,
-        tslib_1.__assign(
-            { recipe: props.recipe.emailVerification, history: props.history },
-            { children: props.children }
-        )
+        __assign({ recipe: props.recipe.emailVerification, history: props.history }, { children: props.children })
     );
     if (props.requireAuth === false) {
         return (0, jsx_runtime_1.jsx)(
             sessionAuth_1.default,
-            tslib_1.__assign({ onSessionExpired: props.onSessionExpired }, { children: emailVerification })
+            __assign({ onSessionExpired: props.onSessionExpired }, { children: emailVerification })
         );
     }
     return (0, jsx_runtime_1.jsx)(
         sessionAuth_1.default,
-        tslib_1.__assign(
+        __assign(
             {
                 redirectToLogin: function () {
                     void recipe_1.default
@@ -48,12 +63,12 @@ var ThirdPartyEmailPasswordAuthWrapper = function (_a) {
     var history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
-        tslib_1.__assign(
+        __assign(
             { userContext: userContext },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     ThirdPartyEmailPasswordAuthMemo,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             history: history,
                             onSessionExpired: onSessionExpired,

--- a/lib/build/recipe/thirdpartyemailpassword/utils.js
+++ b/lib/build/recipe/thirdpartyemailpassword/utils.js
@@ -13,9 +13,22 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.normaliseThirdPartyEmailPasswordConfig = void 0;
-var tslib_1 = require("tslib");
 var utils_1 = require("../authRecipeWithEmailVerification/utils");
 /*
  * Methods.
@@ -30,7 +43,7 @@ function normaliseThirdPartyEmailPasswordConfig(config) {
     ) {
         throw new Error("You need to enable either email password or third party providers login.");
     }
-    var override = tslib_1.__assign(
+    var override = __assign(
         {
             functions: function (originalImplementation) {
                 return originalImplementation;
@@ -40,7 +53,7 @@ function normaliseThirdPartyEmailPasswordConfig(config) {
         config.override
     );
     var signInAndUpFeature = normaliseSignInUpFeatureConfig(config.signInAndUpFeature);
-    return tslib_1.__assign(tslib_1.__assign({}, (0, utils_1.normaliseAuthRecipeWithEmailVerificationConfig)(config)), {
+    return __assign(__assign({}, (0, utils_1.normaliseAuthRecipeWithEmailVerificationConfig)(config)), {
         signInAndUpFeature: signInAndUpFeature,
         oAuthCallbackScreen: config.oAuthCallbackScreen,
         resetPasswordUsingTokenFeature: config.resetPasswordUsingTokenFeature,
@@ -53,7 +66,7 @@ function normaliseSignInUpFeatureConfig(config) {
     var disableDefaultUI =
         config === undefined || config.disableDefaultUI === undefined ? false : config.disableDefaultUI;
     var defaultToSignUp = config === undefined || config.defaultToSignUp === undefined ? false : config.defaultToSignUp;
-    return tslib_1.__assign(tslib_1.__assign({}, config), {
+    return __assign(__assign({}, config), {
         disableDefaultUI: disableDefaultUI,
         defaultToSignUp: defaultToSignUp,
         style: config === undefined || config.style === undefined ? {} : config.style,

--- a/lib/build/recipe/thirdpartypasswordless/components/features/signInAndUp/index.js
+++ b/lib/build/recipe/thirdpartypasswordless/components/features/signInAndUp/index.js
@@ -1,6 +1,64 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,11 +77,11 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var React = tslib_1.__importStar(require("react"));
+var React = __importStar(require("react"));
 var react_1 = require("react");
-var featureWrapper_1 = tslib_1.__importDefault(require("../../../../../components/featureWrapper"));
+var featureWrapper_1 = __importDefault(require("../../../../../components/featureWrapper"));
 var componentOverrideContext_1 = require("../../../../../components/componentOverride/componentOverrideContext");
-var signInUp_1 = tslib_1.__importDefault(require("../../themes/signInUp"));
+var signInUp_1 = __importDefault(require("../../themes/signInUp"));
 var translations_1 = require("../../themes/translations");
 var signInAndUp_1 = require("../../../../thirdparty/components/features/signInAndUp");
 var signInAndUp_2 = require("../../../../passwordless/components/features/signInAndUp");
@@ -46,18 +104,18 @@ var SignInAndUp = function (props) {
                     // Intentionally fall through, both of these should clear the error
                     case "startLogin":
                     case "resendCode":
-                        return tslib_1.__assign(tslib_1.__assign({}, state), { error: undefined });
+                        return __assign(__assign({}, state), { error: undefined });
                     case "load":
                         if (action.loginAttemptInfo !== undefined) {
-                            return tslib_1.__assign(tslib_1.__assign({}, state), { error: action.error });
+                            return __assign(__assign({}, state), { error: action.error });
                         }
-                        return tslib_1.__assign(tslib_1.__assign({}, state), {
+                        return __assign(__assign({}, state), {
                             error: state.error !== undefined ? state.error : action.error,
                         });
                     // Intentionally fall through, both of these should set the error
                     case "restartFlow":
                     case "setError":
-                        return tslib_1.__assign(tslib_1.__assign({}, state), { error: action.error });
+                        return __assign(__assign({}, state), { error: action.error });
                     default:
                         return state;
                 }
@@ -120,12 +178,12 @@ var SignInAndUp = function (props) {
     };
     return (0, jsx_runtime_1.jsx)(
         componentOverrideContext_1.ComponentOverrideContext.Provider,
-        tslib_1.__assign(
+        __assign(
             { value: componentOverrides },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     featureWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             useShadowDom: props.recipe.config.useShadowDom,
                             defaultStore: translations_1.defaultTranslationsThirdPartyPasswordless,
@@ -134,7 +192,7 @@ var SignInAndUp = function (props) {
                             children: (0, jsx_runtime_1.jsxs)(react_1.Fragment, {
                                 children: [
                                     props.children === undefined &&
-                                        (0, jsx_runtime_1.jsx)(signInUp_1.default, tslib_1.__assign({}, childProps)),
+                                        (0, jsx_runtime_1.jsx)(signInUp_1.default, __assign({}, childProps)),
                                     props.children &&
                                         React.Children.map(props.children, function (child) {
                                             if (React.isValidElement(child)) {

--- a/lib/build/recipe/thirdpartypasswordless/components/themes/signInUp/header.js
+++ b/lib/build/recipe/thirdpartypasswordless/components/themes/signInUp/header.js
@@ -1,7 +1,25 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Header = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -23,7 +41,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var react_1 = require("react");
 var __1 = require("../../../../..");
 var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
-var styleContext_1 = tslib_1.__importDefault(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
 /*
  * Component.
  */
@@ -36,7 +54,7 @@ exports.Header = (0, withOverride_1.withOverride)(
             children: [
                 (0, jsx_runtime_1.jsx)(
                     "div",
-                    tslib_1.__assign(
+                    __assign(
                         { "data-supertokens": "headerTitle", css: styles.headerTitle },
                         { children: t("THIRD_PARTY_PASSWORDLESS_SIGN_IN_AND_UP_HEADER_TITLE") }
                     )

--- a/lib/build/recipe/thirdpartypasswordless/components/themes/signInUp/index.js
+++ b/lib/build/recipe/thirdpartypasswordless/components/themes/signInUp/index.js
@@ -1,6 +1,64 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,15 +77,15 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var React = tslib_1.__importStar(require("react"));
+var React = __importStar(require("react"));
 var header_1 = require("./header");
-var styleContext_1 = tslib_1.__importStar(require("../../../../../styles/styleContext"));
+var styleContext_1 = __importStar(require("../../../../../styles/styleContext"));
 var styles_1 = require("../../../../../styles/styles");
 var styles_2 = require("../styles");
 var signInUp_1 = require("../../../../passwordless/components/themes/signInUp");
 var themeBase_1 = require("../themeBase");
 var __1 = require("../../../../..");
-var generalError_1 = tslib_1.__importDefault(require("../../../../emailpassword/components/library/generalError"));
+var generalError_1 = __importDefault(require("../../../../emailpassword/components/library/generalError"));
 var providersForm_1 = require("../../../../thirdparty/components/themes/signInAndUp/providersForm");
 var closeTabScreen_1 = require("../../../../passwordless/components/themes/signInUp/closeTabScreen");
 var linkSent_1 = require("../../../../passwordless/components/themes/signInUp/linkSent");
@@ -41,24 +99,24 @@ var SignInUpTheme = function (props) {
     var t = (0, __1.useTranslation)();
     var styles = React.useContext(styleContext_1.default);
     if (props.activeScreen === signInUp_1.SignInUpScreens.CloseTab) {
-        return (0, jsx_runtime_1.jsx)(closeTabScreen_1.CloseTabScreen, tslib_1.__assign({}, props.pwlessChildProps));
+        return (0, jsx_runtime_1.jsx)(closeTabScreen_1.CloseTabScreen, __assign({}, props.pwlessChildProps));
     } else if (props.activeScreen === signInUp_1.SignInUpScreens.LinkSent) {
         return (0, jsx_runtime_1.jsx)(
             linkSent_1.LinkSent,
-            tslib_1.__assign({}, getCommonPwlessProps(props.pwlessChildProps, props), {
+            __assign({}, getCommonPwlessProps(props.pwlessChildProps, props), {
                 loginAttemptInfo: props.pwlessState.loginAttemptInfo,
             })
         );
     }
     return (0, jsx_runtime_1.jsxs)(
         "div",
-        tslib_1.__assign(
+        __assign(
             { "data-supertokens": "container", css: styles.container },
             {
                 children: [
                     (0, jsx_runtime_1.jsx)(
                         "div",
-                        tslib_1.__assign(
+                        __assign(
                             { "data-supertokens": "row", css: styles.row },
                             {
                                 children:
@@ -68,7 +126,7 @@ var SignInUpTheme = function (props) {
                                             props.activeScreen === signInUp_1.SignInUpScreens.UserInputCodeForm
                                                 ? (0, jsx_runtime_1.jsx)(
                                                       userInputCodeFormHeader_1.UserInputCodeFormHeader,
-                                                      tslib_1.__assign(
+                                                      __assign(
                                                           {},
                                                           getCommonPwlessProps(props.pwlessChildProps, props),
                                                           { loginAttemptInfo: props.pwlessState.loginAttemptInfo }
@@ -83,7 +141,7 @@ var SignInUpTheme = function (props) {
                                                 props.activeScreen !== signInUp_1.SignInUpScreens.UserInputCodeForm &&
                                                 (0, jsx_runtime_1.jsx)(
                                                     providersForm_1.ProvidersForm,
-                                                    tslib_1.__assign({}, props.tpChildProps, {
+                                                    __assign({}, props.tpChildProps, {
                                                         featureState: props.tpState,
                                                         dispatch: props.tpDispatch,
                                                     })
@@ -93,7 +151,7 @@ var SignInUpTheme = function (props) {
                                                 props.activeScreen !== signInUp_1.SignInUpScreens.UserInputCodeForm &&
                                                 (0, jsx_runtime_1.jsxs)(
                                                     "div",
-                                                    tslib_1.__assign(
+                                                    __assign(
                                                         {
                                                             "data-supertokens": "thirdPartyPasswordlessDivider",
                                                             css: styles.thirdPartyPasswordlessDivider,
@@ -106,7 +164,7 @@ var SignInUpTheme = function (props) {
                                                                 }),
                                                                 (0, jsx_runtime_1.jsx)(
                                                                     "div",
-                                                                    tslib_1.__assign(
+                                                                    __assign(
                                                                         {
                                                                             "data-supertokens":
                                                                                 "thirdPartyPasswordlessDividerText",
@@ -130,31 +188,22 @@ var SignInUpTheme = function (props) {
                                             props.activeScreen === signInUp_1.SignInUpScreens.EmailForm
                                                 ? (0, jsx_runtime_1.jsx)(
                                                       emailForm_1.EmailForm,
-                                                      tslib_1.__assign(
-                                                          {},
-                                                          getCommonPwlessProps(props.pwlessChildProps, props)
-                                                      )
+                                                      __assign({}, getCommonPwlessProps(props.pwlessChildProps, props))
                                                   )
                                                 : props.activeScreen === signInUp_1.SignInUpScreens.PhoneForm
                                                 ? (0, jsx_runtime_1.jsx)(
                                                       phoneForm_1.PhoneForm,
-                                                      tslib_1.__assign(
-                                                          {},
-                                                          getCommonPwlessProps(props.pwlessChildProps, props)
-                                                      )
+                                                      __assign({}, getCommonPwlessProps(props.pwlessChildProps, props))
                                                   )
                                                 : props.activeScreen === signInUp_1.SignInUpScreens.EmailOrPhoneForm
                                                 ? (0, jsx_runtime_1.jsx)(
                                                       emailOrPhoneForm_1.EmailOrPhoneForm,
-                                                      tslib_1.__assign(
-                                                          {},
-                                                          getCommonPwlessProps(props.pwlessChildProps, props)
-                                                      )
+                                                      __assign({}, getCommonPwlessProps(props.pwlessChildProps, props))
                                                   )
                                                 : props.activeScreen === signInUp_1.SignInUpScreens.UserInputCodeForm
                                                 ? (0, jsx_runtime_1.jsx)(
                                                       userInputCodeForm_1.UserInputCodeForm,
-                                                      tslib_1.__assign(
+                                                      __assign(
                                                           {},
                                                           getCommonPwlessProps(props.pwlessChildProps, props),
                                                           {
@@ -180,7 +229,7 @@ function SignInUpThemeWrapper(props) {
     // By defining it in a single object here TSC can deduce the connection between props
     var childProps =
         props.passwordlessRecipe !== undefined && props.pwlessChildProps !== undefined
-            ? tslib_1.__assign(tslib_1.__assign({}, props), {
+            ? __assign(__assign({}, props), {
                   activeScreen: (0, signInUp_1.getActiveScreen)({
                       config: props.pwlessChildProps.config,
                       featureState: props.pwlessState,
@@ -188,7 +237,7 @@ function SignInUpThemeWrapper(props) {
                   pwlessChildProps: props.pwlessChildProps,
                   passwordlessRecipe: props.passwordlessRecipe,
               })
-            : tslib_1.__assign(tslib_1.__assign({}, props), {
+            : __assign(__assign({}, props), {
                   activeScreen: undefined,
                   passwordlessRecipe: undefined,
                   pwlessChildProps: undefined,
@@ -207,12 +256,12 @@ function SignInUpThemeWrapper(props) {
     // This style provider will override the parent with the screen specific user config
     return (0, jsx_runtime_1.jsx)(
         themeBase_1.ThemeBase,
-        tslib_1.__assign(
+        __assign(
             { loadDefaultFont: !hasFont },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     styleContext_1.StyleProvider,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             rawPalette: props.config.palette,
                             defaultPalette: styles_1.defaultPalette,
@@ -220,7 +269,7 @@ function SignInUpThemeWrapper(props) {
                             rootStyleFromInit: props.config.rootStyle,
                             getDefaultStyles: styles_2.getStyles,
                         },
-                        { children: (0, jsx_runtime_1.jsx)(SignInUpTheme, tslib_1.__assign({}, childProps)) }
+                        { children: (0, jsx_runtime_1.jsx)(SignInUpTheme, __assign({}, childProps)) }
                     )
                 ),
             }

--- a/lib/build/recipe/thirdpartypasswordless/components/themes/translations.js
+++ b/lib/build/recipe/thirdpartypasswordless/components/themes/translations.js
@@ -1,13 +1,26 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.defaultTranslationsThirdPartyPasswordless = void 0;
-var tslib_1 = require("tslib");
 var translations_1 = require("../../../passwordless/components/themes/translations");
 var translations_2 = require("../../../thirdparty/components/themes/translations");
 exports.defaultTranslationsThirdPartyPasswordless = {
-    en: tslib_1.__assign(
-        tslib_1.__assign(
-            tslib_1.__assign({}, translations_2.defaultTranslationsThirdParty.en),
+    en: __assign(
+        __assign(
+            __assign({}, translations_2.defaultTranslationsThirdParty.en),
             translations_1.defaultTranslationsPasswordless.en
         ),
         {

--- a/lib/build/recipe/thirdpartypasswordless/index.js
+++ b/lib/build/recipe/thirdpartypasswordless/index.js
@@ -1,4 +1,194 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.PasswordlessLinkClicked =
     exports.EmailVerificationTheme =
@@ -40,7 +230,6 @@ exports.PasswordlessLinkClicked =
     exports.init =
     exports.ThirdPartyPasswordlessAuth =
         void 0;
-var tslib_1 = require("tslib");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
  * This software is licensed under the Apache License, Version 2.0 (the
@@ -55,12 +244,12 @@ var tslib_1 = require("tslib");
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var recipe_1 = tslib_1.__importDefault(require("./recipe"));
-var emailVerification_1 = tslib_1.__importDefault(require("../emailverification/components/themes/emailVerification"));
+var recipe_1 = __importDefault(require("./recipe"));
+var emailVerification_1 = __importDefault(require("../emailverification/components/themes/emailVerification"));
 exports.EmailVerificationTheme = emailVerification_1.default;
-var thirdpartyPasswordlessAuth_1 = tslib_1.__importDefault(require("./thirdpartyPasswordlessAuth"));
+var thirdpartyPasswordlessAuth_1 = __importDefault(require("./thirdpartyPasswordlessAuth"));
 exports.ThirdPartyPasswordlessAuth = thirdpartyPasswordlessAuth_1.default;
-var signInUp_1 = tslib_1.__importDefault(require("./components/themes/signInUp"));
+var signInUp_1 = __importDefault(require("./components/themes/signInUp"));
 exports.SignInUpTheme = signInUp_1.default;
 var thirdparty_1 = require("../thirdparty/");
 Object.defineProperty(exports, "Apple", {
@@ -90,15 +279,15 @@ Object.defineProperty(exports, "Github", {
 var linkClickedScreen_1 = require("../passwordless/components/themes/linkClickedScreen");
 var utils_1 = require("../../utils");
 var utils_2 = require("../thirdparty/utils");
-var PasswordlessUtilFunctions = tslib_1.__importStar(require("../passwordless/utils"));
+var PasswordlessUtilFunctions = __importStar(require("../passwordless/utils"));
 var Wrapper = /** @class */ (function () {
     function Wrapper() {}
     Wrapper.init = function (config) {
         return recipe_1.default.init(config);
     };
     Wrapper.signOut = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().signOut({
@@ -111,12 +300,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.isEmailVerified = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.isEmailVerified(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -127,12 +316,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.verifyEmail = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.verifyEmail(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -143,12 +332,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.sendVerificationEmail = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.sendVerificationEmail(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -160,7 +349,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getEmailVerificationTokenFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().emailVerification.recipeImpl.getEmailVerificationTokenFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -168,9 +357,9 @@ var Wrapper = /** @class */ (function () {
         );
     };
     Wrapper.redirectToThirdPartyLogin = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
+        return __awaiter(this, void 0, void 0, function () {
             var recipeInstance;
-            return tslib_1.__generator(this, function (_a) {
+            return __generator(this, function (_a) {
                 recipeInstance = recipe_1.default.getInstanceOrThrow();
                 if (recipeInstance.thirdPartyRecipe === undefined) {
                     throw new Error(
@@ -190,12 +379,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.getAuthorisationURLFromBackend = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.getAuthorisationURLFromBackend(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -204,12 +393,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.thirdPartySignInAndUp = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.thirdPartySignInAndUp(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -221,7 +410,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getThirdPartyStateAndOtherInfoFromStorage = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getThirdPartyStateAndOtherInfoFromStorage(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -229,12 +418,12 @@ var Wrapper = /** @class */ (function () {
         );
     };
     Wrapper.setThirdPartyStateAndOtherInfoToStorage = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.setThirdPartyStateAndOtherInfoToStorage(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -243,14 +432,14 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.getThirdPartyAuthorisationURLWithQueryParamsAndSetState = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default
                         .getInstanceOrThrow()
                         .recipeImpl.getThirdPartyAuthorisationURLWithQueryParamsAndSetState(
-                            tslib_1.__assign(tslib_1.__assign({}, input), {
+                            __assign(__assign({}, input), {
                                 userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                             })
                         ),
@@ -260,7 +449,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.generateThirdPartyStateToSendToOAuthProvider = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.generateThirdPartyStateToSendToOAuthProvider(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -268,12 +457,12 @@ var Wrapper = /** @class */ (function () {
         );
     };
     Wrapper.verifyAndGetThirdPartyStateOrThrowError = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.verifyAndGetThirdPartyStateOrThrowError(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -283,7 +472,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getThirdPartyAuthCodeFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getThirdPartyAuthCodeFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -292,7 +481,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getThirdPartyAuthErrorFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getThirdPartyAuthErrorFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -301,7 +490,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getThirdPartyAuthStateFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getThirdPartyAuthStateFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -309,9 +498,9 @@ var Wrapper = /** @class */ (function () {
         );
     };
     Wrapper.createPasswordlessCode = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
+        return __awaiter(this, void 0, void 0, function () {
             var recipe;
-            return tslib_1.__generator(this, function (_a) {
+            return __generator(this, function (_a) {
                 recipe = recipe_1.default.getInstanceOrThrow();
                 if (recipe.passwordlessRecipe === undefined) {
                     throw new Error(
@@ -321,18 +510,16 @@ var Wrapper = /** @class */ (function () {
                 return [
                     2 /*return*/,
                     PasswordlessUtilFunctions.createCode(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
-                            recipeImplementation: recipe.passwordlessRecipe.recipeImpl,
-                        })
+                        __assign(__assign({}, input), { recipeImplementation: recipe.passwordlessRecipe.recipeImpl })
                     ),
                 ];
             });
         });
     };
     Wrapper.resendPasswordlessCode = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
+        return __awaiter(this, void 0, void 0, function () {
             var recipe;
-            return tslib_1.__generator(this, function (_a) {
+            return __generator(this, function (_a) {
                 recipe = recipe_1.default.getInstanceOrThrow();
                 if (recipe.passwordlessRecipe === undefined) {
                     throw new Error(
@@ -342,18 +529,16 @@ var Wrapper = /** @class */ (function () {
                 return [
                     2 /*return*/,
                     PasswordlessUtilFunctions.resendCode(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
-                            recipeImplementation: recipe.passwordlessRecipe.recipeImpl,
-                        })
+                        __assign(__assign({}, input), { recipeImplementation: recipe.passwordlessRecipe.recipeImpl })
                     ),
                 ];
             });
         });
     };
     Wrapper.consumePasswordlessCode = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
+        return __awaiter(this, void 0, void 0, function () {
             var recipe;
-            return tslib_1.__generator(this, function (_a) {
+            return __generator(this, function (_a) {
                 recipe = recipe_1.default.getInstanceOrThrow();
                 if (recipe.passwordlessRecipe === undefined) {
                     throw new Error(
@@ -363,9 +548,7 @@ var Wrapper = /** @class */ (function () {
                 return [
                     2 /*return*/,
                     PasswordlessUtilFunctions.consumeCode(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
-                            recipeImplementation: recipe.passwordlessRecipe.recipeImpl,
-                        })
+                        __assign(__assign({}, input), { recipeImplementation: recipe.passwordlessRecipe.recipeImpl })
                     ),
                 ];
             });
@@ -373,7 +556,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getPasswordlessLinkCodeFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getPasswordlessLinkCodeFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -382,7 +565,7 @@ var Wrapper = /** @class */ (function () {
     };
     Wrapper.getPasswordlessPreAuthSessionIdFromURL = function (input) {
         return recipe_1.default.getInstanceOrThrow().recipeImpl.getPasswordlessPreAuthSessionIdFromURL(
-            tslib_1.__assign(tslib_1.__assign({}, input), {
+            __assign(__assign({}, input), {
                 userContext: (0, utils_1.getNormalisedUserContext)(
                     input === null || input === void 0 ? void 0 : input.userContext
                 ),
@@ -390,12 +573,12 @@ var Wrapper = /** @class */ (function () {
         );
     };
     Wrapper.doesPasswordlessUserEmailExist = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.doesPasswordlessUserEmailExist(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -404,12 +587,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.doesPasswordlessUserPhoneNumberExist = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.doesPasswordlessUserPhoneNumberExist(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(input.userContext),
                         })
                     ),
@@ -418,12 +601,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.getPasswordlessLoginAttemptInfo = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.getPasswordlessLoginAttemptInfo(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -434,12 +617,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.setPasswordlessLoginAttemptInfo = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.setPasswordlessLoginAttemptInfo(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -450,12 +633,12 @@ var Wrapper = /** @class */ (function () {
         });
     };
     Wrapper.clearPasswordlessLoginAttemptInfo = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 return [
                     2 /*return*/,
                     recipe_1.default.getInstanceOrThrow().recipeImpl.clearPasswordlessLoginAttemptInfo(
-                        tslib_1.__assign(tslib_1.__assign({}, input), {
+                        __assign(__assign({}, input), {
                             userContext: (0, utils_1.getNormalisedUserContext)(
                                 input === null || input === void 0 ? void 0 : input.userContext
                             ),
@@ -467,8 +650,8 @@ var Wrapper = /** @class */ (function () {
     };
     // have backwards compatibility to allow input as "signin" | "signup"
     Wrapper.redirectToAuth = function (input) {
-        return tslib_1.__awaiter(this, void 0, void 0, function () {
-            return tslib_1.__generator(this, function (_a) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
                 if (input === undefined || typeof input === "string") {
                     return [
                         2 /*return*/,

--- a/lib/build/recipe/thirdpartypasswordless/recipe.js
+++ b/lib/build/recipe/thirdpartypasswordless/recipe.js
@@ -1,6 +1,180 @@
 "use strict";
+var __extends =
+    (this && this.__extends) ||
+    (function () {
+        var extendStatics = function (d, b) {
+            extendStatics =
+                Object.setPrototypeOf ||
+                ({ __proto__: [] } instanceof Array &&
+                    function (d, b) {
+                        d.__proto__ = b;
+                    }) ||
+                function (d, b) {
+                    for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
+                };
+            return extendStatics(d, b);
+        };
+        return function (d, b) {
+            if (typeof b !== "function" && b !== null)
+                throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+            extendStatics(d, b);
+            function __() {
+                this.constructor = d;
+            }
+            d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+        };
+    })();
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,23 +193,21 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var authRecipeWithEmailVerification_1 = tslib_1.__importDefault(require("../authRecipeWithEmailVerification"));
+var authRecipeWithEmailVerification_1 = __importDefault(require("../authRecipeWithEmailVerification"));
 var utils_1 = require("../../utils");
 var utils_2 = require("./utils");
-var normalisedURLPath_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
+var normalisedURLPath_1 = __importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
 var constants_1 = require("../../constants");
-var signInAndUp_1 = tslib_1.__importDefault(require("./components/features/signInAndUp"));
-var recipe_1 = tslib_1.__importDefault(require("../passwordless/recipe"));
-var recipe_2 = tslib_1.__importDefault(require("../thirdparty/recipe"));
-var recipeImplementation_1 = tslib_1.__importDefault(require("./recipeImplementation"));
-var passwordlessImplementation_1 = tslib_1.__importDefault(
-    require("./recipeImplementation/passwordlessImplementation")
-);
-var thirdPartyImplementation_1 = tslib_1.__importDefault(require("./recipeImplementation/thirdPartyImplementation"));
-var authWidgetWrapper_1 = tslib_1.__importDefault(require("../authRecipe/authWidgetWrapper"));
-var supertokens_js_override_1 = tslib_1.__importDefault(require("supertokens-js-override"));
+var signInAndUp_1 = __importDefault(require("./components/features/signInAndUp"));
+var recipe_1 = __importDefault(require("../passwordless/recipe"));
+var recipe_2 = __importDefault(require("../thirdparty/recipe"));
+var recipeImplementation_1 = __importDefault(require("./recipeImplementation"));
+var passwordlessImplementation_1 = __importDefault(require("./recipeImplementation/passwordlessImplementation"));
+var thirdPartyImplementation_1 = __importDefault(require("./recipeImplementation/thirdPartyImplementation"));
+var authWidgetWrapper_1 = __importDefault(require("../authRecipe/authWidgetWrapper"));
+var supertokens_js_override_1 = __importDefault(require("supertokens-js-override"));
 var ThirdPartyPasswordless = /** @class */ (function (_super) {
-    tslib_1.__extends(ThirdPartyPasswordless, _super);
+    __extends(ThirdPartyPasswordless, _super);
     function ThirdPartyPasswordless(config, recipes) {
         var _this =
             _super.call(this, (0, utils_2.normaliseThirdPartyPasswordlessConfig)(config), {
@@ -45,10 +217,10 @@ var ThirdPartyPasswordless = /** @class */ (function (_super) {
             var _a, _b;
             var features = {};
             if (_this.passwordlessRecipe !== undefined) {
-                features = tslib_1.__assign(tslib_1.__assign({}, features), _this.passwordlessRecipe.getFeatures());
+                features = __assign(__assign({}, features), _this.passwordlessRecipe.getFeatures());
             }
             if (_this.thirdPartyRecipe !== undefined) {
-                features = tslib_1.__assign(tslib_1.__assign({}, features), _this.thirdPartyRecipe.getFeatures());
+                features = __assign(__assign({}, features), _this.thirdPartyRecipe.getFeatures());
             }
             if (
                 (_this.config.passwordlessUserInput !== undefined &&
@@ -70,11 +242,11 @@ var ThirdPartyPasswordless = /** @class */ (function (_super) {
                     },
                 };
             }
-            return tslib_1.__assign(tslib_1.__assign({}, features), _this.getAuthRecipeWithEmailVerificationFeatures());
+            return __assign(__assign({}, features), _this.getAuthRecipeWithEmailVerificationFeatures());
         };
         _this.getDefaultRedirectionURL = function (context) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [2 /*return*/, this.getAuthRecipeWithEmailVerificationDefaultRedirectionURL(context)];
                 });
             });
@@ -83,14 +255,9 @@ var ThirdPartyPasswordless = /** @class */ (function (_super) {
             if (componentName === "signInUp") {
                 return (0, jsx_runtime_1.jsx)(
                     authWidgetWrapper_1.default,
-                    tslib_1.__assign(
+                    __assign(
                         { authRecipe: _this, history: props.history },
-                        {
-                            children: (0, jsx_runtime_1.jsx)(
-                                signInAndUp_1.default,
-                                tslib_1.__assign({ recipe: _this }, props)
-                            ),
-                        }
+                        { children: (0, jsx_runtime_1.jsx)(signInAndUp_1.default, __assign({ recipe: _this }, props)) }
                     )
                 );
             } else if (componentName === "linkClickedScreen") {
@@ -129,17 +296,14 @@ var ThirdPartyPasswordless = /** @class */ (function (_super) {
                 : _this.config.passwordlessUserInput === undefined
                 ? undefined
                 : new recipe_1.default(
-                      tslib_1.__assign(tslib_1.__assign({}, _this.config.passwordlessUserInput), {
+                      __assign(__assign({}, _this.config.passwordlessUserInput), {
                           appInfo: _this.config.appInfo,
                           recipeId: _this.config.recipeId,
-                          override: tslib_1.__assign(
-                              tslib_1.__assign({}, _this.config.passwordlessUserInput.override),
-                              {
-                                  functions: function () {
-                                      return (0, passwordlessImplementation_1.default)(_this.recipeImpl);
-                                  },
-                              }
-                          ),
+                          override: __assign(__assign({}, _this.config.passwordlessUserInput.override), {
+                              functions: function () {
+                                  return (0, passwordlessImplementation_1.default)(_this.recipeImpl);
+                              },
+                          }),
                       })
                   );
         // we initialise this recipe only if the user has provided thirdparty
@@ -150,10 +314,10 @@ var ThirdPartyPasswordless = /** @class */ (function (_super) {
                 : _this.config.thirdpartyUserInput === undefined
                 ? undefined
                 : new recipe_2.default(
-                      tslib_1.__assign(tslib_1.__assign({}, _this.config.thirdpartyUserInput), {
+                      __assign(__assign({}, _this.config.thirdpartyUserInput), {
                           appInfo: _this.config.appInfo,
                           recipeId: _this.config.recipeId,
-                          override: tslib_1.__assign(tslib_1.__assign({}, _this.config.thirdpartyUserInput.override), {
+                          override: __assign(__assign({}, _this.config.thirdpartyUserInput.override), {
                               functions: function () {
                                   return (0, thirdPartyImplementation_1.default)(_this.recipeImpl);
                               },
@@ -171,10 +335,7 @@ var ThirdPartyPasswordless = /** @class */ (function (_super) {
     ThirdPartyPasswordless.init = function (config) {
         return function (appInfo) {
             ThirdPartyPasswordless.instance = new ThirdPartyPasswordless(
-                tslib_1.__assign(tslib_1.__assign({}, config), {
-                    appInfo: appInfo,
-                    recipeId: ThirdPartyPasswordless.RECIPE_ID,
-                }),
+                __assign(__assign({}, config), { appInfo: appInfo, recipeId: ThirdPartyPasswordless.RECIPE_ID }),
                 {
                     passwordlessInstance: undefined,
                     emailVerificationInstance: undefined,

--- a/lib/build/recipe/thirdpartypasswordless/recipeImplementation/index.js
+++ b/lib/build/recipe/thirdpartypasswordless/recipeImplementation/index.js
@@ -1,13 +1,162 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
-var recipeImplementation_1 = tslib_1.__importDefault(require("../../passwordless/recipeImplementation"));
-var recipeImplementation_2 = tslib_1.__importDefault(require("../../thirdparty/recipeImplementation"));
-var passwordlessImplementation_1 = tslib_1.__importDefault(require("./passwordlessImplementation"));
-var thirdPartyImplementation_1 = tslib_1.__importDefault(require("./thirdPartyImplementation"));
+var recipeImplementation_1 = __importDefault(require("../../passwordless/recipeImplementation"));
+var recipeImplementation_2 = __importDefault(require("../../thirdparty/recipeImplementation"));
+var passwordlessImplementation_1 = __importDefault(require("./passwordlessImplementation"));
+var thirdPartyImplementation_1 = __importDefault(require("./thirdPartyImplementation"));
 function getRecipeImplementation(recipeInput) {
-    var passwordlessImpl = (0, recipeImplementation_1.default)(tslib_1.__assign({}, recipeInput));
-    var thirdPartyImpl = (0, recipeImplementation_2.default)(tslib_1.__assign({}, recipeInput));
+    var passwordlessImpl = (0, recipeImplementation_1.default)(__assign({}, recipeInput));
+    var thirdPartyImpl = (0, recipeImplementation_2.default)(__assign({}, recipeInput));
     return {
         consumePasswordlessCode: function (input) {
             return passwordlessImpl.consumeCode.bind((0, passwordlessImplementation_1.default)(this))(input);
@@ -19,8 +168,8 @@ function getRecipeImplementation(recipeInput) {
             return passwordlessImpl.doesPhoneNumberExist.bind((0, passwordlessImplementation_1.default)(this))(input);
         },
         doesPasswordlessUserEmailExist: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [
                         2 /*return*/,
                         passwordlessImpl.doesEmailExist.bind((0, passwordlessImplementation_1.default)(this))(input),
@@ -49,8 +198,8 @@ function getRecipeImplementation(recipeInput) {
             );
         },
         getAuthorisationURLFromBackend: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [
                         2 /*return*/,
                         thirdPartyImpl.getAuthorisationURLFromBackend.bind(
@@ -61,8 +210,8 @@ function getRecipeImplementation(recipeInput) {
             });
         },
         thirdPartySignInAndUp: function (input) {
-            return tslib_1.__awaiter(this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     return [
                         2 /*return*/,
                         thirdPartyImpl.signInAndUp.bind((0, thirdPartyImplementation_1.default)(this))(input),

--- a/lib/build/recipe/thirdpartypasswordless/thirdpartyPasswordlessAuth.js
+++ b/lib/build/recipe/thirdpartypasswordless/thirdpartyPasswordlessAuth.js
@@ -1,30 +1,45 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var react_1 = require("react");
-var recipe_1 = tslib_1.__importDefault(require("./recipe"));
-var sessionAuth_1 = tslib_1.__importDefault(require("../session/sessionAuth"));
-var emailVerificationAuth_1 = tslib_1.__importDefault(require("../emailverification/emailVerificationAuth"));
-var superTokens_1 = tslib_1.__importDefault(require("../../superTokens"));
-var userContextWrapper_1 = tslib_1.__importDefault(require("../../usercontext/userContextWrapper"));
+var recipe_1 = __importDefault(require("./recipe"));
+var sessionAuth_1 = __importDefault(require("../session/sessionAuth"));
+var emailVerificationAuth_1 = __importDefault(require("../emailverification/emailVerificationAuth"));
+var superTokens_1 = __importDefault(require("../../superTokens"));
+var userContextWrapper_1 = __importDefault(require("../../usercontext/userContextWrapper"));
 function ThirdPartyPasswordlessAuth(props) {
     var emailVerification = (0, jsx_runtime_1.jsx)(
         emailVerificationAuth_1.default,
-        tslib_1.__assign(
-            { recipe: props.recipe.emailVerification, history: props.history },
-            { children: props.children }
-        )
+        __assign({ recipe: props.recipe.emailVerification, history: props.history }, { children: props.children })
     );
     if (props.requireAuth === false) {
         return (0, jsx_runtime_1.jsx)(
             sessionAuth_1.default,
-            tslib_1.__assign({ onSessionExpired: props.onSessionExpired }, { children: emailVerification })
+            __assign({ onSessionExpired: props.onSessionExpired }, { children: emailVerification })
         );
     }
     return (0, jsx_runtime_1.jsx)(
         sessionAuth_1.default,
-        tslib_1.__assign(
+        __assign(
             {
                 redirectToLogin: function () {
                     void recipe_1.default
@@ -48,12 +63,12 @@ var ThirdPartyPasswordlessAuthWrapper = function (_a) {
     var history = routerInfo === undefined ? undefined : routerInfo.useHistoryCustom();
     return (0, jsx_runtime_1.jsx)(
         userContextWrapper_1.default,
-        tslib_1.__assign(
+        __assign(
             { userContext: userContext },
             {
                 children: (0, jsx_runtime_1.jsx)(
                     ThirdPartyPasswordlessAuthMemo,
-                    tslib_1.__assign(
+                    __assign(
                         {
                             history: history,
                             onSessionExpired: onSessionExpired,

--- a/lib/build/recipe/thirdpartypasswordless/utils.js
+++ b/lib/build/recipe/thirdpartypasswordless/utils.js
@@ -13,9 +13,22 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.normaliseThirdPartyPasswordlessConfig = void 0;
-var tslib_1 = require("tslib");
 var utils_1 = require("../authRecipeWithEmailVerification/utils");
 function normaliseThirdPartyPasswordlessConfig(config) {
     var _a;
@@ -27,7 +40,7 @@ function normaliseThirdPartyPasswordlessConfig(config) {
     if (disablePasswordless && disableThirdParty) {
         throw new Error("You need to enable either passwordless or third party providers login.");
     }
-    var override = tslib_1.__assign(
+    var override = __assign(
         {
             functions: function (originalImplementation) {
                 return originalImplementation;
@@ -44,7 +57,7 @@ function normaliseThirdPartyPasswordlessConfig(config) {
             : config === null || config === void 0
             ? void 0
             : config.signInUpFeature.thirdPartyProviderAndEmailOrPhoneFormStyle;
-    return tslib_1.__assign(tslib_1.__assign({}, (0, utils_1.normaliseAuthRecipeWithEmailVerificationConfig)(config)), {
+    return __assign(__assign({}, (0, utils_1.normaliseAuthRecipeWithEmailVerificationConfig)(config)), {
         thirdPartyProviderAndEmailOrPhoneFormStyle: thirdPartyProviderAndEmailOrPhoneFormStyle,
         thirdpartyUserInput: disableThirdParty
             ? undefined
@@ -55,7 +68,7 @@ function normaliseThirdPartyPasswordlessConfig(config) {
                   onHandleEvent: config.onHandleEvent,
                   palette: config.palette,
                   preAPIHook: config.preAPIHook,
-                  signInAndUpFeature: tslib_1.__assign(tslib_1.__assign({}, config.signInUpFeature), {
+                  signInAndUpFeature: __assign(__assign({}, config.signInUpFeature), {
                       style: thirdPartyProviderAndEmailOrPhoneFormStyle,
                   }),
                   oAuthCallbackScreen: config.oAuthCallbackScreen,
@@ -76,7 +89,7 @@ function normaliseThirdPartyPasswordlessConfig(config) {
                   palette: config.palette,
                   preAPIHook: config.preAPIHook,
                   useShadowDom: config.useShadowDom,
-                  signInUpFeature: tslib_1.__assign(tslib_1.__assign({}, config.signInUpFeature), {
+                  signInUpFeature: __assign(__assign({}, config.signInUpFeature), {
                       emailOrPhoneFormStyle: thirdPartyProviderAndEmailOrPhoneFormStyle,
                   }),
                   linkClickedScreenFeature: config.linkClickedScreenFeature,

--- a/lib/build/styles/styleContext.js
+++ b/lib/build/styles/styleContext.js
@@ -1,9 +1,27 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.StyleProvider = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
-var react_1 = tslib_1.__importDefault(require("react"));
+var react_1 = __importDefault(require("react"));
 var styles_1 = require("./styles");
 var StyleContext = react_1.default.createContext({
     palette: {
@@ -32,9 +50,9 @@ var StyleProvider = function (_a) {
         delete styleFromInit.palette;
         mergedStyles = (0, styles_1.getMergedStyles)(mergedStyles, styleFromInit);
     }
-    var value = tslib_1.__assign({ palette: palette }, mergedStyles);
+    var value = __assign({ palette: palette }, mergedStyles);
     value = addNameToAllStylesRecursively(value, "");
-    return (0, jsx_runtime_1.jsx)(StyleContext.Provider, tslib_1.__assign({ value: value }, { children: children }));
+    return (0, jsx_runtime_1.jsx)(StyleContext.Provider, __assign({ value: value }, { children: children }));
 };
 exports.StyleProvider = StyleProvider;
 /*
@@ -44,7 +62,7 @@ exports.StyleProvider = StyleProvider;
  * See https://github.com/supertokens/supertokens-auth-react/issues/354
  * */
 function addNameToAllStylesRecursively(styles, propertyName) {
-    styles = tslib_1.__assign({ name: "-supertokens-efix-" + propertyName }, styles);
+    styles = __assign({ name: "-supertokens-efix-" + propertyName }, styles);
     for (var property in styles) {
         // eslint-disable-next-line no-prototype-builtins
         if (styles.hasOwnProperty(property)) {
@@ -57,10 +75,7 @@ function addNameToAllStylesRecursively(styles, propertyName) {
 }
 function getMergedPalette(defaultPalette, rawPalette) {
     // We copy the defaultPalette into in order to not update the original
-    var palette = {
-        colors: tslib_1.__assign({}, defaultPalette.colors),
-        fonts: tslib_1.__assign({}, defaultPalette.fonts),
-    };
+    var palette = { colors: __assign({}, defaultPalette.colors), fonts: __assign({}, defaultPalette.fonts) };
     for (var key in palette.colors) {
         if (rawPalette[key] !== undefined) {
             palette.colors[key] = rawPalette[key];

--- a/lib/build/styles/styles.js
+++ b/lib/build/styles/styles.js
@@ -13,6 +13,35 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __makeTemplateObject =
+    (this && this.__makeTemplateObject) ||
+    function (cooked, raw) {
+        if (Object.defineProperty) {
+            Object.defineProperty(cooked, "raw", { value: raw });
+        } else {
+            cooked.raw = raw;
+        }
+        return cooked;
+    };
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.hasFontDefined =
     exports.getMergedStyles =
@@ -22,9 +51,8 @@ exports.hasFontDefined =
     exports.slideTop =
     exports.defaultPalette =
         void 0;
-var tslib_1 = require("tslib");
 var react_1 = require("@emotion/react");
-var chroma_js_1 = tslib_1.__importDefault(require("chroma-js"));
+var chroma_js_1 = __importDefault(require("chroma-js"));
 /*
  * Palette
  */
@@ -54,7 +82,7 @@ exports.defaultPalette = {
  */
 exports.slideTop = (0, react_1.keyframes)(
     templateObject_1 ||
-        (templateObject_1 = tslib_1.__makeTemplateObject(
+        (templateObject_1 = __makeTemplateObject(
             [
                 "\n    0% {\n        transform: translateY(-5px);\n    }\n    100% {\n        transform: translateY(0px);\n    }\n",
             ],
@@ -65,7 +93,7 @@ exports.slideTop = (0, react_1.keyframes)(
 );
 exports.swingIn = (0, react_1.keyframes)(
     templateObject_2 ||
-        (templateObject_2 = tslib_1.__makeTemplateObject(
+        (templateObject_2 = __makeTemplateObject(
             [
                 "\n0% {\n    -webkit-transform: rotateX(-100deg);\n            transform: rotateX(-100deg);\n    -webkit-transform-origin: top;\n            transform-origin: top;\n    opacity: 0;\n  }\n  100% {\n    -webkit-transform: rotateX(0deg);\n            transform: rotateX(0deg);\n    -webkit-transform-origin: top;\n            transform-origin: top;\n    opacity: 1;\n  }\n}\n@keyframes swing-in-top-fwd {\n  0% {\n    -webkit-transform: rotateX(-100deg);\n            transform: rotateX(-100deg);\n    -webkit-transform-origin: top;\n            transform-origin: top;\n    opacity: 0;\n  }\n  100% {\n    -webkit-transform: rotateX(0deg);\n            transform: rotateX(0deg);\n    -webkit-transform-origin: top;\n            transform-origin: top;\n    opacity: 1;\n  }\n",
             ],
@@ -264,7 +292,7 @@ exports.getButtonStyle = getButtonStyle;
 function getMergedStyles(defaultStyles, themeStyles) {
     var styles = defaultStyles;
     for (var key in themeStyles) {
-        styles[key] = tslib_1.__assign(tslib_1.__assign({}, styles[key]), themeStyles[key]);
+        styles[key] = __assign(__assign({}, styles[key]), themeStyles[key]);
     }
     return styles;
 }

--- a/lib/build/superTokens.js
+++ b/lib/build/superTokens.js
@@ -1,6 +1,176 @@
 "use strict";
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -19,7 +189,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /*
  * Imports.
  */
-var React = tslib_1.__importStar(require("react"));
+var React = __importStar(require("react"));
 var utils_1 = require("./utils");
 var superTokensRoute_1 = require("./components/superTokensRoute");
 var superTokensRouteV6_1 = require("./components/superTokensRouteV6");
@@ -93,8 +263,8 @@ var SuperTokens = /** @class */ (function () {
             return SuperTokens.reactRouterDom;
         };
         this.changeLanguage = function (lang) {
-            return tslib_1.__awaiter(_this, void 0, void 0, function () {
-                return tslib_1.__generator(this, function (_a) {
+            return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
                             return [

--- a/lib/build/translation/translationContext.js
+++ b/lib/build/translation/translationContext.js
@@ -1,9 +1,193 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.TranslationContextProvider = exports.useTranslation = exports.TranslationContext = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
-var react_1 = tslib_1.__importStar(require("react"));
+var react_1 = __importStar(require("react"));
 var translationHelpers_1 = require("./translationHelpers");
 var utils_1 = require("../utils");
 var errCB = function () {
@@ -31,9 +215,9 @@ var TranslationContextProvider = function (_a) {
     (0, react_1.useEffect)(
         function () {
             function loadLanguageFromCookies() {
-                return tslib_1.__awaiter(this, void 0, void 0, function () {
+                return __awaiter(this, void 0, void 0, function () {
                     var cookieLang, cookieLangTemp;
-                    return tslib_1.__generator(this, function (_a) {
+                    return __generator(this, function (_a) {
                         switch (_a.label) {
                             case 0:
                                 return [4 /*yield*/, (0, translationHelpers_1.getCurrentLanguageFromCookie)()];
@@ -102,7 +286,7 @@ var TranslationContextProvider = function (_a) {
     }
     return (0, jsx_runtime_1.jsx)(
         exports.TranslationContext.Provider,
-        tslib_1.__assign({ value: { translate: translateFunc } }, { children: children })
+        __assign({ value: { translate: translateFunc } }, { children: children })
     );
 };
 exports.TranslationContextProvider = TranslationContextProvider;

--- a/lib/build/translation/translationHelpers.js
+++ b/lib/build/translation/translationHelpers.js
@@ -1,7 +1,137 @@
 "use strict";
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getCurrentLanguageFromCookie = exports.saveCurrentLanguage = exports.TranslationController = void 0;
-var tslib_1 = require("tslib");
 var utils_1 = require("../utils");
 var TranslationController = /** @class */ (function () {
     function TranslationController() {
@@ -32,9 +162,9 @@ var TranslationController = /** @class */ (function () {
 exports.TranslationController = TranslationController;
 var CURRENT_LANGUAGE_COOKIE_NAME = "sCurrLanguage";
 function saveCurrentLanguage(language, cookieDomain) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
+    return __awaiter(this, void 0, void 0, function () {
         var _a;
-        return tslib_1.__generator(this, function (_b) {
+        return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
                     _b.trys.push([0, 2, , 3]);
@@ -56,9 +186,9 @@ function saveCurrentLanguage(language, cookieDomain) {
 }
 exports.saveCurrentLanguage = saveCurrentLanguage;
 function getCurrentLanguageFromCookie() {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
+    return __awaiter(this, void 0, void 0, function () {
         var _a;
-        return tslib_1.__generator(this, function (_b) {
+        return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
                     _b.trys.push([0, 2, , 3]);

--- a/lib/build/usercontext/index.js
+++ b/lib/build/usercontext/index.js
@@ -1,7 +1,60 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __createBinding =
+    (this && this.__createBinding) ||
+    (Object.create
+        ? function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              var desc = Object.getOwnPropertyDescriptor(m, k);
+              if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+                  desc = {
+                      enumerable: true,
+                      get: function () {
+                          return m[k];
+                      },
+                  };
+              }
+              Object.defineProperty(o, k2, desc);
+          }
+        : function (o, m, k, k2) {
+              if (k2 === undefined) k2 = k;
+              o[k2] = m[k];
+          });
+var __setModuleDefault =
+    (this && this.__setModuleDefault) ||
+    (Object.create
+        ? function (o, v) {
+              Object.defineProperty(o, "default", { enumerable: true, value: v });
+          }
+        : function (o, v) {
+              o["default"] = v;
+          });
+var __importStar =
+    (this && this.__importStar) ||
+    function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null)
+            for (var k in mod)
+                if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.UserContextProvider = exports.useUserContext = exports.UserContextContext = void 0;
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 /* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -17,7 +70,7 @@ var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var react_1 = tslib_1.__importStar(require("react"));
+var react_1 = __importStar(require("react"));
 var utils_1 = require("../utils");
 exports.UserContextContext = react_1.default.createContext(undefined);
 var useUserContext = function () {
@@ -30,7 +83,7 @@ var UserContextProvider = function (_a) {
     var currentUserContext = (0, react_1.useState)((0, utils_1.getNormalisedUserContext)(userContext))[0];
     return (0, jsx_runtime_1.jsx)(
         exports.UserContextContext.Provider,
-        tslib_1.__assign({ value: currentUserContext }, { children: children })
+        __assign({ value: currentUserContext }, { children: children })
     );
 };
 exports.UserContextProvider = UserContextProvider;

--- a/lib/build/usercontext/userContextWrapper.js
+++ b/lib/build/usercontext/userContextWrapper.js
@@ -1,6 +1,19 @@
 "use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
-var tslib_1 = require("tslib");
 var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
 var _1 = require(".");
 function UserContextWrapper(props) {
@@ -14,7 +27,7 @@ function UserContextWrapper(props) {
     if (props.userContext !== undefined) {
         return (0, jsx_runtime_1.jsx)(
             _1.UserContextProvider,
-            tslib_1.__assign({ userContext: props.userContext }, { children: props.children })
+            __assign({ userContext: props.userContext }, { children: props.children })
         );
     }
     return (0, jsx_runtime_1.jsx)(_1.UserContextContext.Consumer, {

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -13,6 +13,156 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __awaiter =
+    (this && this.__awaiter) ||
+    function (thisArg, _arguments, P, generator) {
+        function adopt(value) {
+            return value instanceof P
+                ? value
+                : new P(function (resolve) {
+                      resolve(value);
+                  });
+        }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) {
+                try {
+                    step(generator.next(value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function rejected(value) {
+                try {
+                    step(generator["throw"](value));
+                } catch (e) {
+                    reject(e);
+                }
+            }
+            function step(result) {
+                result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+            }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+var __generator =
+    (this && this.__generator) ||
+    function (thisArg, body) {
+        var _ = {
+                label: 0,
+                sent: function () {
+                    if (t[0] & 1) throw t[1];
+                    return t[1];
+                },
+                trys: [],
+                ops: [],
+            },
+            f,
+            y,
+            t,
+            g;
+        return (
+            (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+            typeof Symbol === "function" &&
+                (g[Symbol.iterator] = function () {
+                    return this;
+                }),
+            g
+        );
+        function verb(n) {
+            return function (v) {
+                return step([n, v]);
+            };
+        }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_)
+                try {
+                    if (
+                        ((f = 1),
+                        y &&
+                            (t =
+                                op[0] & 2
+                                    ? y["return"]
+                                    : op[0]
+                                    ? y["throw"] || ((t = y["return"]) && t.call(y), 0)
+                                    : y.next) &&
+                            !(t = t.call(y, op[1])).done)
+                    )
+                        return t;
+                    if (((y = 0), t)) op = [op[0] & 2, t.value];
+                    switch (op[0]) {
+                        case 0:
+                        case 1:
+                            t = op;
+                            break;
+                        case 4:
+                            _.label++;
+                            return { value: op[1], done: false };
+                        case 5:
+                            _.label++;
+                            y = op[1];
+                            op = [0];
+                            continue;
+                        case 7:
+                            op = _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                        default:
+                            if (
+                                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                                (op[0] === 6 || op[0] === 2)
+                            ) {
+                                _ = 0;
+                                continue;
+                            }
+                            if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                                _.label = op[1];
+                                break;
+                            }
+                            if (op[0] === 6 && _.label < t[1]) {
+                                _.label = t[1];
+                                t = op;
+                                break;
+                            }
+                            if (t && _.label < t[2]) {
+                                _.label = t[2];
+                                _.ops.push(op);
+                                break;
+                            }
+                            if (t[2]) _.ops.pop();
+                            _.trys.pop();
+                            continue;
+                    }
+                    op = body.call(thisArg, _);
+                } catch (e) {
+                    op = [6, e];
+                    y = 0;
+                } finally {
+                    f = t = 0;
+                }
+            if (op[0] & 5) throw op[1];
+            return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.useOnMountAPICall =
     exports.getNormalisedUserContext =
@@ -41,12 +191,11 @@ exports.useOnMountAPICall =
     exports.clearQueryParams =
     exports.getRecipeIdFromSearch =
         void 0;
-var tslib_1 = require("tslib");
 var react_1 = require("react");
 var constants_1 = require("./constants");
 var cookieHandler_1 = require("supertokens-website/utils/cookieHandler");
-var normalisedURLDomain_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/normalisedURLDomain"));
-var normalisedURLPath_1 = tslib_1.__importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
+var normalisedURLDomain_1 = __importDefault(require("supertokens-web-js/utils/normalisedURLDomain"));
+var normalisedURLPath_1 = __importDefault(require("supertokens-web-js/utils/normalisedURLPath"));
 var windowHandler_1 = require("supertokens-website/utils/windowHandler");
 /*
  * getRecipeIdFromPath
@@ -154,9 +303,9 @@ function getNormalisedURLPathOrDefault(defaultPath, path) {
 // We check that the number of fields in input and config form field is the same.
 // We check that each item in the config form field is also present in the input form field
 function validateForm(inputs, configFormFields) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
+    return __awaiter(this, void 0, void 0, function () {
         var validationErrors, _loop_1, i;
-        return tslib_1.__generator(this, function (_a) {
+        return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
                     validationErrors = [];
@@ -165,7 +314,7 @@ function validateForm(inputs, configFormFields) {
                     }
                     _loop_1 = function (i) {
                         var field, input, value, error;
-                        return tslib_1.__generator(this, function (_b) {
+                        return __generator(this, function (_b) {
                             switch (_b.label) {
                                 case 0:
                                     field = configFormFields[i];
@@ -288,9 +437,9 @@ function getOriginOfPage() {
 }
 exports.getOriginOfPage = getOriginOfPage;
 function getLocalStorage(key) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
+    return __awaiter(this, void 0, void 0, function () {
         var res;
-        return tslib_1.__generator(this, function (_a) {
+        return __generator(this, function (_a) {
             res = windowHandler_1.WindowHandlerReference.getReferenceOrThrow().windowHandler.localStorage.getItem(key);
             if (res === null || res === undefined) {
                 return [2 /*return*/, null];
@@ -301,8 +450,8 @@ function getLocalStorage(key) {
 }
 exports.getLocalStorage = getLocalStorage;
 function setLocalStorage(key, value) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
-        return tslib_1.__generator(this, function (_a) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
                     return [
@@ -321,8 +470,8 @@ function setLocalStorage(key, value) {
 }
 exports.setLocalStorage = setLocalStorage;
 function removeFromLocalStorage(key) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
-        return tslib_1.__generator(this, function (_a) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
                     return [
@@ -340,7 +489,7 @@ function removeFromLocalStorage(key) {
 }
 exports.removeFromLocalStorage = removeFromLocalStorage;
 function mergeObjects(obj1, obj2) {
-    var res = tslib_1.__assign({}, obj1);
+    var res = __assign({}, obj1);
     for (var key in obj2) {
         if (typeof res[key] === "object" && typeof obj2[key] === "object") {
             res[key] = mergeObjects(res[key], obj2[key]);
@@ -399,9 +548,9 @@ function getDefaultCookieScope() {
 }
 exports.getDefaultCookieScope = getDefaultCookieScope;
 function getCookieValue(name) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
+    return __awaiter(this, void 0, void 0, function () {
         var value, _a, parts, last, temp;
-        return tslib_1.__generator(this, function (_b) {
+        return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
                     _a = "; ";
@@ -430,9 +579,9 @@ function getCookieValue(name) {
 exports.getCookieValue = getCookieValue;
 // undefined value will remove the cookie
 function setFrontendCookie(name, value, scope) {
-    return tslib_1.__awaiter(this, void 0, void 0, function () {
+    return __awaiter(this, void 0, void 0, function () {
         var expires, cookieVal;
-        return tslib_1.__generator(this, function (_a) {
+        return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
                     expires = "Thu, 01 Jan 1970 00:00:01 GMT";
@@ -518,9 +667,9 @@ var useOnMountAPICall = function (fetch, handleResponse, handleError) {
     (0, react_1.useEffect)(
         function () {
             var effect = function (signal) {
-                return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+                return __awaiter(void 0, void 0, void 0, function () {
                     var resp, err_1;
-                    return tslib_1.__generator(this, function (_a) {
+                    return __generator(this, function (_a) {
                         switch (_a.label) {
                             case 0:
                                 _a.trys.push([0, 2, , 3]);

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -18,7 +18,7 @@
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "noImplicitReturns": true,
-        "importHelpers": true,
+        "importHelpers": false,
         "noFallthroughCasesInSwitch": true,
         "types": ["node", "react", "@emotion/react/types/css-prop"]
     },

--- a/package.json
+++ b/package.json
@@ -112,23 +112,23 @@
         },
         {
             "path": "recipe/thirdpartyemailpassword/index.js",
-            "limit": "124kb"
+            "limit": "130kb"
         },
         {
             "path": "recipe/thirdparty/index.js",
-            "limit": "112kb"
+            "limit": "115kb"
         },
         {
             "path": "recipe/emailpassword/index.js",
-            "limit": "113kb"
+            "limit": "115kb"
         },
         {
             "path": "recipe/passwordless/index.js",
-            "limit": "205kb"
+            "limit": "207kb"
         },
         {
             "path": "recipe/thirdpartypasswordless/index.js",
-            "limit": "225kb"
+            "limit": "227kb"
         }
     ],
     "repository": {


### PR DESCRIPTION
## Summary of change

Disabled importing helpers from tslib in the published build to avoid issues with different versions of it being installed.

## Related issues

-

## Test Plan

Build only change

## Documentation changes

Build only change

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

