### PR TITLE
chore: Add tests for isNewUser in getRedirectionURL context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Additional tests for `getRedirectionURL`
 
+### Changed
+
+-   Update `supertokens-web-js` dependency version
+
 ## [0.24.0] - 2022-07-06
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+-   Additional tests for `getRedirectionURL`
+
 ## [0.24.0] - 2022-07-06
 
 ### Bug fixes

--- a/examples/for-tests-react-16/src/App.js
+++ b/examples/for-tests-react-16/src/App.js
@@ -526,6 +526,7 @@ function getEmailPasswordConfigs({ disableDefaultUI }) {
         getRedirectionURL: async (context) => {
             console.log(`ST_LOGS EMAIL_PASSWORD GET_REDIRECTION_URL ${context.action}`);
             if (context.action === "SUCCESS") {
+                setIsNewUserToStorage("emailpassword", context.isNewUser);
                 return context.redirectToPath || "/dashboard";
             }
         },
@@ -675,6 +676,7 @@ function getThirdPartyPasswordlessConfigs({ disableDefaultUI }) {
         getRedirectionURL: async (context) => {
             console.log(`ST_LOGS THIRDPARTYPASSWORDLESS GET_REDIRECTION_URL ${context.action}`);
             if (context.action === "SUCCESS") {
+                setIsNewUserToStorage("thirdpartypasswordless", context.isNewUser);
                 return context.redirectToPath || "/dashboard";
             }
         },
@@ -777,6 +779,7 @@ function getPasswordlessConfigs({ disableDefaultUI }) {
         getRedirectionURL: async (context) => {
             console.log(`ST_LOGS PASSWORDLESS GET_REDIRECTION_URL ${context.action}`);
             if (context.action === "SUCCESS") {
+                setIsNewUserToStorage("passwordless", context.isNewUser);
                 return context.redirectToPath || "/dashboard";
             }
         },
@@ -818,6 +821,7 @@ function getThirdPartyConfigs({ disableDefaultUI }) {
         getRedirectionURL: async (context) => {
             console.log(`ST_LOGS THIRD_PARTY GET_REDIRECTION_URL ${context.action}`);
             if (context.action === "SUCCESS") {
+                setIsNewUserToStorage("thirdparty", context.isNewUser);
                 return context.redirectToPath || "/dashboard";
             }
         },
@@ -916,6 +920,7 @@ function getThirdPartyEmailPasswordConfigs({ disableDefaultUI }) {
         getRedirectionURL: async (context) => {
             console.log(`ST_LOGS THIRD_PARTY_EMAIL_PASSWORD GET_REDIRECTION_URL ${context.action}`);
             if (context.action === "SUCCESS") {
+                setIsNewUserToStorage("thirdpartyemailpassword", context.isNewUser);
                 return context.redirectToPath || "/dashboard";
             }
         },
@@ -1101,6 +1106,10 @@ function getThirdPartyEmailPasswordConfigs({ disableDefaultUI }) {
             style: theme.style,
         },
     });
+}
+
+function setIsNewUserToStorage(recipeName, isNewUser) {
+    localStorage.setItem("isNewUserCheck", `${recipeName}-${isNewUser}`);
 }
 
 window.SuperTokens = SuperTokens;

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -547,6 +547,7 @@ function getEmailPasswordConfigs({ disableDefaultUI }) {
         getRedirectionURL: async (context) => {
             console.log(`ST_LOGS EMAIL_PASSWORD GET_REDIRECTION_URL ${context.action}`);
             if (context.action === "SUCCESS") {
+                setIsNewUserToStorage("emailpassword", context.isNewUser);
                 return context.redirectToPath || "/dashboard";
             }
         },
@@ -708,6 +709,7 @@ function getThirdPartyPasswordlessConfigs({ disableDefaultUI }) {
         getRedirectionURL: async (context) => {
             console.log(`ST_LOGS THIRDPARTYPASSWORDLESS GET_REDIRECTION_URL ${context.action}`);
             if (context.action === "SUCCESS") {
+                setIsNewUserToStorage("thirdpartypasswordless", context.isNewUser);
                 return context.redirectToPath || "/dashboard";
             }
         },
@@ -819,6 +821,7 @@ function getPasswordlessConfigs({ disableDefaultUI }) {
         getRedirectionURL: async (context) => {
             console.log(`ST_LOGS PASSWORDLESS GET_REDIRECTION_URL ${context.action}`);
             if (context.action === "SUCCESS") {
+                setIsNewUserToStorage("passwordless", context.isNewUser);
                 return context.redirectToPath || "/dashboard";
             }
         },
@@ -873,6 +876,7 @@ function getThirdPartyConfigs({ disableDefaultUI }) {
         getRedirectionURL: async (context) => {
             console.log(`ST_LOGS THIRD_PARTY GET_REDIRECTION_URL ${context.action}`);
             if (context.action === "SUCCESS") {
+                setIsNewUserToStorage("thirdparty", context.isNewUser);
                 return context.redirectToPath || "/dashboard";
             }
         },
@@ -984,6 +988,7 @@ function getThirdPartyEmailPasswordConfigs({ disableDefaultUI }) {
         getRedirectionURL: async (context) => {
             console.log(`ST_LOGS THIRD_PARTY_EMAIL_PASSWORD GET_REDIRECTION_URL ${context.action}`);
             if (context.action === "SUCCESS") {
+                setIsNewUserToStorage("thirdpartyemailpassword", context.isNewUser);
                 return context.redirectToPath || "/dashboard";
             }
         },
@@ -1169,6 +1174,10 @@ function getThirdPartyEmailPasswordConfigs({ disableDefaultUI }) {
             style: theme.style,
         },
     });
+}
+
+function setIsNewUserToStorage(recipeName, isNewUser) {
+    localStorage.setItem("isNewUserCheck", `${recipeName}-${isNewUser}`);
 }
 
 window.SuperTokens = SuperTokens;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "react-select": "5.2.1",
                 "react-shadow": "19.0.3",
                 "supertokens-js-override": "^0.0.4",
-                "supertokens-web-js": "^0.1.1"
+                "supertokens-web-js": "^0.1.2"
             },
             "devDependencies": {
                 "@babel/core": "7.12.1",
@@ -15235,9 +15235,9 @@
             "integrity": "sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg=="
         },
         "node_modules/supertokens-web-js": {
-            "version": "0.1.1",
-            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#e189d19cdcc0b6ff3664bcd713c359c518f61895",
-            "license": "Apache-2.0",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/supertokens-web-js/-/supertokens-web-js-0.1.2.tgz",
+            "integrity": "sha512-LP54DoTmvtfrdOJAzbT3QlYxH/IPOEqjFa1ZG/XhDD4EUA+iDDKp4S8o1IGglEbgl9HXvPrdlCdg2y3IBTmWoQ==",
             "dependencies": {
                 "supertokens-js-override": "0.0.4",
                 "supertokens-website": "^13.0.0"
@@ -28396,8 +28396,9 @@
             "integrity": "sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg=="
         },
         "supertokens-web-js": {
-            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#e189d19cdcc0b6ff3664bcd713c359c518f61895",
-            "from": "supertokens-web-js@^0.1.1",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/supertokens-web-js/-/supertokens-web-js-0.1.2.tgz",
+            "integrity": "sha512-LP54DoTmvtfrdOJAzbT3QlYxH/IPOEqjFa1ZG/XhDD4EUA+iDDKp4S8o1IGglEbgl9HXvPrdlCdg2y3IBTmWoQ==",
             "requires": {
                 "supertokens-js-override": "0.0.4",
                 "supertokens-website": "^13.0.0"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "react-select": "5.2.1",
         "react-shadow": "19.0.3",
         "supertokens-js-override": "^0.0.4",
-        "supertokens-web-js": "^0.1.1"
+        "supertokens-web-js": "^0.1.2"
     },
     "peerDependencies": {
         "react": ">=16.8.0"

--- a/test/end-to-end/getRedirectionURL.test.js
+++ b/test/end-to-end/getRedirectionURL.test.js
@@ -1,0 +1,338 @@
+import assert from "assert";
+import fetch from "isomorphic-fetch";
+import puppeteer from "puppeteer";
+import {
+    toggleSignInSignUp,
+    defaultSignUp,
+    screenshotOnFailure,
+    assertProviders,
+    clickOnProviderButton,
+    loginWithAuth0,
+    setPasswordlessFlowType,
+    waitForSTElement,
+    getPasswordlessDevice,
+    setInputValues,
+    submitForm,
+    clearBrowserCookiesWithoutAffectingConsole,
+} from "../helpers";
+// Run the tests in a DOM environment.
+require("jsdom-global")();
+import { TEST_CLIENT_BASE_URL, TEST_SERVER_BASE_URL, SIGN_IN_UP_API } from "../constants";
+
+describe("getRedirectionURL Tests", function () {
+    describe("Test that isNewUser is passed correctly", function () {
+        describe("Email Password Recipe", function () {
+            let browser;
+            let page;
+            before(async function () {
+                await fetch(`${TEST_SERVER_BASE_URL}/beforeeach`, {
+                    method: "POST",
+                }).catch(console.error);
+
+                await fetch(`${TEST_SERVER_BASE_URL}/startst`, {
+                    method: "POST",
+                }).catch(console.error);
+
+                browser = await puppeteer.launch({
+                    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+                    headless: true,
+                });
+            });
+
+            after(async function () {
+                await browser.close();
+                await fetch(`${TEST_SERVER_BASE_URL}/after`, {
+                    method: "POST",
+                }).catch(console.error);
+                await fetch(`${TEST_SERVER_BASE_URL}/stop`, {
+                    method: "POST",
+                }).catch(console.error);
+            });
+
+            afterEach(function () {
+                return screenshotOnFailure(this, browser);
+            });
+
+            beforeEach(async function () {
+                page = await browser.newPage();
+                await clearBrowserCookiesWithoutAffectingConsole(page, []);
+                await Promise.all([
+                    page.goto(`${TEST_CLIENT_BASE_URL}/auth?authRecipe=emailpassword`),
+                    page.waitForNavigation({ waitUntil: "networkidle0" }),
+                ]);
+                await page.evaluate(() => localStorage.removeItem("isNewUserCheck"));
+            });
+
+            it("Test that isNewUser is true when signing up", async function () {
+                await toggleSignInSignUp(page);
+                await defaultSignUp(page);
+                const newUserCheck = await page.evaluate(() => localStorage.getItem("isNewUserCheck"));
+                assert.equal(newUserCheck, "emailpassword-true");
+            });
+        });
+
+        describe("Third party recipe", function () {
+            let browser;
+            let page;
+            before(async function () {
+                await fetch(`${TEST_SERVER_BASE_URL}/beforeeach`, {
+                    method: "POST",
+                }).catch(console.error);
+
+                await fetch(`${TEST_SERVER_BASE_URL}/startst`, {
+                    method: "POST",
+                }).catch(console.error);
+
+                browser = await puppeteer.launch({
+                    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+                    headless: true,
+                });
+            });
+
+            after(async function () {
+                await browser.close();
+                await fetch(`${TEST_SERVER_BASE_URL}/after`, {
+                    method: "POST",
+                }).catch(console.error);
+                await fetch(`${TEST_SERVER_BASE_URL}/stop`, {
+                    method: "POST",
+                }).catch(console.error);
+            });
+
+            afterEach(function () {
+                return screenshotOnFailure(this, browser);
+            });
+
+            beforeEach(async function () {
+                page = await browser.newPage();
+                await clearBrowserCookiesWithoutAffectingConsole(page, []);
+                await page.goto(`${TEST_CLIENT_BASE_URL}/auth?authRecipe=thirdparty`);
+                await page.evaluate(() => localStorage.removeItem("isNewUserCheck"));
+            });
+
+            it("Test that isNewUser works correctly", async function () {
+                await assertProviders(page);
+                await clickOnProviderButton(page, "Auth0");
+                await Promise.all([
+                    loginWithAuth0(page),
+                    page.waitForResponse((response) => response.url() === SIGN_IN_UP_API && response.status() === 200),
+                ]);
+                const newUserCheck = await page.evaluate(() => localStorage.getItem("isNewUserCheck"));
+                assert.equal(newUserCheck, "thirdparty-true");
+            });
+        });
+
+        describe("Thirdpartyemailpassword recipe", function () {
+            let browser;
+            let page;
+            before(async function () {
+                await fetch(`${TEST_SERVER_BASE_URL}/beforeeach`, {
+                    method: "POST",
+                }).catch(console.error);
+
+                await fetch(`${TEST_SERVER_BASE_URL}/startst`, {
+                    method: "POST",
+                }).catch(console.error);
+
+                browser = await puppeteer.launch({
+                    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+                    headless: true,
+                });
+            });
+
+            after(async function () {
+                await browser.close();
+                await fetch(`${TEST_SERVER_BASE_URL}/after`, {
+                    method: "POST",
+                }).catch(console.error);
+                await fetch(`${TEST_SERVER_BASE_URL}/stop`, {
+                    method: "POST",
+                }).catch(console.error);
+            });
+
+            afterEach(function () {
+                return screenshotOnFailure(this, browser);
+            });
+
+            beforeEach(async function () {
+                page = await browser.newPage();
+                await clearBrowserCookiesWithoutAffectingConsole(page, []);
+                await page.goto(`${TEST_CLIENT_BASE_URL}/auth?authRecipe=thirdpartyemailpassword`);
+                await page.evaluate(() => localStorage.removeItem("isNewUserCheck"));
+            });
+
+            it("Test that isNewUser is true when signing up with email", async function () {
+                await toggleSignInSignUp(page);
+                await defaultSignUp(page, "thirdpartyemailpassword");
+                const newUserCheck = await page.evaluate(() => localStorage.getItem("isNewUserCheck"));
+                assert.equal(newUserCheck, "thirdpartyemailpassword-true");
+            });
+
+            it("Test that isNewUser works correctly when signing up with auth 0", async function () {
+                await assertProviders(page);
+                await clickOnProviderButton(page, "Auth0");
+                await Promise.all([
+                    loginWithAuth0(page),
+                    page.waitForResponse((response) => response.url() === SIGN_IN_UP_API && response.status() === 200),
+                ]);
+                const newUserCheck = await page.evaluate(() => localStorage.getItem("isNewUserCheck"));
+                assert.equal(newUserCheck, "thirdpartyemailpassword-true");
+            });
+        });
+
+        describe("Passwordless recipe", function () {
+            let browser;
+            let page;
+            const exampleEmail = "test@example.com";
+
+            before(async function () {
+                await fetch(`${TEST_SERVER_BASE_URL}/beforeeach`, {
+                    method: "POST",
+                }).catch(console.error);
+
+                await fetch(`${TEST_SERVER_BASE_URL}/startst`, {
+                    method: "POST",
+                    headers: [["content-type", "application/json"]],
+                    body: JSON.stringify({
+                        configUpdates: [
+                            { key: "passwordless_code_lifetime", value: 4000 },
+                            { key: "passwordless_max_code_input_attempts", value: 3 },
+                        ],
+                    }),
+                }).catch(console.error);
+
+                browser = await puppeteer.launch({
+                    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+                    headless: true,
+                });
+            });
+
+            after(async function () {
+                await browser.close();
+                await fetch(`${TEST_SERVER_BASE_URL}/after`, {
+                    method: "POST",
+                }).catch(console.error);
+                await fetch(`${TEST_SERVER_BASE_URL}/stop`, {
+                    method: "POST",
+                }).catch(console.error);
+            });
+
+            afterEach(function () {
+                return screenshotOnFailure(this, browser);
+            });
+
+            beforeEach(async function () {
+                page = await browser.newPage();
+                await clearBrowserCookiesWithoutAffectingConsole(page, []);
+                await Promise.all([
+                    page.goto(
+                        `${TEST_CLIENT_BASE_URL}/auth?authRecipe=passwordless&passwordlessContactMethodType=EMAIL`
+                    ),
+                    page.waitForNavigation({ waitUntil: "networkidle0" }),
+                ]);
+                await page.evaluate(() => localStorage.removeItem("isNewUserCheck"));
+                await setPasswordlessFlowType("EMAIL", "USER_INPUT_CODE");
+            });
+
+            it("Test that isNewUser is passed correctly", async function () {
+                await setInputValues(page, [{ name: "email", value: exampleEmail }]);
+                await submitForm(page);
+                await waitForSTElement(page, "[data-supertokens~=input][name=userInputCode]");
+
+                const loginAttemptInfo = JSON.parse(
+                    await page.evaluate(() => localStorage.getItem("supertokens-passwordless-loginAttemptInfo"))
+                );
+                const device = await getPasswordlessDevice(loginAttemptInfo);
+                await setInputValues(page, [{ name: "userInputCode", value: device.codes[0].userInputCode }]);
+                await submitForm(page);
+                await page.waitForSelector(".sessionInfo-user-id");
+
+                const newUserCheck = await page.evaluate(() => localStorage.getItem("isNewUserCheck"));
+                assert.equal(newUserCheck, "passwordless-true");
+            });
+        });
+
+        describe("ThirdPartyPasswordless recipe", function () {
+            let browser;
+            let page;
+            const exampleEmail = "test@example.com";
+
+            before(async function () {
+                await fetch(`${TEST_SERVER_BASE_URL}/beforeeach`, {
+                    method: "POST",
+                }).catch(console.error);
+
+                await fetch(`${TEST_SERVER_BASE_URL}/startst`, {
+                    method: "POST",
+                    headers: [["content-type", "application/json"]],
+                    body: JSON.stringify({
+                        configUpdates: [
+                            { key: "passwordless_code_lifetime", value: 4000 },
+                            { key: "passwordless_max_code_input_attempts", value: 3 },
+                        ],
+                    }),
+                }).catch(console.error);
+
+                browser = await puppeteer.launch({
+                    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+                    headless: true,
+                });
+            });
+
+            after(async function () {
+                await browser.close();
+                await fetch(`${TEST_SERVER_BASE_URL}/after`, {
+                    method: "POST",
+                }).catch(console.error);
+                await fetch(`${TEST_SERVER_BASE_URL}/stop`, {
+                    method: "POST",
+                }).catch(console.error);
+            });
+
+            afterEach(function () {
+                return screenshotOnFailure(this, browser);
+            });
+
+            beforeEach(async function () {
+                page = await browser.newPage();
+                await clearBrowserCookiesWithoutAffectingConsole(page, []);
+                await Promise.all([
+                    page.goto(
+                        `${TEST_CLIENT_BASE_URL}/auth?authRecipe=thirdpartypasswordless&passwordlessContactMethodType=EMAIL`
+                    ),
+                    page.waitForNavigation({ waitUntil: "networkidle0" }),
+                ]);
+                await page.evaluate(() => localStorage.removeItem("isNewUserCheck"));
+                await setPasswordlessFlowType("EMAIL", "USER_INPUT_CODE");
+            });
+
+            it("Test that isNewUser is passed correctly", async function () {
+                await setInputValues(page, [{ name: "email", value: exampleEmail }]);
+                await submitForm(page);
+                await waitForSTElement(page, "[data-supertokens~=input][name=userInputCode]");
+
+                const loginAttemptInfo = JSON.parse(
+                    await page.evaluate(() => localStorage.getItem("supertokens-passwordless-loginAttemptInfo"))
+                );
+                const device = await getPasswordlessDevice(loginAttemptInfo);
+                await setInputValues(page, [{ name: "userInputCode", value: device.codes[0].userInputCode }]);
+                await submitForm(page);
+                await page.waitForSelector(".sessionInfo-user-id");
+
+                const newUserCheck = await page.evaluate(() => localStorage.getItem("isNewUserCheck"));
+                assert.equal(newUserCheck, "thirdpartypasswordless-true");
+            });
+
+            it("Test that isNewUser works correctly when signing up with auth 0", async function () {
+                await assertProviders(page);
+                await clickOnProviderButton(page, "Auth0");
+                await Promise.all([
+                    loginWithAuth0(page),
+                    page.waitForResponse((response) => response.url() === SIGN_IN_UP_API && response.status() === 200),
+                ]);
+                const newUserCheck = await page.evaluate(() => localStorage.getItem("isNewUserCheck"));
+                assert.equal(newUserCheck, "thirdpartypasswordless-true");
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary of change

- Adds tests to make sure isNewUser is passed correctly for all recipes

## Related issues

-   https://github.com/supertokens/supertokens-auth-react/issues/519

## Test Plan

NOTE: Some of the new tests fail, they will pass once https://github.com/supertokens/supertokens-web-js/pull/47 is merged and released

## Documentation changes

None

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Remaining TODOs for this PR

-   [ ] 
