### PR TITLE
fix: Add feature checks for passwordless and thirdpartypasswordless for getRedirectionUrl tests

### DIFF
--- a/test/end-to-end/getRedirectionURL.test.js
+++ b/test/end-to-end/getRedirectionURL.test.js
@@ -14,6 +14,8 @@ import {
     setInputValues,
     submitForm,
     clearBrowserCookiesWithoutAffectingConsole,
+    isPasswordlessSupported,
+    isThirdPartyPasswordlessSupported,
 } from "../helpers";
 // Run the tests in a DOM environment.
 require("jsdom-global")();
@@ -186,6 +188,11 @@ describe("getRedirectionURL Tests", function () {
             const exampleEmail = "test@example.com";
 
             before(async function () {
+                let isPasswordlessSupported = await isPasswordlessSupported();
+                if (!isPasswordlessSupported) {
+                    this.skip();
+                }
+
                 await fetch(`${TEST_SERVER_BASE_URL}/beforeeach`, {
                     method: "POST",
                 }).catch(console.error);
@@ -258,6 +265,11 @@ describe("getRedirectionURL Tests", function () {
             const exampleEmail = "test@example.com";
 
             before(async function () {
+                let isThirdPartyPasswordlessSupported = await isThirdPartyPasswordlessSupported();
+                if (!isThirdPartyPasswordlessSupported) {
+                    this.skip();
+                }
+
                 await fetch(`${TEST_SERVER_BASE_URL}/beforeeach`, {
                     method: "POST",
                 }).catch(console.error);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -741,6 +741,24 @@ export async function isGeneralErrorSupported() {
     return true;
 }
 
+export async function isPasswordlessSupported() {
+    const features = await getFeatureFlags();
+    if (features.includes("passwordless")) {
+        return true;
+    }
+
+    return false;
+}
+
+export async function isThirdPartyPasswordlessSupported() {
+    const features = await getFeatureFlags();
+    if (features.includes("thirdpartypasswordless")) {
+        return true;
+    }
+
+    return false;
+}
+
 /**
  * For example setGeneralErrorToLocalStorage("EMAIL_PASSWORD", "EMAIL_PASSWORD_SIGN_UP", page) to
  * set for signUp in email password


### PR DESCRIPTION
## Summary of change

- Adds feature checks to make sure the tests dont run against a backend SDK version that doesnt support the Recipes

## Related issues

-   

## Test Plan



## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Remaining TODOs for this PR

-   [ ] ...
