### PR TITLE
fix: GitHub casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Updated `react-scripts` in all examples
 -   Updated READMEs for example apps, removed information that is no longer relevant.
 
+### Fixed
+
+-   Fixed capitalization of GitHub on the UI (fixes https://github.com/supertokens/supertokens-auth-react/issues/539)
+
 ## [0.24.2] - 2022-07-28
 
 -   Fixes prop passing when custom theme is used with the feature components

--- a/lib/build/recipe/thirdparty/providers/github.js
+++ b/lib/build/recipe/thirdparty/providers/github.js
@@ -76,7 +76,7 @@ var Github = /** @class */ (function (_super) {
         var _this =
             _super.call(this, {
                 id: "github",
-                name: "Github",
+                name: "GitHub",
                 clientId: config === null || config === void 0 ? void 0 : config.clientId,
             }) || this;
         _this.getButton = function () {

--- a/lib/ts/recipe/thirdparty/providers/github.tsx
+++ b/lib/ts/recipe/thirdparty/providers/github.tsx
@@ -36,7 +36,7 @@ export default class Github extends Provider {
     constructor(config?: BuiltInProviderConfig) {
         super({
             id: "github",
-            name: "Github",
+            name: "GitHub",
             clientId: config?.clientId,
         });
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -488,7 +488,7 @@ export async function getLatestURLWithToken() {
 export async function assertProviders(page) {
     const providers = await getProvidersLabels(page);
     assert.deepStrictEqual(providers, [
-        "Continue with Github",
+        "Continue with GitHub",
         "Continue with Google",
         "Continue with Facebook",
         "Continue with Apple",


### PR DESCRIPTION
## Summary of change

Fix how we capitalize GitHub on the UI (API remains unchanged)

## Related issues

-   #539 

## Test Plan

Updated string in tests

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
