### PR TITLE
chore: apply prettier to new example

### DIFF
--- a/examples/with-okta-multi-tenant-pkce-flow/README.md
+++ b/examples/with-okta-multi-tenant-pkce-flow/README.md
@@ -7,17 +7,17 @@ Ref: https://developer.okta.com/blog/2019/08/22/okta-authjs-pkce
 
 This demo app demonstrates the following:
 
-- How to add custom thirdparty provider to support Okta
-  - Passing state from frontend to the backend APIs
-  - Code Challenge and verifier implementation
-- How to handle multi-tenancy
-  - Accepting tenant id in the frontend
-  - Passing tenant id to the backend APIs
-  - Simulate multiple User Pool using the tenant id
-
+-   How to add custom thirdparty provider to support Okta
+    -   Passing state from frontend to the backend APIs
+    -   Code Challenge and verifier implementation
+-   How to handle multi-tenancy
+    -   Accepting tenant id in the frontend
+    -   Passing tenant id to the backend APIs
+    -   Simulate multiple User Pool using the tenant id
 
 ## Required changes
-- Update the config.go to update the tenantIDs and corresponding okta configs.
+
+-   Update the config.go to update the tenantIDs and corresponding okta configs.
 
 ## Run the demo app
 
@@ -41,12 +41,12 @@ Frontend will start on `http://localhost:3000`
 
 ## How to use the demo app
 
-- Once the frontend and backend are running, navigate to http://localhost:3000
-- Enter the tenant id and click on Login (as configured in the config.go file)
-- You should now be provided with a login link to Okta, click that
-- Login to the Okta as prompted by the provider
-- You should now be redirected to the Dashboard page with JWT token displayed
-- Verify that the JWT contains tenantID using the utility - https://jwt.io
+-   Once the frontend and backend are running, navigate to http://localhost:3000
+-   Enter the tenant id and click on Login (as configured in the config.go file)
+-   You should now be provided with a login link to Okta, click that
+-   Login to the Okta as prompted by the provider
+-   You should now be redirected to the Dashboard page with JWT token displayed
+-   Verify that the JWT contains tenantID using the utility - https://jwt.io
 
 ## Author
 

--- a/examples/with-okta-multi-tenant-pkce-flow/package.json
+++ b/examples/with-okta-multi-tenant-pkce-flow/package.json
@@ -1,41 +1,41 @@
 {
-  "name": "frontend",
-  "version": "0.1.0",
-  "private": true,
-  "dependencies": {
-    "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^13.3.0",
-    "@testing-library/user-event": "^13.5.0",
-    "axios": "^0.27.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.3.0",
-    "react-scripts": "5.0.1",
-    "supertokens-auth-react": "^0.24.1",
-    "web-vitals": "^2.1.4"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  }
+    "name": "frontend",
+    "version": "0.1.0",
+    "private": true,
+    "dependencies": {
+        "@testing-library/jest-dom": "^5.16.4",
+        "@testing-library/react": "^13.3.0",
+        "@testing-library/user-event": "^13.5.0",
+        "axios": "^0.27.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.3.0",
+        "react-scripts": "5.0.1",
+        "supertokens-auth-react": "^0.24.1",
+        "web-vitals": "^2.1.4"
+    },
+    "scripts": {
+        "start": "react-scripts start",
+        "build": "react-scripts build",
+        "test": "react-scripts test",
+        "eject": "react-scripts eject"
+    },
+    "eslintConfig": {
+        "extends": [
+            "react-app",
+            "react-app/jest"
+        ]
+    },
+    "browserslist": {
+        "production": [
+            ">0.2%",
+            "not dead",
+            "not op_mini all"
+        ],
+        "development": [
+            "last 1 chrome version",
+            "last 1 firefox version",
+            "last 1 safari version"
+        ]
+    }
 }

--- a/examples/with-okta-multi-tenant-pkce-flow/public/index.html
+++ b/examples/with-okta-multi-tenant-pkce-flow/public/index.html
@@ -1,43 +1,40 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
+    <head>
+        <meta charset="utf-8" />
+        <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#000000" />
+        <meta name="description" content="Web site created using create-react-app" />
+        <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+        <!--
+          manifest.json provides metadata used when your web app is installed on a
+          user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
+        -->
+        <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+        <!--
+          Notice the use of %PUBLIC_URL% in the tags above.
+          It will be replaced with the URL of the `public` folder during the build.
+          Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>React App</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
+          Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+          work correctly both with client-side routing and a non-root public URL.
+          Learn how to configure a non-root public URL by running `npm run build`.
+        -->
+        <title>React App</title>
+    </head>
+    <body>
+        <noscript>You need to enable JavaScript to run this app.</noscript>
+        <div id="root"></div>
+        <!--
+          This HTML file is a template.
+          If you open it directly in the browser, you will see an empty page.
 
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
+          You can add webfonts, meta tags, or analytics to this file.
+          The build step will place the bundled scripts into the <body> tag.
 
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-  </body>
+          To begin the development, run `npm start` or `yarn start`.
+          To create a production bundle, use `npm run build` or `yarn build`.
+        -->
+    </body>
 </html>

--- a/examples/with-okta-multi-tenant-pkce-flow/public/manifest.json
+++ b/examples/with-okta-multi-tenant-pkce-flow/public/manifest.json
@@ -1,25 +1,25 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
-  "icons": [
-    {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
-    }
-  ],
-  "start_url": ".",
-  "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+    "short_name": "React App",
+    "name": "Create React App Sample",
+    "icons": [
+        {
+            "src": "favicon.ico",
+            "sizes": "64x64 32x32 24x24 16x16",
+            "type": "image/x-icon"
+        },
+        {
+            "src": "logo192.png",
+            "type": "image/png",
+            "sizes": "192x192"
+        },
+        {
+            "src": "logo512.png",
+            "type": "image/png",
+            "sizes": "512x512"
+        }
+    ],
+    "start_url": ".",
+    "display": "standalone",
+    "theme_color": "#000000",
+    "background_color": "#ffffff"
 }

--- a/examples/with-okta-multi-tenant-pkce-flow/src/index.css
+++ b/examples/with-okta-multi-tenant-pkce-flow/src/index.css
@@ -1,71 +1,68 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
-
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap");
 
 body {
-  margin: 0;
-  font-family: 'Poppins', sans-serif;
+    margin: 0;
+    font-family: "Poppins", sans-serif;
 
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  color: #777;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    color: #777;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+    font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
 .home {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100vh;
-  text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    text-align: center;
 }
 
 .home .auth {
-  padding: 24px;
-  background-color: #eee;
-  border-radius: 4px;
+    padding: 24px;
+    background-color: #eee;
+    border-radius: 4px;
 }
 
 .home .auth h1 {
-  color: #333;
-  font-size: 18px;
-  font-weight: 600;
+    color: #333;
+    font-size: 18px;
+    font-weight: 600;
 }
 
 .tenant-input {
-  display: flex;
-  align-items: center;
-
+    display: flex;
+    align-items: center;
 }
 
 .tenant-input input {
-  border: #ccc 1px solid;
-  border-radius: 4px;
-  padding: 8px 16px;
-  font-family: 'Poppins', sans-serif;
-  color: #444;
-  display: block;
+    border: #ccc 1px solid;
+    border-radius: 4px;
+    padding: 8px 16px;
+    font-family: "Poppins", sans-serif;
+    color: #444;
+    display: block;
 }
 
 .tenant-input span {
-  color: #1976D2;
+    color: #1976d2;
 }
 
 a.btn {
-  background-color: #1976D2;
-  padding: 4px 16px;
-  display: inline-block;
-  color: #fff;
-  text-decoration: none;
-  border-radius: 4px;
-  margin-left: 24px;
+    background-color: #1976d2;
+    padding: 4px 16px;
+    display: inline-block;
+    color: #fff;
+    text-decoration: none;
+    border-radius: 4px;
+    margin-left: 24px;
 }
 
 pre {
-  max-width: 500px;
-  overflow-x: auto;
+    max-width: 500px;
+    overflow-x: auto;
 }

--- a/examples/with-okta-multi-tenant-pkce-flow/src/index.tsx
+++ b/examples/with-okta-multi-tenant-pkce-flow/src/index.tsx
@@ -1,10 +1,6 @@
-import ReactDOM from 'react-dom/client';
-import {
-  BrowserRouter,
-  Routes,
-  Route,
-} from "react-router-dom";
-import './index.css';
+import ReactDOM from "react-dom/client";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import "./index.css";
 import * as reactRouterDom from "react-router-dom";
 
 import SuperTokens, { SuperTokensWrapper, getSuperTokensRoutesForReactRouterDom } from "supertokens-auth-react";
@@ -12,9 +8,9 @@ import ThirdParty from "supertokens-auth-react/recipe/thirdparty";
 
 import Session from "supertokens-auth-react/recipe/session";
 
-import Index from "./routes/index"
-import Dashboard from "./routes/dashboard"
-import { PreAndPostAPIHookAction } from 'supertokens-web-js/recipe/thirdparty';
+import Index from "./routes/index";
+import Dashboard from "./routes/dashboard";
+import { PreAndPostAPIHookAction } from "supertokens-web-js/recipe/thirdparty";
 
 SuperTokens.init({
     appInfo: {
@@ -27,91 +23,103 @@ SuperTokens.init({
         ThirdParty.init({
             signInAndUpFeature: {
                 providers: [
-                  { 
-                    // Adding a custom provider with id "okta". Also adding a custom button component for the provider.
-                    // ref: https://supertokens.com/docs/thirdparty/common-customizations/sign-in-and-up/custom-providers
-                    id: "okta",
-                    name: "Okta",
-                    buttonComponent: <div style={{
-                        cursor: "pointer",
-                        border: "1",
-                        paddingTop: "5px",
-                        paddingBottom: "5px",
-                        borderRadius: "5px",
-                        borderStyle: "solid"
-                    }}>Login with Okta</div>
-                  }
-                ]
+                    {
+                        // Adding a custom provider with id "okta". Also adding a custom button component for the provider.
+                        // ref: https://supertokens.com/docs/thirdparty/common-customizations/sign-in-and-up/custom-providers
+                        id: "okta",
+                        name: "Okta",
+                        buttonComponent: (
+                            <div
+                                style={{
+                                    cursor: "pointer",
+                                    border: "1",
+                                    paddingTop: "5px",
+                                    paddingBottom: "5px",
+                                    borderRadius: "5px",
+                                    borderStyle: "solid",
+                                }}>
+                                Login with Okta
+                            </div>
+                        ),
+                    },
+                ],
             },
             getRedirectionURL: async (context) => {
-              // This callback ensures that we redirect the logged in user to the dashboard page after login
-              if (context.action === "SUCCESS") {
-                  if (context.redirectToPath !== undefined) {
-                      // we are navigating back to where the user was before they authenticated
-                      return context.redirectToPath;
-                  }
-                  return "/dashboard";
-              }
-              return undefined;
-          },
-          preAPIHook: async (context) => {
-            // ref: https://supertokens.com/docs/thirdparty/advanced-customizations/frontend-hooks/pre-api
-
-            let url = context.url;
-            let requestInit = context.requestInit;
-            let action : PreAndPostAPIHookAction = context.action;
-
-            // Fetching the user entered TenantID from the local storage. This is set in the index route "/"
-            const tenant : String | null = window.localStorage.getItem('tenant');
-
-            // Adding the `state` and the `TenantID` as query parameters to the API calls
-            // so that the backend can consume them to get the correct Okta config for this tenant.
-            if (action === "THIRD_PARTY_SIGN_IN_UP") {
-              // `state` is returned from the provider as a query parameter
-              const queryParams: any = new Proxy(new URLSearchParams(window.location.search), {
-                get: (searchParams: URLSearchParams, prop: any) => searchParams.get(prop),
-              });
-              url += `?state=${queryParams.state}&tenant=${tenant}`
-            } else if (action === 'GET_AUTHORISATION_URL') {
-              // `state` comes from the userContext set in the override `generateStateToSendToOAuthProvider` below
-              url += `&state=${context.userContext.stateToProvider}&tenant=${tenant}`
-            }
-
-            return {
-                requestInit, url
-            };
-          },
-          override: {
-            functions: (originalImplementation) => {
-              return {
-                ...originalImplementation,
-                generateStateToSendToOAuthProvider: (input) => {
-                  // The client generates the state which is sent to Okta. We need to also send this state to the
-                  // backend so that it can be saved against the PKCE verifier. In order to send it to the backend,
-                  // we need to be able to access the generated state in the preAPIHook callback, and we can do
-                  // that via the userContext feature
-                  const resp = originalImplementation.generateStateToSendToOAuthProvider(input);
-                  input.userContext.stateToProvider = resp
-                  return resp
+                // This callback ensures that we redirect the logged in user to the dashboard page after login
+                if (context.action === "SUCCESS") {
+                    if (context.redirectToPath !== undefined) {
+                        // we are navigating back to where the user was before they authenticated
+                        return context.redirectToPath;
+                    }
+                    return "/dashboard";
                 }
-              }
-            }
-          }
+                return undefined;
+            },
+            preAPIHook: async (context) => {
+                // ref: https://supertokens.com/docs/thirdparty/advanced-customizations/frontend-hooks/pre-api
+
+                let url = context.url;
+                let requestInit = context.requestInit;
+                let action: PreAndPostAPIHookAction = context.action;
+
+                // Fetching the user entered TenantID from the local storage. This is set in the index route "/"
+                const tenant: String | null = window.localStorage.getItem("tenant");
+
+                // Adding the `state` and the `TenantID` as query parameters to the API calls
+                // so that the backend can consume them to get the correct Okta config for this tenant.
+                if (action === "THIRD_PARTY_SIGN_IN_UP") {
+                    // `state` is returned from the provider as a query parameter
+                    const queryParams: any = new Proxy(new URLSearchParams(window.location.search), {
+                        get: (searchParams: URLSearchParams, prop: any) => searchParams.get(prop),
+                    });
+                    url += `?state=${queryParams.state}&tenant=${tenant}`;
+                } else if (action === "GET_AUTHORISATION_URL") {
+                    // `state` comes from the userContext set in the override `generateStateToSendToOAuthProvider` below
+                    url += `&state=${context.userContext.stateToProvider}&tenant=${tenant}`;
+                }
+
+                return {
+                    requestInit,
+                    url,
+                };
+            },
+            override: {
+                functions: (originalImplementation) => {
+                    return {
+                        ...originalImplementation,
+                        generateStateToSendToOAuthProvider: (input) => {
+                            // The client generates the state which is sent to Okta. We need to also send this state to the
+                            // backend so that it can be saved against the PKCE verifier. In order to send it to the backend,
+                            // we need to be able to access the generated state in the preAPIHook callback, and we can do
+                            // that via the userContext feature
+                            const resp = originalImplementation.generateStateToSendToOAuthProvider(input);
+                            input.userContext.stateToProvider = resp;
+                            return resp;
+                        },
+                    };
+                },
+            },
         }),
-        Session.init()
-    ]
+        Session.init(),
+    ],
 });
 
-
-const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
 root.render(
-  <SuperTokensWrapper>
-    <BrowserRouter>
-      <Routes>
-        {getSuperTokensRoutesForReactRouterDom(reactRouterDom)}
-        <Route path="/" element={<Index />} />
-        <Route path="dashboard" element={<ThirdParty.ThirdPartyAuth><Dashboard /></ThirdParty.ThirdPartyAuth>} />
-      </Routes>
-    </BrowserRouter>
-  </SuperTokensWrapper>
+    <SuperTokensWrapper>
+        <BrowserRouter>
+            <Routes>
+                {getSuperTokensRoutesForReactRouterDom(reactRouterDom)}
+                <Route path="/" element={<Index />} />
+                <Route
+                    path="dashboard"
+                    element={
+                        <ThirdParty.ThirdPartyAuth>
+                            <Dashboard />
+                        </ThirdParty.ThirdPartyAuth>
+                    }
+                />
+            </Routes>
+        </BrowserRouter>
+    </SuperTokensWrapper>
 );

--- a/examples/with-okta-multi-tenant-pkce-flow/src/routes/dashboard.tsx
+++ b/examples/with-okta-multi-tenant-pkce-flow/src/routes/dashboard.tsx
@@ -5,24 +5,26 @@ import Session from "supertokens-auth-react/recipe/session";
 // JWT payload can be inspected using the utility - https://jwt.io/
 // We can find the TenantID added to the jwt payload as described in the API server code
 export default function Dashboard() {
-  async function onLogout() {
-    await signOut();
-    window.location.href = "http://localhost:3000";
-  }
+    async function onLogout() {
+        await signOut();
+        window.location.href = "http://localhost:3000";
+    }
 
-  let sessionContext = Session.useSessionContext();
+    let sessionContext = Session.useSessionContext();
 
-  if (sessionContext.loading) {
-    return null
-  }
+    if (sessionContext.loading) {
+        return null;
+    }
 
-  return (
-    <div className="home">
-      <main className="dashboard">
-        <h1>Dashboard</h1>
-        <pre style={{textAlign: "left"}}>{ sessionContext.accessTokenPayload.jwt }</pre>
-        <a href="#" onClick={onLogout} className="btn">Logout</a>
-      </main>
-    </div>
-  );
+    return (
+        <div className="home">
+            <main className="dashboard">
+                <h1>Dashboard</h1>
+                <pre style={{ textAlign: "left" }}>{sessionContext.accessTokenPayload.jwt}</pre>
+                <a href="#" onClick={onLogout} className="btn">
+                    Logout
+                </a>
+            </main>
+        </div>
+    );
 }

--- a/examples/with-okta-multi-tenant-pkce-flow/src/routes/index.tsx
+++ b/examples/with-okta-multi-tenant-pkce-flow/src/routes/index.tsx
@@ -1,30 +1,36 @@
-import {useState} from 'react';
+import { useState } from "react";
 
 // This is a index route. Here we accept the Tenant ID to be used for the login.
 export default function Index() {
+    const [tenant, setTenant] = useState("");
 
-  const [tenant, setTenant] = useState('');
+    function handleClick(e: any) {
+        e.preventDefault();
+        // We store the tenant ID entered by user to the local storage, which will be later used by
+        // the Supertokens Auth components, as described in the `src/index.tsx` file
+        window.localStorage.setItem("tenant", tenant);
+        // We redirect the user to the auth page provided by the Supertokens Auth React SDK
+        window.location.href = `http://localhost:3000/auth`;
+    }
 
-  function handleClick(e: any) {
-    e.preventDefault();
-    // We store the tenant ID entered by user to the local storage, which will be later used by
-    // the Supertokens Auth components, as described in the `src/index.tsx` file
-    window.localStorage.setItem('tenant', tenant);
-    // We redirect the user to the auth page provided by the Supertokens Auth React SDK
-    window.location.href = `http://localhost:3000/auth`
-  }
-
-  return (
-    <div className="home">
-      <main className="auth">
-        <h1>Proceed to Login</h1>
-        <div className="tenant-input">
-          <input type="text" placeholder="tenant-id" value={tenant} onChange={(e)=>setTenant(e.target.value)} />
+    return (
+        <div className="home">
+            <main className="auth">
+                <h1>Proceed to Login</h1>
+                <div className="tenant-input">
+                    <input
+                        type="text"
+                        placeholder="tenant-id"
+                        value={tenant}
+                        onChange={(e) => setTenant(e.target.value)}
+                    />
+                </div>
+                <div style={{ marginTop: "24px" }}>
+                    <a href="#" className="btn" onClick={handleClick}>
+                        Login
+                    </a>
+                </div>
+            </main>
         </div>
-        <div style={{ marginTop: "24px" }}>
-          <a href="#" className="btn" onClick={handleClick}>Login</a>
-        </div>
-      </main>
-    </div>
-  );
+    );
 }

--- a/examples/with-okta-multi-tenant-pkce-flow/src/setupTests.tsx
+++ b/examples/with-okta-multi-tenant-pkce-flow/src/setupTests.tsx
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";

--- a/examples/with-okta-multi-tenant-pkce-flow/tsconfig.json
+++ b/examples/with-okta-multi-tenant-pkce-flow/tsconfig.json
@@ -1,20 +1,20 @@
 {
-  "compilerOptions": {
-      "target": "es5",
-      "lib": ["dom", "dom.iterable", "esnext"],
-      "allowJs": true,
-      "skipLibCheck": true,
-      "esModuleInterop": true,
-      "allowSyntheticDefaultImports": true,
-      "strict": true,
-      "forceConsistentCasingInFileNames": true,
-      "noFallthroughCasesInSwitch": true,
-      "module": "esnext",
-      "moduleResolution": "node",
-      "resolveJsonModule": true,
-      "isolatedModules": true,
-      "noEmit": true,
-      "jsx": "react-jsx"
-  },
-  "include": ["src"]
+    "compilerOptions": {
+        "target": "es5",
+        "lib": ["dom", "dom.iterable", "esnext"],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "noFallthroughCasesInSwitch": true,
+        "module": "esnext",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "react-jsx"
+    },
+    "include": ["src"]
 }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "build-pretty": "npm run build && npm run pretty && npm run pretty",
         "lint": "node other/checkTranslationKeys.js && cd lib && eslint ./ts --ext .ts,.tsx",
         "prune": "cd lib && ts-prune | grep -vE 'used in module| - default$| - package_version$|getSuperTokensRoutesForReactRouterDom$' && exit 1 || exit 0",
-        "pretty-check": "npx pretty-quick --check .",
+        "pretty-check": "npx pretty-quick --staged --check .",
         "set-up-hooks": "cp hooks/pre-commit.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit",
         "build-docs": "rm -rf ./docs && npx typedoc --out ./docs --tsconfig ./lib/tsconfig.json ./lib/ts/index.ts ./lib/ts/**/index.ts ./lib/ts/**/*/index.ts",
         "size": "size-limit",


### PR DESCRIPTION
## Summary of change

- applied prettier on new example
- updated scripts to only check staged files during pre-commit

## Related issues

-   

## Test Plan

N/A, example only change

## Documentation changes

N/A, example only change

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
