### PR TITLE
feat: Add commands in the README to clone and enter the example dirs swiftly

### DIFF
--- a/examples/with-angular-thirdpartyemailpassword/README.md
+++ b/examples/with-angular-thirdpartyemailpassword/README.md
@@ -15,9 +15,11 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-angular-thirdpartyemailpassword
 npm install
 ```
 

--- a/examples/with-emailpassword/README.md
+++ b/examples/with-emailpassword/README.md
@@ -12,9 +12,11 @@ This demo app demonstrates the following use cases:
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-emailpassword
 npm install
 ```
 

--- a/examples/with-emailverification-then-password-thirdpartyemailpassword/README.md
+++ b/examples/with-emailverification-then-password-thirdpartyemailpassword/README.md
@@ -21,9 +21,11 @@ This demo app demonstrates the following use cases:
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-emailverification-then-password-thirdpartyemailpassword
 npm install
 ```
 

--- a/examples/with-emailverification-with-otp/README.md
+++ b/examples/with-emailverification-with-otp/README.md
@@ -12,9 +12,11 @@ This demo app demonstrates the following use cases:
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-emailverification-with-otp
 npm install
 ```
 

--- a/examples/with-hasura-thirdpartyemailpassword/README.md
+++ b/examples/with-hasura-thirdpartyemailpassword/README.md
@@ -15,9 +15,11 @@ You can learn more about the setup [in our docs](https://supertokens.com/docs/th
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-hasura-thirdpartyemailpassword
 npm install
 ```
 

--- a/examples/with-i18next/README.md
+++ b/examples/with-i18next/README.md
@@ -12,9 +12,11 @@ This demo app demonstrates the following use cases:
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-i18next
 npm install
 ```
 

--- a/examples/with-jwt-localstorage/README.md
+++ b/examples/with-jwt-localstorage/README.md
@@ -24,9 +24,11 @@ On the frontend, since we are using our supertokens-auth-react SDK, we save the 
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-jwt-localstorage
 npm install
 ```
 

--- a/examples/with-multiple-email-sign-in/README.md
+++ b/examples/with-multiple-email-sign-in/README.md
@@ -19,9 +19,11 @@ This demo app demonstrates the following use cases:
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-multiple-email-sign-in
 npm install
 ```
 

--- a/examples/with-no-session-on-sign-up-thirdpartyemailpassword/README.md
+++ b/examples/with-no-session-on-sign-up-thirdpartyemailpassword/README.md
@@ -20,9 +20,11 @@ This demo app demonstrates the following use cases:
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-no-session-on-sign-up-thirdpartyemailpassword
 npm install
 ```
 

--- a/examples/with-passwordless/README.md
+++ b/examples/with-passwordless/README.md
@@ -10,9 +10,11 @@ This demo app demonstrates the following use cases:
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-passwordless
 npm install
 ```
 

--- a/examples/with-phone-password/README.md
+++ b/examples/with-phone-password/README.md
@@ -11,9 +11,11 @@ This demo app demonstrates the following use cases:
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-phone-password
 npm install
 ```
 

--- a/examples/with-sign-in-up-split-emailpassword/README.md
+++ b/examples/with-sign-in-up-split-emailpassword/README.md
@@ -14,9 +14,11 @@ This also showcases how you can use the react component override feature and the
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-sign-in-up-split-emailpassword
 npm install
 ```
 

--- a/examples/with-svelte-react-thirdpartyemailpassword/README.md
+++ b/examples/with-svelte-react-thirdpartyemailpassword/README.md
@@ -13,9 +13,11 @@ This also showcases how you can use the supertokens-auth-react SDK inside a svel
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-svelte-react-thirdpartyemailpassword
 npm install
 ```
 

--- a/examples/with-thirdparty/README.md
+++ b/examples/with-thirdparty/README.md
@@ -10,9 +10,11 @@ This demo app demonstrates the following use cases:
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-thirdparty
 npm install
 ```
 

--- a/examples/with-thirdpartyemailpassword-2fa-passwordless/README.md
+++ b/examples/with-thirdpartyemailpassword-2fa-passwordless/README.md
@@ -6,9 +6,11 @@ This demo app demonstrates how we can implement sign in with third party provide
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-thirdpartyemailpassword-2fa-passwordless
 npm install
 ```
 

--- a/examples/with-thirdpartyemailpassword-passwordless/README.md
+++ b/examples/with-thirdpartyemailpassword-passwordless/README.md
@@ -13,9 +13,11 @@ This demo app demonstrates the following use cases:
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-thirdpartyemailpassword-passwordless
 npm install
 ```
 

--- a/examples/with-thirdpartyemailpassword/README.md
+++ b/examples/with-thirdpartyemailpassword/README.md
@@ -12,9 +12,11 @@ This demo app demonstrates the following use cases:
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-thirdpartyemailpassword
 npm install
 ```
 

--- a/examples/with-thirdpartypasswordless-electron/README.md
+++ b/examples/with-thirdpartypasswordless-electron/README.md
@@ -11,9 +11,11 @@ This demo app demonstrates the following use cases:
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-thirdpartypasswordless-electron
 npm install
 ```
 

--- a/examples/with-thirdpartypasswordless/README.md
+++ b/examples/with-thirdpartypasswordless/README.md
@@ -11,9 +11,11 @@ This demo app demonstrates the following use cases:
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-thirdpartypasswordless
 npm install
 ```
 

--- a/examples/with-vue-thirdpartyemailpassword/README.md
+++ b/examples/with-vue-thirdpartyemailpassword/README.md
@@ -13,9 +13,11 @@ In this demo, when our root component loads we will initialize the `supertokens-
 
 ## Project setup
 
-Use `npm` to install the project dependencies:
+Clone the repo, enter the directory, and use `npm` to install the project dependencies:
 
 ```bash
+git clone https://github.com/supertokens/supertokens-auth-react
+cd examples/with-vue-thirdpartyemailpassword
 npm install
 ```
 


### PR DESCRIPTION
## Summary of change

Add commands in the README to clone and enter the example dirs swiftly


## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
