### PR TITLE
fix: Fix step in examples README to cd into supertokens-auth-react dir

### DIFF
--- a/examples/with-angular-thirdpartyemailpassword/README.md
+++ b/examples/with-angular-thirdpartyemailpassword/README.md
@@ -19,7 +19,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-angular-thirdpartyemailpassword
+cd supertokens-auth-react/examples/with-angular-thirdpartyemailpassword
 npm install
 ```
 

--- a/examples/with-emailpassword/README.md
+++ b/examples/with-emailpassword/README.md
@@ -16,7 +16,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-emailpassword
+cd supertokens-auth-react/examples/with-emailpassword
 npm install
 ```
 

--- a/examples/with-emailverification-then-password-thirdpartyemailpassword/README.md
+++ b/examples/with-emailverification-then-password-thirdpartyemailpassword/README.md
@@ -25,7 +25,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-emailverification-then-password-thirdpartyemailpassword
+cd supertokens-auth-react/examples/with-emailverification-then-password-thirdpartyemailpassword
 npm install
 ```
 

--- a/examples/with-emailverification-with-otp/README.md
+++ b/examples/with-emailverification-with-otp/README.md
@@ -16,7 +16,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-emailverification-with-otp
+cd supertokens-auth-react/examples/with-emailverification-with-otp
 npm install
 ```
 

--- a/examples/with-hasura-thirdpartyemailpassword/README.md
+++ b/examples/with-hasura-thirdpartyemailpassword/README.md
@@ -19,7 +19,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-hasura-thirdpartyemailpassword
+cd supertokens-auth-react/examples/with-hasura-thirdpartyemailpassword
 npm install
 ```
 

--- a/examples/with-i18next/README.md
+++ b/examples/with-i18next/README.md
@@ -16,7 +16,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-i18next
+cd supertokens-auth-react/examples/with-i18next
 npm install
 ```
 

--- a/examples/with-jwt-localstorage/README.md
+++ b/examples/with-jwt-localstorage/README.md
@@ -28,7 +28,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-jwt-localstorage
+cd supertokens-auth-react/examples/with-jwt-localstorage
 npm install
 ```
 

--- a/examples/with-multiple-email-sign-in/README.md
+++ b/examples/with-multiple-email-sign-in/README.md
@@ -23,7 +23,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-multiple-email-sign-in
+cd supertokens-auth-react/examples/with-multiple-email-sign-in
 npm install
 ```
 

--- a/examples/with-no-session-on-sign-up-thirdpartyemailpassword/README.md
+++ b/examples/with-no-session-on-sign-up-thirdpartyemailpassword/README.md
@@ -24,7 +24,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-no-session-on-sign-up-thirdpartyemailpassword
+cd supertokens-auth-react/examples/with-no-session-on-sign-up-thirdpartyemailpassword
 npm install
 ```
 

--- a/examples/with-passwordless/README.md
+++ b/examples/with-passwordless/README.md
@@ -14,7 +14,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-passwordless
+cd supertokens-auth-react/examples/with-passwordless
 npm install
 ```
 

--- a/examples/with-phone-password/README.md
+++ b/examples/with-phone-password/README.md
@@ -15,7 +15,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-phone-password
+cd supertokens-auth-react/examples/with-phone-password
 npm install
 ```
 

--- a/examples/with-sign-in-up-split-emailpassword/README.md
+++ b/examples/with-sign-in-up-split-emailpassword/README.md
@@ -18,7 +18,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-sign-in-up-split-emailpassword
+cd supertokens-auth-react/examples/with-sign-in-up-split-emailpassword
 npm install
 ```
 

--- a/examples/with-svelte-react-thirdpartyemailpassword/README.md
+++ b/examples/with-svelte-react-thirdpartyemailpassword/README.md
@@ -17,7 +17,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-svelte-react-thirdpartyemailpassword
+cd supertokens-auth-react/examples/with-svelte-react-thirdpartyemailpassword
 npm install
 ```
 

--- a/examples/with-thirdparty/README.md
+++ b/examples/with-thirdparty/README.md
@@ -14,7 +14,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-thirdparty
+cd supertokens-auth-react/examples/with-thirdparty
 npm install
 ```
 

--- a/examples/with-thirdpartyemailpassword-2fa-passwordless/README.md
+++ b/examples/with-thirdpartyemailpassword-2fa-passwordless/README.md
@@ -10,7 +10,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-thirdpartyemailpassword-2fa-passwordless
+cd supertokens-auth-react/examples/with-thirdpartyemailpassword-2fa-passwordless
 npm install
 ```
 

--- a/examples/with-thirdpartyemailpassword-passwordless/README.md
+++ b/examples/with-thirdpartyemailpassword-passwordless/README.md
@@ -17,7 +17,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-thirdpartyemailpassword-passwordless
+cd supertokens-auth-react/examples/with-thirdpartyemailpassword-passwordless
 npm install
 ```
 

--- a/examples/with-thirdpartyemailpassword/README.md
+++ b/examples/with-thirdpartyemailpassword/README.md
@@ -16,7 +16,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-thirdpartyemailpassword
+cd supertokens-auth-react/examples/with-thirdpartyemailpassword
 npm install
 ```
 

--- a/examples/with-thirdpartypasswordless-electron/README.md
+++ b/examples/with-thirdpartypasswordless-electron/README.md
@@ -15,7 +15,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-thirdpartypasswordless-electron
+cd supertokens-auth-react/examples/with-thirdpartypasswordless-electron
 npm install
 ```
 

--- a/examples/with-thirdpartypasswordless/README.md
+++ b/examples/with-thirdpartypasswordless/README.md
@@ -15,7 +15,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-thirdpartypasswordless
+cd supertokens-auth-react/examples/with-thirdpartypasswordless
 npm install
 ```
 

--- a/examples/with-vue-thirdpartyemailpassword/README.md
+++ b/examples/with-vue-thirdpartyemailpassword/README.md
@@ -17,7 +17,7 @@ Clone the repo, enter the directory, and use `npm` to install the project depend
 
 ```bash
 git clone https://github.com/supertokens/supertokens-auth-react
-cd examples/with-vue-thirdpartyemailpassword
+cd supertokens-auth-react/examples/with-vue-thirdpartyemailpassword
 npm install
 ```
 


### PR DESCRIPTION
## Summary of change

Fix step in examples README to cd into supertokens-auth-react dir

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
