### PR TITLE
fix: migrates supabase app to supertokens-auth-react to 0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+-   Updates supabase example app to use supertokens-auth-react version 0.24
+
 ## [0.24.1] - 2022-07-12
 
 ### Added

--- a/examples/with-supabase/pages/_app.tsx
+++ b/examples/with-supabase/pages/_app.tsx
@@ -1,7 +1,7 @@
 import "../styles/globals.css";
 import React from "react";
 import { useEffect } from "react";
-import SuperTokensReact from "supertokens-auth-react";
+import SuperTokensReact, { SuperTokensWrapper } from "supertokens-auth-react";
 import * as SuperTokensConfig from "../config/frontendConfig";
 import Session from "supertokens-auth-react/recipe/session";
 import { redirectToAuth } from "supertokens-auth-react/recipe/thirdpartyemailpassword";
@@ -27,7 +27,11 @@ function MyApp({ Component, pageProps }) {
     if (pageProps.fromSupertokens === "needs-refresh") {
         return null;
     }
-    return <Component {...pageProps} />;
+    return (
+        <SuperTokensWrapper>
+            <Component {...pageProps} />
+        </SuperTokensWrapper>
+    );
 }
 
 export default MyApp;

--- a/examples/with-supabase/pages/index.tsx
+++ b/examples/with-supabase/pages/index.tsx
@@ -1,29 +1,28 @@
 import React, { useState, useEffect } from "react";
 import Head from "next/head";
 import styles from "../styles/Home.module.css";
-import ThirdPartyEmailPassword from "supertokens-auth-react/recipe/thirdpartyemailpassword";
+import ThirdPartyEmailPassword, {
+    ThirdPartyEmailPasswordAuth,
+} from "supertokens-auth-react/recipe/thirdpartyemailpassword";
 import dynamic from "next/dynamic";
 import { useSessionContext } from "supertokens-auth-react/recipe/session";
 import { getSupabase } from "../utils/supabase";
 
-const ThirdPartyEmailPasswordAuthNoSSR = dynamic(
-    new Promise<typeof ThirdPartyEmailPassword.ThirdPartyEmailPasswordAuth>((res) =>
-        res(ThirdPartyEmailPassword.ThirdPartyEmailPasswordAuth)
-    ),
-    { ssr: false }
-);
-
 export default function Home() {
     return (
-        <ThirdPartyEmailPasswordAuthNoSSR>
+        <ThirdPartyEmailPasswordAuth>
             <ProtectedPage />
-        </ThirdPartyEmailPasswordAuthNoSSR>
+        </ThirdPartyEmailPasswordAuth>
     );
 }
 
 function ProtectedPage() {
     // retrieve the authenticated user's accessTokenPayload and userId from the sessionContext
     const sessionContext = useSessionContext();
+
+    if (sessionContext.loading === true) {
+        return null;
+    }
 
     const [userEmail, setEmail] = useState("");
     useEffect(() => {


### PR DESCRIPTION
## Summary of change

- changes to resolve supertokens-auth-react being updated to 0.24

## Related issues

-   https://github.com/supertokens/supertokens-core/issues/462

## Test Plan

- manual testing

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Remaining TODOs for this PR

-  [ ]  update supabase guide docs https://github.com/supabase/supabase/pull/7757
