### PR TITLE
test: fix missing cleanup

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,4 +1,3 @@
-exit: true
 spec:
     - test/unit/**/*.test.js
     - test/end-to-end/**/*.test.js

--- a/test/end-to-end/emailverification.test.js
+++ b/test/end-to-end/emailverification.test.js
@@ -664,6 +664,16 @@ describe("Email verification signOut errors", function () {
         });
     });
 
+    after(async function () {
+        await browser.close();
+        await fetch(`${TEST_SERVER_BASE_URL}/after`, {
+            method: "POST",
+        }).catch(console.error);
+        await fetch(`${TEST_SERVER_BASE_URL}/stop`, {
+            method: "POST",
+        }).catch(console.error);
+    });
+
     afterEach(function () {
         return screenshotOnFailure(this, browser);
     });


### PR DESCRIPTION
## Summary of change

- Fixed missing cleanup
- Remove exit=true from default mocha options to catch this locally

## Related issues

## Test Plan

Test/ci only change

## Documentation changes

Test/ci only change

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
