### PR TITLE
feat: remove remaining emailverification references

### DIFF
--- a/lib/build/recipe/thirdparty/index.d.ts
+++ b/lib/build/recipe/thirdparty/index.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="react" />
-import EmailVerificationTheme from "../emailverification/components/themes/emailVerification";
 import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 import SignInAndUpTheme from "./components/themes/signInAndUp";
 import { SignInAndUpCallbackTheme } from "./components/themes/signInAndUpCallback";
@@ -74,8 +73,6 @@ export default class Wrapper {
     static SignInAndUpTheme: import("react").FC<import("./types").SignInAndUpThemeProps>;
     static SignInAndUpCallback: (prop?: any) => JSX.Element;
     static SignInAndUpCallbackTheme: import("react").ComponentType<{}>;
-    static EmailVerification: (prop?: any) => JSX.Element;
-    static EmailVerificationTheme: typeof EmailVerificationTheme;
 }
 declare const init: typeof Wrapper.init;
 declare const signOut: typeof Wrapper.signOut;
@@ -92,7 +89,6 @@ declare const getAuthStateFromURL: typeof Wrapper.getAuthStateFromURL;
 declare const signInAndUp: typeof Wrapper.signInAndUp;
 declare const SignInAndUp: (prop?: any) => JSX.Element;
 declare const SignInAndUpCallback: (prop?: any) => JSX.Element;
-declare const EmailVerification: (prop?: any) => JSX.Element;
 export {
     init,
     Apple,
@@ -115,8 +111,6 @@ export {
     SignInAndUpCallback,
     SignInAndUpCallbackTheme,
     signOut,
-    EmailVerification,
-    EmailVerificationTheme,
     User,
     GetRedirectionURLContext,
     PreAPIHookContext,

--- a/lib/build/recipe/thirdparty/index.js
+++ b/lib/build/recipe/thirdparty/index.js
@@ -164,9 +164,7 @@ var __importDefault =
         return mod && mod.__esModule ? mod : { default: mod };
     };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.EmailVerificationTheme =
-    exports.EmailVerification =
-    exports.signOut =
+exports.signOut =
     exports.SignInAndUpCallbackTheme =
     exports.SignInAndUpCallback =
     exports.SignInAndUpTheme =
@@ -193,8 +191,6 @@ exports.EmailVerificationTheme =
  */
 // /!\ ThirdParty must be imported before any of the providers to prevent circular dependencies.
 var recipe_1 = __importDefault(require("./recipe"));
-var emailVerification_1 = __importDefault(require("../emailverification/components/themes/emailVerification"));
-exports.EmailVerificationTheme = emailVerification_1.default;
 var signInAndUp_1 = __importDefault(require("./components/themes/signInAndUp"));
 exports.SignInAndUpTheme = signInAndUp_1.default;
 var signInAndUpCallback_1 = require("./components/themes/signInAndUpCallback");
@@ -385,10 +381,6 @@ var Wrapper = /** @class */ (function () {
         return recipe_1.default.getInstanceOrThrow().getFeatureComponent("signinupcallback", prop);
     };
     Wrapper.SignInAndUpCallbackTheme = signInAndUpCallback_1.SignInAndUpCallbackTheme;
-    Wrapper.EmailVerification = function (prop) {
-        return recipe_1.default.getInstanceOrThrow().getFeatureComponent("emailverification", prop);
-    };
-    Wrapper.EmailVerificationTheme = emailVerification_1.default;
     return Wrapper;
 })();
 exports.default = Wrapper;
@@ -422,5 +414,3 @@ var SignInAndUp = Wrapper.SignInAndUp;
 exports.SignInAndUp = SignInAndUp;
 var SignInAndUpCallback = Wrapper.SignInAndUpCallback;
 exports.SignInAndUpCallback = SignInAndUpCallback;
-var EmailVerification = Wrapper.EmailVerification;
-exports.EmailVerification = EmailVerification;

--- a/lib/build/recipe/thirdparty/recipe.d.ts
+++ b/lib/build/recipe/thirdparty/recipe.d.ts
@@ -21,10 +21,7 @@ export default class ThirdParty extends AuthRecipe<
     recipeImpl: WebJSRecipeInterface;
     constructor(config: Config);
     getFeatures: () => RecipeFeatureComponentMap;
-    getFeatureComponent: (
-        componentName: "signinup" | "signinupcallback" | "emailverification",
-        props: any
-    ) => JSX.Element;
+    getFeatureComponent: (componentName: "signinup" | "signinupcallback", props: any) => JSX.Element;
     getDefaultRedirectionURL: (context: GetRedirectionURLContext) => Promise<string>;
     static init(
         config: UserInput

--- a/lib/build/recipe/thirdpartyemailpassword/index.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/index.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="react" />
-import EmailVerificationTheme from "../emailverification/components/themes/emailVerification";
 import ResetPasswordUsingTokenTheme from "../emailpassword/components/themes/resetPasswordUsingToken";
 import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 import SignInAndUpTheme from "./components/themes/signInAndUp";
@@ -174,15 +173,12 @@ export default class Wrapper {
     static ThirdPartySignInAndUpCallback: (prop?: any) => JSX.Element;
     static ResetPasswordUsingToken: (prop?: any) => JSX.Element;
     static ResetPasswordUsingTokenTheme: typeof ResetPasswordUsingTokenTheme;
-    static EmailVerification: (prop?: any) => JSX.Element;
-    static EmailVerificationTheme: typeof EmailVerificationTheme;
     static ThirdPartySignInAndUpCallbackTheme: import("react").ComponentType<{}>;
 }
 declare const init: typeof Wrapper.init;
 declare const signOut: typeof Wrapper.signOut;
 declare const SignInAndUp: (prop?: any) => JSX.Element;
 declare const ThirdPartySignInAndUpCallback: (prop?: any) => JSX.Element;
-declare const EmailVerification: (prop?: any) => JSX.Element;
 declare const ResetPasswordUsingToken: (prop?: any) => JSX.Element;
 declare const submitNewPassword: typeof Wrapper.submitNewPassword;
 declare const sendPasswordResetEmail: typeof Wrapper.sendPasswordResetEmail;
@@ -229,8 +225,6 @@ export {
     getAuthCodeFromURL,
     getAuthErrorFromURL,
     getAuthStateFromURL,
-    EmailVerification,
-    EmailVerificationTheme,
     ResetPasswordUsingToken,
     ResetPasswordUsingTokenTheme,
     GetRedirectionURLContext,

--- a/lib/build/recipe/thirdpartyemailpassword/index.js
+++ b/lib/build/recipe/thirdpartyemailpassword/index.js
@@ -152,8 +152,6 @@ var __importDefault =
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ResetPasswordUsingTokenTheme =
     exports.ResetPasswordUsingToken =
-    exports.EmailVerificationTheme =
-    exports.EmailVerification =
     exports.getAuthStateFromURL =
     exports.getAuthErrorFromURL =
     exports.getAuthCodeFromURL =
@@ -197,8 +195,6 @@ exports.ResetPasswordUsingTokenTheme =
  * under the License.
  */
 var recipe_1 = __importDefault(require("./recipe"));
-var emailVerification_1 = __importDefault(require("../emailverification/components/themes/emailVerification"));
-exports.EmailVerificationTheme = emailVerification_1.default;
 var resetPasswordUsingToken_1 = __importDefault(require("../emailpassword/components/themes/resetPasswordUsingToken"));
 exports.ResetPasswordUsingTokenTheme = resetPasswordUsingToken_1.default;
 var signInAndUp_1 = __importDefault(require("./components/themes/signInAndUp"));
@@ -489,10 +485,6 @@ var Wrapper = /** @class */ (function () {
         return recipe_1.default.getInstanceOrThrow().getFeatureComponent("resetpassword", prop);
     };
     Wrapper.ResetPasswordUsingTokenTheme = resetPasswordUsingToken_1.default;
-    Wrapper.EmailVerification = function (prop) {
-        return recipe_1.default.getInstanceOrThrow().getFeatureComponent("emailverification", prop);
-    };
-    Wrapper.EmailVerificationTheme = emailVerification_1.default;
     Wrapper.ThirdPartySignInAndUpCallbackTheme = signInAndUpCallback_1.SignInAndUpCallbackTheme;
     return Wrapper;
 })();
@@ -505,8 +497,6 @@ var SignInAndUp = Wrapper.SignInAndUp;
 exports.SignInAndUp = SignInAndUp;
 var ThirdPartySignInAndUpCallback = Wrapper.ThirdPartySignInAndUpCallback;
 exports.ThirdPartySignInAndUpCallback = ThirdPartySignInAndUpCallback;
-var EmailVerification = Wrapper.EmailVerification;
-exports.EmailVerification = EmailVerification;
 var ResetPasswordUsingToken = Wrapper.ResetPasswordUsingToken;
 exports.ResetPasswordUsingToken = ResetPasswordUsingToken;
 var submitNewPassword = Wrapper.submitNewPassword;

--- a/lib/build/recipe/thirdpartyemailpassword/recipe.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/recipe.d.ts
@@ -11,7 +11,6 @@ import {
 } from "./types";
 import EmailPassword from "../emailpassword/recipe";
 import ThirdParty from "../thirdparty/recipe";
-import EmailVerification from "../emailverification/recipe";
 import { RecipeInterface } from "supertokens-web-js/recipe/thirdpartyemailpassword";
 export default class ThirdPartyEmailPassword extends AuthRecipe<
     GetRedirectionURLContext,
@@ -27,17 +26,13 @@ export default class ThirdPartyEmailPassword extends AuthRecipe<
     constructor(
         config: Config,
         recipes: {
-            emailVerificationInstance: EmailVerification | undefined;
             thirdPartyInstance: ThirdParty | undefined;
             emailPasswordInstance: EmailPassword | undefined;
         }
     );
     getFeatures: () => RecipeFeatureComponentMap;
     getDefaultRedirectionURL: (context: GetRedirectionURLContext) => Promise<string>;
-    getFeatureComponent: (
-        componentName: "signinup" | "signinupcallback" | "resetpassword" | "emailverification",
-        props: any
-    ) => JSX.Element;
+    getFeatureComponent: (componentName: "signinup" | "signinupcallback" | "resetpassword", props: any) => JSX.Element;
     static init(
         config: UserInput
     ): CreateRecipeFunction<GetRedirectionURLContext, PreAndPostAPIHookAction, OnHandleEventContext, NormalisedConfig>;

--- a/lib/build/recipe/thirdpartyemailpassword/recipe.js
+++ b/lib/build/recipe/thirdpartyemailpassword/recipe.js
@@ -357,7 +357,6 @@ var ThirdPartyEmailPassword = /** @class */ (function (_super) {
                 __assign(__assign({}, config), { appInfo: appInfo, recipeId: ThirdPartyEmailPassword.RECIPE_ID }),
                 {
                     emailPasswordInstance: undefined,
-                    emailVerificationInstance: undefined,
                     thirdPartyInstance: undefined,
                 }
             );

--- a/lib/build/recipe/thirdpartypasswordless/index.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/index.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="react" />
-import EmailVerificationTheme from "../emailverification/components/themes/emailVerification";
 import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 import SignInUpTheme from "./components/themes/signInUp";
 import { Apple, Google, Facebook, Github } from "../thirdparty/";
@@ -163,8 +162,6 @@ export default class Wrapper {
     static SignInAndUp: (prop?: any) => JSX.Element;
     static SignInAndUpTheme: typeof SignInUpTheme;
     static ThirdPartySignInAndUpCallback: (prop?: any) => JSX.Element;
-    static EmailVerification: (prop?: any) => JSX.Element;
-    static EmailVerificationTheme: typeof EmailVerificationTheme;
     static PasswordlessLinkClickedTheme: import("react").ComponentType<
         import("../passwordless/types").LinkClickedScreenProps & {
             children?: import("react").ReactNode;
@@ -197,7 +194,6 @@ declare const setPasswordlessLoginAttemptInfo: typeof Wrapper.setPasswordlessLog
 declare const clearPasswordlessLoginAttemptInfo: typeof Wrapper.clearPasswordlessLoginAttemptInfo;
 declare const SignInAndUp: (prop?: any) => JSX.Element;
 declare const ThirdPartySignInAndUpCallback: (prop?: any) => JSX.Element;
-declare const EmailVerification: (prop?: any) => JSX.Element;
 declare const PasswordlessLinkClicked: (prop?: any) => JSX.Element;
 export {
     init,
@@ -230,8 +226,6 @@ export {
     SignInUpTheme,
     ThirdPartySignInAndUpCallback,
     signOut,
-    EmailVerification,
-    EmailVerificationTheme,
     PasswordlessLinkClicked,
     GetRedirectionURLContext,
     PreAPIHookContext,

--- a/lib/build/recipe/thirdpartypasswordless/index.js
+++ b/lib/build/recipe/thirdpartypasswordless/index.js
@@ -191,8 +191,6 @@ var __importDefault =
     };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.PasswordlessLinkClicked =
-    exports.EmailVerificationTheme =
-    exports.EmailVerification =
     exports.signOut =
     exports.ThirdPartySignInAndUpCallback =
     exports.SignInUpTheme =
@@ -239,8 +237,6 @@ exports.PasswordlessLinkClicked =
  * under the License.
  */
 var recipe_1 = __importDefault(require("./recipe"));
-var emailVerification_1 = __importDefault(require("../emailverification/components/themes/emailVerification"));
-exports.EmailVerificationTheme = emailVerification_1.default;
 var signInUp_1 = __importDefault(require("./components/themes/signInUp"));
 exports.SignInUpTheme = signInUp_1.default;
 var thirdparty_1 = require("../thirdparty/");
@@ -594,10 +590,6 @@ var Wrapper = /** @class */ (function () {
     Wrapper.ThirdPartySignInAndUpCallback = function (prop) {
         return recipe_1.default.getInstanceOrThrow().getFeatureComponent("signinupcallback", prop);
     };
-    Wrapper.EmailVerification = function (prop) {
-        return recipe_1.default.getInstanceOrThrow().getFeatureComponent("emailverification", prop);
-    };
-    Wrapper.EmailVerificationTheme = emailVerification_1.default;
     Wrapper.PasswordlessLinkClickedTheme = linkClickedScreen_1.LinkClickedScreen;
     Wrapper.PasswordlessLinkClicked = function (prop) {
         return recipe_1.default.getInstanceOrThrow().getFeatureComponent("linkClickedScreen", prop);
@@ -657,7 +649,5 @@ var SignInAndUp = Wrapper.SignInAndUp;
 exports.SignInAndUp = SignInAndUp;
 var ThirdPartySignInAndUpCallback = Wrapper.ThirdPartySignInAndUpCallback;
 exports.ThirdPartySignInAndUpCallback = ThirdPartySignInAndUpCallback;
-var EmailVerification = Wrapper.EmailVerification;
-exports.EmailVerification = EmailVerification;
 var PasswordlessLinkClicked = Wrapper.PasswordlessLinkClicked;
 exports.PasswordlessLinkClicked = PasswordlessLinkClicked;

--- a/lib/build/recipe/thirdpartypasswordless/recipe.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/recipe.d.ts
@@ -11,7 +11,6 @@ import {
 } from "./types";
 import Passwordless from "../passwordless/recipe";
 import ThirdParty from "../thirdparty/recipe";
-import EmailVerification from "../emailverification/recipe";
 import { RecipeInterface as TPPWlessRecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
 export default class ThirdPartyPasswordless extends AuthRecipe<
     GetRedirectionURLContext,
@@ -27,7 +26,6 @@ export default class ThirdPartyPasswordless extends AuthRecipe<
     constructor(
         config: Config,
         recipes: {
-            emailVerificationInstance: EmailVerification | undefined;
             thirdPartyInstance: ThirdParty | undefined;
             passwordlessInstance: Passwordless | undefined;
         }
@@ -35,7 +33,7 @@ export default class ThirdPartyPasswordless extends AuthRecipe<
     getFeatures: () => RecipeFeatureComponentMap;
     getDefaultRedirectionURL: (context: GetRedirectionURLContext) => Promise<string>;
     getFeatureComponent: (
-        componentName: "emailverification" | "signInUp" | "linkClickedScreen" | "signinupcallback",
+        componentName: "signInUp" | "linkClickedScreen" | "signinupcallback",
         props: any
     ) => JSX.Element;
     static init(

--- a/lib/build/recipe/thirdpartypasswordless/recipe.js
+++ b/lib/build/recipe/thirdpartypasswordless/recipe.js
@@ -346,7 +346,6 @@ var ThirdPartyPasswordless = /** @class */ (function (_super) {
                 __assign(__assign({}, config), { appInfo: appInfo, recipeId: ThirdPartyPasswordless.RECIPE_ID }),
                 {
                     passwordlessInstance: undefined,
-                    emailVerificationInstance: undefined,
                     thirdPartyInstance: undefined,
                 }
             );

--- a/lib/ts/recipe/thirdparty/index.ts
+++ b/lib/ts/recipe/thirdparty/index.ts
@@ -19,7 +19,6 @@
 
 // /!\ ThirdParty must be imported before any of the providers to prevent circular dependencies.
 import ThirdParty from "./recipe";
-import EmailVerificationTheme from "../emailverification/components/themes/emailVerification";
 import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 import SignInAndUpTheme from "./components/themes/signInAndUp";
 import { SignInAndUpCallbackTheme } from "./components/themes/signInAndUpCallback";
@@ -176,9 +175,6 @@ export default class Wrapper {
     static SignInAndUpCallback = (prop?: any) =>
         ThirdParty.getInstanceOrThrow().getFeatureComponent("signinupcallback", prop);
     static SignInAndUpCallbackTheme = SignInAndUpCallbackTheme;
-    static EmailVerification = (prop?: any) =>
-        ThirdParty.getInstanceOrThrow().getFeatureComponent("emailverification", prop);
-    static EmailVerificationTheme = EmailVerificationTheme;
 }
 
 const init = Wrapper.init;
@@ -196,7 +192,6 @@ const getAuthStateFromURL = Wrapper.getAuthStateFromURL;
 const signInAndUp = Wrapper.signInAndUp;
 const SignInAndUp = Wrapper.SignInAndUp;
 const SignInAndUpCallback = Wrapper.SignInAndUpCallback;
-const EmailVerification = Wrapper.EmailVerification;
 
 export {
     init,
@@ -220,8 +215,6 @@ export {
     SignInAndUpCallback,
     SignInAndUpCallbackTheme,
     signOut,
-    EmailVerification,
-    EmailVerificationTheme,
     User,
     GetRedirectionURLContext,
     PreAPIHookContext,

--- a/lib/ts/recipe/thirdparty/recipe.tsx
+++ b/lib/ts/recipe/thirdparty/recipe.tsx
@@ -97,10 +97,7 @@ export default class ThirdParty extends AuthRecipe<
         return features;
     };
 
-    getFeatureComponent = (
-        componentName: "signinup" | "signinupcallback" | "emailverification",
-        props: any
-    ): JSX.Element => {
+    getFeatureComponent = (componentName: "signinup" | "signinupcallback", props: any): JSX.Element => {
         if (componentName === "signinup") {
             return (
                 <UserContextWrapper userContext={props.userContext}>

--- a/lib/ts/recipe/thirdpartyemailpassword/index.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/index.ts
@@ -13,7 +13,6 @@
  * under the License.
  */
 import ThirdPartyEmailPassword from "./recipe";
-import EmailVerificationTheme from "../emailverification/components/themes/emailVerification";
 import ResetPasswordUsingTokenTheme from "../emailpassword/components/themes/resetPasswordUsingToken";
 
 import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
@@ -309,9 +308,6 @@ export default class Wrapper {
     static ResetPasswordUsingToken = (prop?: any) =>
         ThirdPartyEmailPassword.getInstanceOrThrow().getFeatureComponent("resetpassword", prop);
     static ResetPasswordUsingTokenTheme = ResetPasswordUsingTokenTheme;
-    static EmailVerification = (prop?: any) =>
-        ThirdPartyEmailPassword.getInstanceOrThrow().getFeatureComponent("emailverification", prop);
-    static EmailVerificationTheme = EmailVerificationTheme;
     static ThirdPartySignInAndUpCallbackTheme = ThirdPartySignInAndUpCallbackTheme;
 }
 
@@ -319,7 +315,6 @@ const init = Wrapper.init;
 const signOut = Wrapper.signOut;
 const SignInAndUp = Wrapper.SignInAndUp;
 const ThirdPartySignInAndUpCallback = Wrapper.ThirdPartySignInAndUpCallback;
-const EmailVerification = Wrapper.EmailVerification;
 const ResetPasswordUsingToken = Wrapper.ResetPasswordUsingToken;
 const submitNewPassword = Wrapper.submitNewPassword;
 const sendPasswordResetEmail = Wrapper.sendPasswordResetEmail;
@@ -367,8 +362,6 @@ export {
     getAuthCodeFromURL,
     getAuthErrorFromURL,
     getAuthStateFromURL,
-    EmailVerification,
-    EmailVerificationTheme,
     ResetPasswordUsingToken,
     ResetPasswordUsingTokenTheme,
     GetRedirectionURLContext,

--- a/lib/ts/recipe/thirdpartyemailpassword/recipe.tsx
+++ b/lib/ts/recipe/thirdpartyemailpassword/recipe.tsx
@@ -35,7 +35,6 @@ import SignInAndUp from "./components/features/signInAndUp";
 import EmailPassword from "../emailpassword/recipe";
 import ThirdParty from "../thirdparty/recipe";
 import RecipeImplementation from "./recipeImplementation";
-import EmailVerification from "../emailverification/recipe";
 import AuthWidgetWrapper from "../authRecipe/authWidgetWrapper";
 import { RecipeInterface } from "supertokens-web-js/recipe/thirdpartyemailpassword";
 import OverrideableBuilder from "supertokens-js-override";
@@ -61,7 +60,6 @@ export default class ThirdPartyEmailPassword extends AuthRecipe<
     constructor(
         config: Config,
         recipes: {
-            emailVerificationInstance: EmailVerification | undefined;
             thirdPartyInstance: ThirdParty | undefined;
             emailPasswordInstance: EmailPassword | undefined;
         }
@@ -173,7 +171,7 @@ export default class ThirdPartyEmailPassword extends AuthRecipe<
     };
 
     getFeatureComponent = (
-        componentName: "signinup" | "signinupcallback" | "resetpassword" | "emailverification",
+        componentName: "signinup" | "signinupcallback" | "resetpassword",
         props: any
     ): JSX.Element => {
         if (componentName === "signinup") {
@@ -226,7 +224,6 @@ export default class ThirdPartyEmailPassword extends AuthRecipe<
                 },
                 {
                     emailPasswordInstance: undefined,
-                    emailVerificationInstance: undefined,
                     thirdPartyInstance: undefined,
                 }
             );

--- a/lib/ts/recipe/thirdpartypasswordless/index.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/index.ts
@@ -13,7 +13,6 @@
  * under the License.
  */
 import ThirdPartyPasswordless from "./recipe";
-import EmailVerificationTheme from "../emailverification/components/themes/emailVerification";
 
 import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 import SignInUpTheme from "./components/themes/signInUp";
@@ -340,9 +339,6 @@ export default class Wrapper {
     static SignInAndUpTheme = SignInUpTheme;
     static ThirdPartySignInAndUpCallback = (prop?: any) =>
         ThirdPartyPasswordless.getInstanceOrThrow().getFeatureComponent("signinupcallback", prop);
-    static EmailVerification = (prop?: any) =>
-        ThirdPartyPasswordless.getInstanceOrThrow().getFeatureComponent("emailverification", prop);
-    static EmailVerificationTheme = EmailVerificationTheme;
 
     static PasswordlessLinkClickedTheme = LinkClickedScreen;
     static PasswordlessLinkClicked = (prop?: any) =>
@@ -375,7 +371,6 @@ const setPasswordlessLoginAttemptInfo = Wrapper.setPasswordlessLoginAttemptInfo;
 const clearPasswordlessLoginAttemptInfo = Wrapper.clearPasswordlessLoginAttemptInfo;
 const SignInAndUp = Wrapper.SignInAndUp;
 const ThirdPartySignInAndUpCallback = Wrapper.ThirdPartySignInAndUpCallback;
-const EmailVerification = Wrapper.EmailVerification;
 const PasswordlessLinkClicked = Wrapper.PasswordlessLinkClicked;
 
 export {
@@ -409,8 +404,6 @@ export {
     SignInUpTheme,
     ThirdPartySignInAndUpCallback,
     signOut,
-    EmailVerification,
-    EmailVerificationTheme,
     PasswordlessLinkClicked,
     GetRedirectionURLContext,
     PreAPIHookContext,

--- a/lib/ts/recipe/thirdpartypasswordless/recipe.tsx
+++ b/lib/ts/recipe/thirdpartypasswordless/recipe.tsx
@@ -38,7 +38,6 @@ import ThirdParty from "../thirdparty/recipe";
 import RecipeImplementation from "./recipeImplementation";
 import getPasswordlessImpl from "./recipeImplementation/passwordlessImplementation";
 import getThirdPartyImpl from "./recipeImplementation/thirdPartyImplementation";
-import EmailVerification from "../emailverification/recipe";
 import AuthWidgetWrapper from "../authRecipe/authWidgetWrapper";
 import OverrideableBuilder from "supertokens-js-override";
 import { RecipeInterface as TPPWlessRecipeInterface } from "supertokens-web-js/recipe/thirdpartypasswordless";
@@ -62,7 +61,6 @@ export default class ThirdPartyPasswordless extends AuthRecipe<
     constructor(
         config: Config,
         recipes: {
-            emailVerificationInstance: EmailVerification | undefined;
             thirdPartyInstance: ThirdParty | undefined;
             passwordlessInstance: Passwordless | undefined;
         }
@@ -155,7 +153,7 @@ export default class ThirdPartyPasswordless extends AuthRecipe<
     };
 
     getFeatureComponent = (
-        componentName: "emailverification" | "signInUp" | "linkClickedScreen" | "signinupcallback",
+        componentName: "signInUp" | "linkClickedScreen" | "signinupcallback",
         props: any
     ): JSX.Element => {
         if (componentName === "signInUp") {
@@ -210,7 +208,6 @@ export default class ThirdPartyPasswordless extends AuthRecipe<
                 },
                 {
                     passwordlessInstance: undefined,
-                    emailVerificationInstance: undefined,
                     thirdPartyInstance: undefined,
                 }
             );

--- a/test/unit/exports.test.tsx
+++ b/test/unit/exports.test.tsx
@@ -17,8 +17,6 @@ describe("Exports", function () {
                 signOut,
                 signUp,
                 submitNewPassword,
-                redirectToAuth,
-                EmailPasswordAuth,
                 ResetPasswordUsingToken,
                 ResetPasswordUsingTokenTheme,
                 SignInAndUp,
@@ -33,8 +31,6 @@ describe("Exports", function () {
             assert(signUp !== undefined && _default.signUp !== undefined);
             assert(submitNewPassword !== undefined && _default.submitNewPassword !== undefined);
 
-            assert(redirectToAuth !== undefined && _default.redirectToAuth !== undefined);
-            assert(EmailPasswordAuth !== undefined && _default.EmailPasswordAuth !== undefined);
             assert(ResetPasswordUsingToken !== undefined && _default.ResetPasswordUsingToken !== undefined);
             assert(ResetPasswordUsingTokenTheme !== undefined && _default.ResetPasswordUsingTokenTheme !== undefined);
             assert(SignInAndUp !== undefined && _default.SignInAndUp !== undefined);
@@ -58,7 +54,6 @@ describe("Exports", function () {
                 signInAndUp,
                 signOut,
                 verifyAndGetStateOrThrowError,
-                redirectToAuth,
                 redirectToThirdPartyLogin,
                 Facebook,
                 Apple,
@@ -68,7 +63,6 @@ describe("Exports", function () {
                 SignInAndUpCallback,
                 SignInAndUpCallbackTheme,
                 SignInAndUpTheme,
-                ThirdPartyAuth,
             } = require("../../recipe/thirdparty");
 
             assert(init !== undefined && _default.init !== undefined);
@@ -94,7 +88,6 @@ describe("Exports", function () {
             assert(signOut !== undefined && _default.signOut !== undefined);
             assert(verifyAndGetStateOrThrowError !== undefined && _default.verifyAndGetStateOrThrowError !== undefined);
 
-            assert(redirectToAuth !== undefined && _default.redirectToAuth !== undefined);
             assert(redirectToThirdPartyLogin !== undefined && _default.redirectToThirdPartyLogin !== undefined);
             assert(Facebook !== undefined && _default.Facebook !== undefined);
             assert(Apple !== undefined && _default.Apple !== undefined);
@@ -104,7 +97,6 @@ describe("Exports", function () {
             assert(SignInAndUpCallback !== undefined && _default.SignInAndUpCallback !== undefined);
             assert(SignInAndUpCallbackTheme !== undefined && _default.SignInAndUpCallbackTheme !== undefined);
             assert(SignInAndUpTheme !== undefined && _default.SignInAndUpTheme !== undefined);
-            assert(ThirdPartyAuth !== undefined && _default.ThirdPartyAuth !== undefined);
         });
     });
 
@@ -130,7 +122,6 @@ describe("Exports", function () {
                 submitNewPassword,
                 thirdPartySignInAndUp,
                 verifyAndGetStateOrThrowError,
-                redirectToAuth,
                 redirectToThirdPartyLogin,
                 Apple,
                 Facebook,
@@ -140,7 +131,6 @@ describe("Exports", function () {
                 ResetPasswordUsingTokenTheme,
                 SignInAndUp,
                 SignInAndUpTheme,
-                ThirdPartyEmailPasswordAuth,
                 ThirdPartySignInAndUpCallback,
                 ThirdPartySignInAndUpCallbackTheme,
             } = require("../../recipe/thirdpartyemailpassword");
@@ -174,7 +164,6 @@ describe("Exports", function () {
             assert(thirdPartySignInAndUp !== undefined && _default.thirdPartySignInAndUp !== undefined);
             assert(verifyAndGetStateOrThrowError !== undefined && _default.verifyAndGetStateOrThrowError !== undefined);
 
-            assert(redirectToAuth !== undefined && _default.redirectToAuth !== undefined);
             assert(redirectToThirdPartyLogin !== undefined && _default.redirectToThirdPartyLogin !== undefined);
             assert(Apple !== undefined && _default.Apple !== undefined);
             assert(Facebook !== undefined && _default.Facebook !== undefined);
@@ -184,7 +173,6 @@ describe("Exports", function () {
             assert(ResetPasswordUsingTokenTheme !== undefined && _default.ResetPasswordUsingTokenTheme !== undefined);
             assert(SignInAndUp !== undefined && _default.SignInAndUp !== undefined);
             assert(SignInAndUpTheme !== undefined && _default.SignInAndUpTheme !== undefined);
-            assert(ThirdPartyEmailPasswordAuth !== undefined && _default.ThirdPartyEmailPasswordAuth !== undefined);
             assert(ThirdPartySignInAndUpCallback !== undefined && _default.ThirdPartySignInAndUpCallback !== undefined);
             assert(
                 ThirdPartySignInAndUpCallbackTheme !== undefined &&
@@ -209,9 +197,7 @@ describe("Exports", function () {
                 init,
                 setLoginAttemptInfo,
                 signOut,
-                redirectToAuth,
                 LinkClicked,
-                PasswordlessAuth,
                 SignInUp,
                 SignInUpTheme,
             } = require("../../recipe/passwordless");
@@ -229,9 +215,7 @@ describe("Exports", function () {
             assert(setLoginAttemptInfo !== undefined && _default.setLoginAttemptInfo !== undefined);
             assert(signOut !== undefined && _default.signOut !== undefined);
 
-            assert(redirectToAuth !== undefined && _default.redirectToAuth !== undefined);
             assert(LinkClicked !== undefined && _default.LinkClicked !== undefined);
-            assert(PasswordlessAuth !== undefined && _default.PasswordlessAuth !== undefined);
             assert(SignInUp !== undefined && _default.SignInUp !== undefined);
             assert(SignInUpTheme !== undefined && _default.SignInUpTheme !== undefined);
         });
@@ -263,7 +247,6 @@ describe("Exports", function () {
                 signOut,
                 thirdPartySignInAndUp,
                 verifyAndGetThirdPartyStateOrThrowError,
-                redirectToAuth,
                 redirectToThirdPartyLogin,
                 Apple,
                 Facebook,
@@ -272,7 +255,6 @@ describe("Exports", function () {
                 PasswordlessLinkClicked,
                 SignInAndUp,
                 SignInUpTheme,
-                ThirdPartyPasswordlessAuth,
                 ThirdPartySignInAndUpCallback,
             } = require("../../recipe/thirdpartypasswordless");
 
@@ -333,7 +315,6 @@ describe("Exports", function () {
                     _default.verifyAndGetThirdPartyStateOrThrowError !== undefined
             );
 
-            assert(redirectToAuth !== undefined && _default.redirectToAuth !== undefined);
             assert(redirectToThirdPartyLogin !== undefined && _default.redirectToThirdPartyLogin !== undefined);
             assert(Apple !== undefined && _default.Apple !== undefined);
             assert(Facebook !== undefined && _default.Facebook !== undefined);
@@ -342,7 +323,6 @@ describe("Exports", function () {
             assert(PasswordlessLinkClicked !== undefined && _default.PasswordlessLinkClicked !== undefined);
             assert(SignInAndUp !== undefined && _default.SignInAndUp !== undefined);
             assert(SignInUpTheme !== undefined && _default.SignInUpTheme !== undefined);
-            assert(ThirdPartyPasswordlessAuth !== undefined && _default.ThirdPartyPasswordlessAuth !== undefined);
             assert(ThirdPartySignInAndUpCallback !== undefined && _default.ThirdPartySignInAndUpCallback !== undefined);
         });
     });

--- a/test/unit/exports.test.tsx
+++ b/test/unit/exports.test.tsx
@@ -1,5 +1,5 @@
 import assert from "assert";
-import SuperTokens from "../../lib/build/supertokens";
+import SuperTokens from "../../lib/ts/superTokens";
 
 describe("Exports", function () {
     beforeEach(function () {
@@ -13,19 +13,12 @@ describe("Exports", function () {
                 init,
                 doesEmailExist,
                 getResetPasswordTokenFromURL,
-                isEmailVerified,
-                sendPasswordResetEmail,
-                sendVerificationEmail,
                 signIn,
                 signOut,
                 signUp,
                 submitNewPassword,
-                verifyEmail,
                 redirectToAuth,
-                getEmailVerificationTokenFromURL,
                 EmailPasswordAuth,
-                EmailVerification,
-                EmailVerificationTheme,
                 ResetPasswordUsingToken,
                 ResetPasswordUsingTokenTheme,
                 SignInAndUp,
@@ -35,23 +28,13 @@ describe("Exports", function () {
             assert(init !== undefined && _default.init !== undefined);
             assert(doesEmailExist !== undefined && _default.doesEmailExist !== undefined);
             assert(getResetPasswordTokenFromURL !== undefined && _default.getResetPasswordTokenFromURL !== undefined);
-            assert(isEmailVerified !== undefined && _default.isEmailVerified !== undefined);
-            assert(sendPasswordResetEmail !== undefined && _default.sendPasswordResetEmail !== undefined);
-            assert(sendVerificationEmail !== undefined && _default.sendVerificationEmail !== undefined);
             assert(signIn !== undefined && _default.signIn !== undefined);
             assert(signOut !== undefined && _default.signOut !== undefined);
             assert(signUp !== undefined && _default.signUp !== undefined);
             assert(submitNewPassword !== undefined && _default.submitNewPassword !== undefined);
-            assert(verifyEmail !== undefined && _default.verifyEmail !== undefined);
 
             assert(redirectToAuth !== undefined && _default.redirectToAuth !== undefined);
-            assert(
-                getEmailVerificationTokenFromURL !== undefined &&
-                    _default.getEmailVerificationTokenFromURL !== undefined
-            );
             assert(EmailPasswordAuth !== undefined && _default.EmailPasswordAuth !== undefined);
-            assert(EmailVerification !== undefined && _default.EmailVerification !== undefined);
-            assert(EmailVerificationTheme !== undefined && _default.EmailVerificationTheme !== undefined);
             assert(ResetPasswordUsingToken !== undefined && _default.ResetPasswordUsingToken !== undefined);
             assert(ResetPasswordUsingTokenTheme !== undefined && _default.ResetPasswordUsingTokenTheme !== undefined);
             assert(SignInAndUp !== undefined && _default.SignInAndUp !== undefined);
@@ -71,18 +54,12 @@ describe("Exports", function () {
                 getAuthorisationURLFromBackend,
                 getAuthorisationURLWithQueryParamsAndSetState,
                 getStateAndOtherInfoFromStorage,
-                isEmailVerified,
-                sendVerificationEmail,
                 setStateAndOtherInfoToStorage,
                 signInAndUp,
                 signOut,
                 verifyAndGetStateOrThrowError,
-                verifyEmail,
-                getEmailVerificationTokenFromURL,
                 redirectToAuth,
                 redirectToThirdPartyLogin,
-                EmailVerification,
-                EmailVerificationTheme,
                 Facebook,
                 Apple,
                 Github,
@@ -112,22 +89,13 @@ describe("Exports", function () {
             assert(
                 getStateAndOtherInfoFromStorage !== undefined && _default.getStateAndOtherInfoFromStorage !== undefined
             );
-            assert(isEmailVerified !== undefined && _default.isEmailVerified !== undefined);
-            assert(sendVerificationEmail !== undefined && _default.sendVerificationEmail !== undefined);
             assert(setStateAndOtherInfoToStorage !== undefined && _default.setStateAndOtherInfoToStorage !== undefined);
             assert(signInAndUp !== undefined && _default.signInAndUp !== undefined);
             assert(signOut !== undefined && _default.signOut !== undefined);
             assert(verifyAndGetStateOrThrowError !== undefined && _default.verifyAndGetStateOrThrowError !== undefined);
-            assert(verifyEmail !== undefined && _default.verifyEmail !== undefined);
 
-            assert(
-                getEmailVerificationTokenFromURL !== undefined &&
-                    _default.getEmailVerificationTokenFromURL !== undefined
-            );
             assert(redirectToAuth !== undefined && _default.redirectToAuth !== undefined);
             assert(redirectToThirdPartyLogin !== undefined && _default.redirectToThirdPartyLogin !== undefined);
-            assert(EmailVerification !== undefined && _default.EmailVerification !== undefined);
-            assert(EmailVerificationTheme !== undefined && _default.EmailVerificationTheme !== undefined);
             assert(Facebook !== undefined && _default.Facebook !== undefined);
             assert(Apple !== undefined && _default.Apple !== undefined);
             assert(Github !== undefined && _default.Github !== undefined);
@@ -156,21 +124,15 @@ describe("Exports", function () {
                 getAuthorisationURLWithQueryParamsAndSetState,
                 getResetPasswordTokenFromURL,
                 getStateAndOtherInfoFromStorage,
-                isEmailVerified,
                 sendPasswordResetEmail,
-                sendVerificationEmail,
                 setStateAndOtherInfoToStorage,
                 signOut,
                 submitNewPassword,
                 thirdPartySignInAndUp,
                 verifyAndGetStateOrThrowError,
-                verifyEmail,
-                getEmailVerificationTokenFromURL,
                 redirectToAuth,
                 redirectToThirdPartyLogin,
                 Apple,
-                EmailVerification,
-                EmailVerificationTheme,
                 Facebook,
                 Github,
                 Google,
@@ -205,25 +167,16 @@ describe("Exports", function () {
             assert(
                 getStateAndOtherInfoFromStorage !== undefined && _default.getStateAndOtherInfoFromStorage !== undefined
             );
-            assert(isEmailVerified !== undefined && _default.isEmailVerified !== undefined);
             assert(sendPasswordResetEmail !== undefined && _default.sendPasswordResetEmail !== undefined);
-            assert(sendVerificationEmail !== undefined && _default.sendVerificationEmail !== undefined);
             assert(setStateAndOtherInfoToStorage !== undefined && _default.setStateAndOtherInfoToStorage !== undefined);
             assert(signOut !== undefined && _default.signOut !== undefined);
             assert(submitNewPassword !== undefined && _default.submitNewPassword !== undefined);
             assert(thirdPartySignInAndUp !== undefined && _default.thirdPartySignInAndUp !== undefined);
             assert(verifyAndGetStateOrThrowError !== undefined && _default.verifyAndGetStateOrThrowError !== undefined);
-            assert(verifyEmail !== undefined && _default.verifyEmail !== undefined);
 
-            assert(
-                getEmailVerificationTokenFromURL !== undefined &&
-                    _default.getEmailVerificationTokenFromURL !== undefined
-            );
             assert(redirectToAuth !== undefined && _default.redirectToAuth !== undefined);
             assert(redirectToThirdPartyLogin !== undefined && _default.redirectToThirdPartyLogin !== undefined);
             assert(Apple !== undefined && _default.Apple !== undefined);
-            assert(EmailVerification !== undefined && _default.EmailVerification !== undefined);
-            assert(EmailVerificationTheme !== undefined && _default.EmailVerificationTheme !== undefined);
             assert(Facebook !== undefined && _default.Facebook !== undefined);
             assert(Github !== undefined && _default.Github !== undefined);
             assert(Google !== undefined && _default.Google !== undefined);
@@ -304,21 +257,15 @@ describe("Exports", function () {
                 getThirdPartyAuthStateFromURL,
                 getThirdPartyAuthorisationURLWithQueryParamsAndSetState,
                 getThirdPartyStateAndOtherInfoFromStorage,
-                isEmailVerified,
                 resendPasswordlessCode,
-                sendVerificationEmail,
                 setPasswordlessLoginAttemptInfo,
                 setThirdPartyStateAndOtherInfoToStorage,
                 signOut,
                 thirdPartySignInAndUp,
                 verifyAndGetThirdPartyStateOrThrowError,
-                verifyEmail,
-                getEmailVerificationTokenFromURL,
                 redirectToAuth,
                 redirectToThirdPartyLogin,
                 Apple,
-                EmailVerification,
-                EmailVerificationTheme,
                 Facebook,
                 Github,
                 Google,
@@ -371,9 +318,7 @@ describe("Exports", function () {
                 getThirdPartyStateAndOtherInfoFromStorage !== undefined &&
                     _default.getThirdPartyStateAndOtherInfoFromStorage !== undefined
             );
-            assert(isEmailVerified !== undefined && _default.isEmailVerified !== undefined);
             assert(resendPasswordlessCode !== undefined && _default.resendPasswordlessCode !== undefined);
-            assert(sendVerificationEmail !== undefined && _default.sendVerificationEmail !== undefined);
             assert(
                 setPasswordlessLoginAttemptInfo !== undefined && _default.setPasswordlessLoginAttemptInfo !== undefined
             );
@@ -387,17 +332,10 @@ describe("Exports", function () {
                 verifyAndGetThirdPartyStateOrThrowError !== undefined &&
                     _default.verifyAndGetThirdPartyStateOrThrowError !== undefined
             );
-            assert(verifyEmail !== undefined && _default.verifyEmail !== undefined);
 
-            assert(
-                getEmailVerificationTokenFromURL !== undefined &&
-                    _default.getEmailVerificationTokenFromURL !== undefined
-            );
             assert(redirectToAuth !== undefined && _default.redirectToAuth !== undefined);
             assert(redirectToThirdPartyLogin !== undefined && _default.redirectToThirdPartyLogin !== undefined);
             assert(Apple !== undefined && _default.Apple !== undefined);
-            assert(EmailVerification !== undefined && _default.EmailVerification !== undefined);
-            assert(EmailVerificationTheme !== undefined && _default.EmailVerificationTheme !== undefined);
             assert(Facebook !== undefined && _default.Facebook !== undefined);
             assert(Github !== undefined && _default.Github !== undefined);
             assert(Google !== undefined && _default.Google !== undefined);


### PR DESCRIPTION
## Summary of change

- removed remaining email verification references from other recipes
- updated exports test

## Related issues

-   

## Test Plan

Updated a test

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
