### PR TITLE
fix: pwless phone number guesser + tests

### DIFF
--- a/lib/build/recipe/passwordless/utils.js
+++ b/lib/build/recipe/passwordless/utils.js
@@ -315,6 +315,9 @@ function normalisePasswordlessBaseConfig(config) {
 }
 function defaultGuessInternationPhoneNumberFromInputPhoneNumber(value, defaultCountryFromConfig) {
     var _a;
+    if (value === undefined || value.length === 0) {
+        return value;
+    }
     if (defaultCountryFromConfig !== undefined) {
         try {
             return (_a = (0, min_1.default)(value, {

--- a/lib/ts/recipe/passwordless/utils.ts
+++ b/lib/ts/recipe/passwordless/utils.ts
@@ -146,6 +146,9 @@ export function defaultGuessInternationPhoneNumberFromInputPhoneNumber(
     value: string,
     defaultCountryFromConfig?: CountryCode
 ) {
+    if (value === undefined || value.length === 0) {
+        return value;
+    }
     if (defaultCountryFromConfig !== undefined) {
         try {
             return parsePhoneNumber(value, {

--- a/test/end-to-end/passwordless.test.js
+++ b/test/end-to-end/passwordless.test.js
@@ -350,7 +350,7 @@ export function getPasswordlessTestCases({ authRecipe, logId, generalErrorRecipe
                     await setInputValues(page, [{ name: inputName, value: "06701234324" }]);
                     await submitForm(page);
                     const input = await waitForSTElement(page, `[data-supertokens~=input][name=emailOrPhone_text]`);
-                    await checkInputValue(page, input, "06701234324");
+                    await checkInputValue(page, input, "+06701234324");
                 });
 
                 it("should show phone UI for a shorter local number", async function () {
@@ -362,7 +362,7 @@ export function getPasswordlessTestCases({ authRecipe, logId, generalErrorRecipe
                     await setInputValues(page, [{ name: inputName, value: "701234325" }]);
                     await submitForm(page);
                     const input = await waitForSTElement(page, `[data-supertokens~=input][name=emailOrPhone_text]`);
-                    await checkInputValue(page, input, "701234325");
+                    await checkInputValue(page, input, "+701234325");
                 });
 
                 it("should show phone UI for missed + sign", async function () {
@@ -374,7 +374,7 @@ export function getPasswordlessTestCases({ authRecipe, logId, generalErrorRecipe
                     await setInputValues(page, [{ name: inputName, value: "36701234326" }]);
                     await submitForm(page);
                     const input = await waitForSTElement(page, `[data-supertokens~=input][name=emailOrPhone_text]`);
-                    await checkInputValue(page, input, "36701234326");
+                    await checkInputValue(page, input, "+36701234326");
                 });
 
                 it("should show phone UI for too long input", async function () {
@@ -386,7 +386,7 @@ export function getPasswordlessTestCases({ authRecipe, logId, generalErrorRecipe
                     await setInputValues(page, [{ name: inputName, value: "654654654654654654654" }]);
                     await submitForm(page);
                     const input = await waitForSTElement(page, `[data-supertokens~=input][name=emailOrPhone_text]`);
-                    await checkInputValue(page, input, "654654654654654654654");
+                    await checkInputValue(page, input, "+654654654654654654654");
                 });
 
                 it("should show phone UI for too short input", async function () {
@@ -398,7 +398,7 @@ export function getPasswordlessTestCases({ authRecipe, logId, generalErrorRecipe
                     await setInputValues(page, [{ name: inputName, value: "654" }]);
                     await submitForm(page);
                     const input = await waitForSTElement(page, `[data-supertokens~=input][name=emailOrPhone_text]`);
-                    await checkInputValue(page, input, "654");
+                    await checkInputValue(page, input, "+654");
                 });
             });
 


### PR DESCRIPTION
## Summary of change

- Fixed phone number guesser adding a + to undefined/empty values
- Updated tests to match new behavior

## Related issues

-   

## Test Plan

Not necessary

## Documentation changes

None necessary

## Checklist for important updates

-   [ ] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
