### PR TITLE
feat: useClaimValue w/ doesSessionExist

### DIFF
--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -15,10 +15,10 @@ export default class SessionAPIWrapper {
     static useClaimValue: <T>(claim: SessionClaim<T>) =>
         | {
               loading: true;
-              value: undefined;
           }
         | {
               loading: false;
+              doesSessionExist: boolean;
               value: T | undefined;
           };
     static SessionAuth: import("react").FC<
@@ -55,10 +55,10 @@ declare const useSessionContext: () => SessionContextType;
 declare const useClaimValue: <T>(claim: SessionClaim<T>) =>
     | {
           loading: true;
-          value: undefined;
       }
     | {
           loading: false;
+          doesSessionExist: boolean;
           value: T | undefined;
       };
 declare const SessionAuth: import("react").FC<

--- a/lib/build/recipe/session/useClaimValue.d.ts
+++ b/lib/build/recipe/session/useClaimValue.d.ts
@@ -2,9 +2,9 @@ import { SessionClaim } from "supertokens-web-js/recipe/session";
 export declare const useClaimValue: <T>(claim: SessionClaim<T>) =>
     | {
           loading: true;
-          value: undefined;
       }
     | {
           loading: false;
+          doesSessionExist: boolean;
           value: T | undefined;
       };

--- a/lib/build/recipe/session/useClaimValue.js
+++ b/lib/build/recipe/session/useClaimValue.js
@@ -9,14 +9,22 @@ exports.useClaimValue = void 0;
 var useSessionContext_1 = __importDefault(require("./useSessionContext"));
 var useClaimValue = function (claim) {
     var ctx = (0, useSessionContext_1.default)();
+    console.log(ctx);
     if (ctx.loading) {
         return {
             loading: true,
+        };
+    }
+    if (ctx.doesSessionExist === false) {
+        return {
+            loading: false,
+            doesSessionExist: false,
             value: undefined,
         };
     }
     return {
         loading: false,
+        doesSessionExist: false,
         value: claim.getValueFromPayload(ctx.accessTokenPayload),
     };
 };

--- a/lib/ts/recipe/session/useClaimValue.ts
+++ b/lib/ts/recipe/session/useClaimValue.ts
@@ -4,16 +4,26 @@ import useSessionContext from "./useSessionContext";
 
 export const useClaimValue = <T>(
     claim: SessionClaim<T>
-): { loading: true; value: undefined } | { loading: false; value: T | undefined } => {
+): { loading: true } | { loading: false; doesSessionExist: boolean; value: T | undefined } => {
     const ctx = useSessionContext();
+
     if (ctx.loading) {
         return {
             loading: true,
+        };
+    }
+
+    if (ctx.doesSessionExist === false) {
+        return {
+            loading: false,
+            doesSessionExist: false,
             value: undefined,
         };
     }
+
     return {
         loading: false,
+        doesSessionExist: true,
         value: claim.getValueFromPayload(ctx.accessTokenPayload),
     };
 };

--- a/test/unit/recipe/session/sessionAuth.test.tsx
+++ b/test/unit/recipe/session/sessionAuth.test.tsx
@@ -23,10 +23,15 @@ const MockSession = {
 
 const MockSessionConsumer = () => {
     const session = useContext(SessionContext);
-    const { value: claimValue } = useClaimValue(TestClaim);
-    if (session.loading === true) {
+    const claimValueCtx = useClaimValue(TestClaim);
+
+    expect(session.loading).toEqual(claimValueCtx.loading);
+
+    if (session.loading === true || claimValueCtx.loading === true) {
         return <h1>Loading</h1>;
     }
+
+    expect(session.doesSessionExist).toEqual(claimValueCtx.doesSessionExist);
 
     if (!session.doesSessionExist) {
         return <h1>Session doesn't exist</h1>;
@@ -37,7 +42,7 @@ const MockSessionConsumer = () => {
             <span>userId: {session.userId}</span>
             <span>accessTokenPayload: {JSON.stringify(session.accessTokenPayload)}</span>
             <span>invalidClaims: {session.invalidClaims.map((a) => a.validatorId).join(", ")}</span>
-            <span>testClaimValue: {claimValue === undefined ? "undefined" : claimValue}</span>
+            <span>testClaimValue: {claimValueCtx.value === undefined ? "undefined" : claimValueCtx.value}</span>
         </>
     );
 };


### PR DESCRIPTION
## Summary of change

Added `doesSessionExist` to the return type of `useClaimValue`

## Related issues

-   #558 

## Test Plan

Extended existing tests for the new prop

## Documentation changes

Done separately

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
