### PR TITLE
feat!: rethrow errors occuring during onmount async calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Updated `react-scripts` in all examples
 -   Updated READMEs for example apps, removed information that is no longer relevant.
 
+### Breaking changes
+
+-   SuperTokens components can now throw in case the server goes down. We advise adding an ErrorBoundary to provide a meaningful error screen. Please check here: https://reactjs.org/docs/error-boundaries.html
+
 ## [0.24.2] - 2022-07-28
 
 -   Fixes prop passing when custom theme is used with the feature components

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -678,6 +678,9 @@ var useOnMountAPICall = function (fetch, handleResponse, handleError, startLoadi
         startLoading = true;
     }
     var consumeReq = (0, react_1.useRef)();
+    var _a = (0, react_1.useState)(undefined),
+        error = _a[0],
+        setError = _a[1];
     (0, react_1.useEffect)(
         function () {
             var effect = function (signal) {
@@ -699,8 +702,12 @@ var useOnMountAPICall = function (fetch, handleResponse, handleError, startLoadi
                                 return [3 /*break*/, 3];
                             case 2:
                                 err_1 = _a.sent();
-                                if (!signal.aborted && handleError) {
-                                    handleError(err_1, resp);
+                                if (!signal.aborted) {
+                                    if (handleError !== undefined) {
+                                        handleError(err_1, resp);
+                                    } else {
+                                        setError(err_1);
+                                    }
                                 }
                                 return [3 /*break*/, 3];
                             case 3:
@@ -718,7 +725,10 @@ var useOnMountAPICall = function (fetch, handleResponse, handleError, startLoadi
             }
             return;
         },
-        [consumeReq, fetch, handleResponse, handleError, startLoading]
+        [setError, consumeReq, fetch, handleResponse, handleError, startLoading]
     );
+    if (error) {
+        throw error;
+    }
 };
 exports.useOnMountAPICall = useOnMountAPICall;

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -13,7 +13,7 @@
  * under the License.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { DEFAULT_API_BASE_PATH, DEFAULT_WEBSITE_BASE_PATH, RECIPE_ID_QUERY_PARAM } from "./constants";
 import { CookieHandlerReference } from "supertokens-website/utils/cookieHandler";
 import NormalisedURLDomain from "supertokens-web-js/utils/normalisedURLDomain";
@@ -409,6 +409,7 @@ export const useOnMountAPICall = <T>(
 ) => {
     const consumeReq = useRef<Promise<T>>();
 
+    const [error, setError] = useState<any>(undefined);
     useEffect(() => {
         const effect = async (signal: AbortSignal) => {
             let resp;
@@ -423,8 +424,12 @@ export const useOnMountAPICall = <T>(
                     void handleResponse(resp);
                 }
             } catch (err) {
-                if (!signal.aborted && handleError) {
-                    handleError(err, resp);
+                if (!signal.aborted) {
+                    if (handleError !== undefined) {
+                        handleError(err, resp);
+                    } else {
+                        setError(err);
+                    }
                 }
             }
         };
@@ -437,5 +442,9 @@ export const useOnMountAPICall = <T>(
             };
         }
         return;
-    }, [consumeReq, fetch, handleResponse, handleError, startLoading]);
+    }, [setError, consumeReq, fetch, handleResponse, handleError, startLoading]);
+
+    if (error) {
+        throw error;
+    }
 };


### PR DESCRIPTION
## Summary of change

Rethrow errors that occur in the `fetch` part of `useOnMountAPICall` if no handler is added.

Rationale: This will result in the render throwing, and potentially the entire react tree being unmounted (e.g., if the server/ST core goes down), but also allows the user to add an error boundary that can handle the error and provide a meaningful error screen.
Matches the philosophy of React on unhandled errors: https://reactjs.org/docs/error-boundaries.html#new-behavior-for-uncaught-errors

## Related issues

-   #547

## Test Plan

Not sure how we could test this meaningfully.

## Documentation changes

Not necessary, but we could advise adding an error boundary.

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
