### PR TITLE
refactor: Edit READMEs for example apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Updated `react-scripts` in all examples
+-   Updated READMEs for example apps, removed information that is no longer relevant.
 
 ## [0.24.2] - 2022-07-28
 

--- a/examples/with-emailpassword/README.md
+++ b/examples/with-emailpassword/README.md
@@ -40,12 +40,6 @@ If you would like to modify the website (http://localhost:3000) or the API serve
 -   The frontend code is located in the `src` folder.
 -   The backend API is in the `api-server.js` file.
 
-## Production build
-
-```bash
-npm run build && npm run start
-```
-
 ## Author
 
 Created with :heart: by the folks at supertokens.com.

--- a/examples/with-passwordless/README.md
+++ b/examples/with-passwordless/README.md
@@ -42,12 +42,6 @@ If you would like to modify the website (http://localhost:3000) or the API serve
 -   The frontend code is located in the `src` folder.
 -   The backend API is in the `api-server/index.js` file.
 
-## Production build
-
-```bash
-npm run build && npm run start
-```
-
 ## Author
 
 Created with :heart: by the folks at supertokens.com.

--- a/examples/with-thirdparty/README.md
+++ b/examples/with-thirdparty/README.md
@@ -38,12 +38,6 @@ If you would like to modify the website (http://localhost:3000) or the API serve
 -   The frontend code is located in the `src` folder.
 -   The backend API is in the `api-server.js` file.
 
-## Production build
-
-```bash
-npm run build && npm run start
-```
-
 ## Author
 
 Created with :heart: by the folks at supertokens.com.

--- a/examples/with-thirdpartyemailpassword/README.md
+++ b/examples/with-thirdpartyemailpassword/README.md
@@ -40,12 +40,6 @@ If you would like to modify the website (http://localhost:3000) or the API serve
 -   The frontend code is located in the `src` folder.
 -   The backend API is in the `api-server.js` file.
 
-## Production build
-
-```bash
-npm run build && npm run start
-```
-
 ## Author
 
 Created with :heart: by the folks at supertokens.com.

--- a/examples/with-thirdpartypasswordless/README.md
+++ b/examples/with-thirdpartypasswordless/README.md
@@ -43,12 +43,6 @@ If you would like to modify the website (http://localhost:3000) or the API serve
 -   The frontend code is located in the `src` folder.
 -   The backend API is in the `api-server/index.js` file.
 
-## Production build
-
-```bash
-npm run build && npm run start
-```
-
 ## Author
 
 Created with :heart: by the folks at supertokens.com.

--- a/examples/with-thirdpartypasswordless/README.md
+++ b/examples/with-thirdpartypasswordless/README.md
@@ -21,20 +21,6 @@ npm install
 
 The demo app, by default sends email and SMS by contacting https://api.supertokens.com servers. The SMS sending via this service is rate limited. You can configure the demo app to use your own SMTP server and use your own Twilio account credentials. You can also override how the emails and SMS are sent to take full control of their design and how they are sent.
 
-## Set environment variables
-
-The demo app contains code for seding emails to the user for passwordless auth. You need to set the following environment variables for the email user before running the demo app:
-
-```bash
-NODEMAILER_USER
-NODEMAILER_PASSWORD
-```
-
-You can do this by:
-
--   Editing the `api-server/.env.example` file
--   Rename the `api-server/.env.example` file to `.env`
-
 ## Run the demo app
 
 This compiles and serves the React app and starts the backend API server on port 3001.


### PR DESCRIPTION
## Summary of change

- Removes the section of adding environment variables for nodemailer in the with-thirdpartypasswordless example app. The example no longer uses those variables so it was redundant

- Removes the section for production builds from 
    - with-emailpassword
    - with-thirdparty
    - with-thirdpartyemailpassword
    - with-passwordless
    - with-thirdpartypasswordless

## Related issues

-   

## Test Plan
No code changes

## Documentation changes

None

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Remaining TODOs for this PR

-   [ ] 
