### PR TITLE
feat: add doRedirection to SessionAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Adds Session claims support and `UserRoleClaim`, `PermissionClaim` and `EmailVerificationClaim`
--   Added `overrideGlobalClaimValidators` callback to `SessionAuth`
+-   Added `overrideGlobalClaimValidators` and `doRedirection` to `SessionAuth` props
 -   Added `validateClaims`, `useClaimValue` and `getInvalidClaimsFromResponse` to the `Session` recipe
 -   Added `API_INVALID_CLAIM` event to the `Session` recipe
 -   Export for `EmailVerification` recipe

--- a/lib/build/components/supertokensWrapper.js
+++ b/lib/build/components/supertokensWrapper.js
@@ -25,12 +25,7 @@ var sessionAuth_1 = __importDefault(require("../recipe/session/sessionAuth"));
 var SuperTokensWrapper = function (props) {
     return (0, jsx_runtime_1.jsx)(
         sessionAuth_1.default,
-        __assign({}, props, {
-            requireAuth: false,
-            overrideGlobalClaimValidators: function () {
-                return [];
-            },
-        })
+        __assign({}, props, { requireAuth: false, doRedirection: false })
     );
 };
 exports.SuperTokensWrapper = SuperTokensWrapper;

--- a/lib/build/recipe/authRecipe/authWidgetWrapper.js
+++ b/lib/build/recipe/authRecipe/authWidgetWrapper.js
@@ -50,12 +50,7 @@ var AuthWidgetWrapper = function (props) {
     return (0, jsx_runtime_1.jsx)(
         session_1.SessionAuth,
         __assign(
-            {
-                requireAuth: false,
-                overrideGlobalClaimValidators: function () {
-                    return [];
-                },
-            },
+            { requireAuth: false, doRedirection: false },
             { children: (0, jsx_runtime_1.jsx)(Redirector, __assign({}, props)) }
         )
     );

--- a/lib/build/recipe/session/sessionAuth.d.ts
+++ b/lib/build/recipe/session/sessionAuth.d.ts
@@ -2,6 +2,7 @@ import React, { PropsWithChildren } from "react";
 import { SessionClaimValidator } from "supertokens-website";
 export declare type SessionAuthProps = {
     requireAuth?: boolean;
+    doRedirection?: boolean;
     onSessionExpired?: () => void;
     overrideGlobalClaimValidators?: (
         globalClaimValidators: SessionClaimValidator[],

--- a/lib/build/recipe/session/sessionAuth.js
+++ b/lib/build/recipe/session/sessionAuth.js
@@ -299,12 +299,12 @@ var SessionAuth = function (_a) {
                             if (context.loading === false) {
                                 return [2 /*return*/];
                             }
+                            if (!(props.doRedirection !== false)) return [3 /*break*/, 3];
                             if (!(!toSetContext.doesSessionExist && props.requireAuth !== false))
                                 return [3 /*break*/, 1];
                             redirectToLogin();
-                            return [3 /*break*/, 3];
+                            return [2 /*return*/];
                         case 1:
-                            setContext(toSetContext);
                             redirectPath = (0, utils_1.popInvalidClaimRedirectPathFromContext)(userContext);
                             if (!redirectPath) return [3 /*break*/, 3];
                             return [
@@ -313,14 +313,15 @@ var SessionAuth = function (_a) {
                             ];
                         case 2:
                             _a.sent();
-                            _a.label = 3;
+                            return [2 /*return*/];
                         case 3:
+                            setContext(toSetContext);
                             return [2 /*return*/];
                     }
                 });
             });
         },
-        [props.requireAuth, redirectToLogin, context]
+        [props.doRedirection, props.requireAuth, redirectToLogin, context]
     );
     (0, utils_1.useOnMountAPICall)(buildContext, setInitialContextAndMaybeRedirect);
     // subscribe to events on mount
@@ -365,7 +366,7 @@ var SessionAuth = function (_a) {
                                     })
                                 );
                                 redirectPath = (0, utils_1.popInvalidClaimRedirectPathFromContext)(userContext);
-                                if (!redirectPath) return [3 /*break*/, 4];
+                                if (!(props.doRedirection !== false && redirectPath)) return [3 /*break*/, 4];
                                 return [
                                     4 /*yield*/,
                                     superTokens_1.default.getInstanceOrThrow().redirectToUrl(redirectPath, history),
@@ -386,7 +387,7 @@ var SessionAuth = function (_a) {
                                 );
                                 if (props.onSessionExpired !== undefined) {
                                     props.onSessionExpired();
-                                } else if (props.requireAuth !== false) {
+                                } else if (props.requireAuth !== false && props.doRedirection !== false) {
                                     redirectToLogin();
                                 }
                                 return [2 /*return*/];

--- a/lib/ts/components/supertokensWrapper.tsx
+++ b/lib/ts/components/supertokensWrapper.tsx
@@ -6,5 +6,5 @@ export const SuperTokensWrapper: React.FC<
         userContext?: any;
     }>
 > = (props) => {
-    return <SessionAuthWrapper {...props} requireAuth={false} overrideGlobalClaimValidators={() => []} />;
+    return <SessionAuthWrapper {...props} requireAuth={false} doRedirection={false} />;
 };

--- a/lib/ts/recipe/authRecipe/authWidgetWrapper.tsx
+++ b/lib/ts/recipe/authRecipe/authWidgetWrapper.tsx
@@ -43,7 +43,7 @@ const AuthWidgetWrapper = <
     props: PropsWithChildren<Props<T, Action, R, N>>
 ): React.ReactElement | null => {
     return (
-        <SessionAuth requireAuth={false} overrideGlobalClaimValidators={() => []}>
+        <SessionAuth requireAuth={false} doRedirection={false}>
             <Redirector {...props} />
         </SessionAuth>
     );

--- a/test/unit/recipe/emailpassword/signInUp.test.tsx
+++ b/test/unit/recipe/emailpassword/signInUp.test.tsx
@@ -6,13 +6,14 @@ import Session from "../../../../lib/ts/recipe/session/recipe";
 import Recipe from "../../../../lib/ts/recipe/emailpassword/recipe";
 import { SignInAndUp } from "../../../../lib/ts/recipe/emailpassword";
 import { SessionContextType } from "../../../../lib/ts/recipe/session";
-import { WindowHandlerInterface } from "supertokens-website/utils/windowHandler/types";
 
 const MockSession = {
     addEventListener: jest.fn(),
     getUserId: jest.fn(),
     getAccessTokenPayloadSecurely: jest.fn(),
     doesSessionExist: jest.fn(),
+    validateClaims: jest.fn(),
+    validateGlobalClaimsAndHandleSuccessRedirection: jest.fn(),
 };
 
 const setMockResolvesSession = (ctx: SessionContextType) => {
@@ -21,10 +22,12 @@ const setMockResolvesSession = (ctx: SessionContextType) => {
         MockSession.getUserId.mockReturnValue(new Promise<any>(() => {}));
         MockSession.getAccessTokenPayloadSecurely.mockReturnValue(new Promise<any>(() => {}));
         MockSession.doesSessionExist.mockReturnValue(new Promise<any>(() => {}));
+        MockSession.validateClaims.mockReturnValue(new Promise<any>(() => {}));
     } else {
         MockSession.getUserId.mockResolvedValue(ctx.userId);
         MockSession.getAccessTokenPayloadSecurely.mockResolvedValue(ctx.accessTokenPayload);
         MockSession.doesSessionExist.mockResolvedValue(ctx.doesSessionExist);
+        MockSession.validateClaims.mockReturnValue(ctx.invalidClaims);
     }
 };
 
@@ -32,7 +35,6 @@ jest.spyOn(Session, "getInstanceOrThrow").mockImplementation(() => MockSession a
 
 describe("EmailPassword.SignInAndUp", () => {
     const websiteDomain = "http://localhost:3000";
-    let myWindow: WindowHandlerInterface;
     beforeEach(() => {
         jest.clearAllMocks();
         Recipe.reset();
@@ -51,58 +53,42 @@ describe("EmailPassword.SignInAndUp", () => {
                     useShadowDom: false,
                 }),
             ],
-            windowHandler: (orig) => {
-                let url = new URL(websiteDomain + "/start");
-
-                myWindow = {
-                    ...orig,
-                    location: {
-                        assign: (val) => {
-                            url = new URL(typeof val === "string" && val.startsWith("/") ? websiteDomain + val : val);
-                        },
-                        setHref: (val) => {
-                            myWindow.location.assign(val);
-                        },
-                        getHash: () => url.hash,
-                        getHostName: () => url.hostname,
-                        getHref: () => url.href,
-                        getOrigin: () => url.origin,
-                        getPathName: () => url.pathname,
-                        getSearch: () => url.search,
-                    },
-                };
-                return myWindow;
-            },
         });
 
         setMockResolvesSession({
             userId: "mock-user-id",
             accessTokenPayload: {},
+            invalidClaims: [],
             doesSessionExist: true,
             loading: false,
         });
     });
 
     test("redirect if session exists", async () => {
-        const spy = jest.spyOn(myWindow.location, "setHref");
         // when
         render(<SignInAndUp />);
         // then
         await waitFor(() => {
-            expect(spy).toHaveBeenCalledTimes(1);
-            expect(spy).toHaveBeenCalledWith("/");
+            expect(MockSession.validateGlobalClaimsAndHandleSuccessRedirection).toHaveBeenCalledTimes(1);
+            expect(MockSession.validateGlobalClaimsAndHandleSuccessRedirection).toHaveBeenCalledWith(
+                {
+                    rid: "emailpassword",
+                    successRedirectContext: { action: "SUCCESS", isNewUser: false, redirectToPath: undefined },
+                },
+                {},
+                undefined
+            );
         });
     });
 
     test("not redirect if session exists but redirectOnSessionExists=false", async () => {
-        const spy = jest.spyOn(myWindow.location, "setHref");
         // when
         const result = render(<SignInAndUp redirectOnSessionExists={false}> mockRenderedText </SignInAndUp>);
 
         expect(await result.findByText(`mockRenderedText`)).toBeInTheDocument();
         // then
         await waitFor(() => {
-            expect(spy).toHaveBeenCalledTimes(0);
+            expect(MockSession.validateGlobalClaimsAndHandleSuccessRedirection).toHaveBeenCalledTimes(0);
         });
     });
 });

--- a/test/unit/recipe/thirdparty/signInUp.test.tsx
+++ b/test/unit/recipe/thirdparty/signInUp.test.tsx
@@ -6,13 +6,14 @@ import Session from "../../../../lib/ts/recipe/session/recipe";
 import Recipe from "../../../../lib/ts/recipe/thirdparty/recipe";
 import { Github, SignInAndUp } from "../../../../lib/ts/recipe/thirdparty";
 import { SessionContextType } from "../../../../lib/ts/recipe/session";
-import { WindowHandlerInterface } from "supertokens-website/utils/windowHandler/types";
 
 const MockSession = {
     addEventListener: jest.fn(),
     getUserId: jest.fn(),
     getAccessTokenPayloadSecurely: jest.fn(),
     doesSessionExist: jest.fn(),
+    validateClaims: jest.fn(),
+    validateGlobalClaimsAndHandleSuccessRedirection: jest.fn(),
 };
 
 const setMockResolvesSession = (ctx: SessionContextType) => {
@@ -21,10 +22,12 @@ const setMockResolvesSession = (ctx: SessionContextType) => {
         MockSession.getUserId.mockReturnValue(new Promise<any>(() => {}));
         MockSession.getAccessTokenPayloadSecurely.mockReturnValue(new Promise<any>(() => {}));
         MockSession.doesSessionExist.mockReturnValue(new Promise<any>(() => {}));
+        MockSession.validateClaims.mockReturnValue(new Promise<any>(() => {}));
     } else {
         MockSession.getUserId.mockResolvedValue(ctx.userId);
         MockSession.getAccessTokenPayloadSecurely.mockResolvedValue(ctx.accessTokenPayload);
         MockSession.doesSessionExist.mockResolvedValue(ctx.doesSessionExist);
+        MockSession.validateClaims.mockReturnValue(ctx.invalidClaims);
     }
 };
 
@@ -32,7 +35,6 @@ jest.spyOn(Session, "getInstanceOrThrow").mockImplementation(() => MockSession a
 
 describe("ThirdParty.SignInAndUp", () => {
     const websiteDomain = "http://localhost:3000";
-    let myWindow: WindowHandlerInterface;
     beforeEach(() => {
         jest.clearAllMocks();
         Recipe.reset();
@@ -55,58 +57,42 @@ describe("ThirdParty.SignInAndUp", () => {
                     useShadowDom: false,
                 }),
             ],
-            windowHandler: (orig) => {
-                let url = new URL(websiteDomain + "/start");
-
-                myWindow = {
-                    ...orig,
-                    location: {
-                        assign: (val) => {
-                            url = new URL(typeof val === "string" && val.startsWith("/") ? websiteDomain + val : val);
-                        },
-                        setHref: (val) => {
-                            myWindow.location.assign(val);
-                        },
-                        getHash: () => url.hash,
-                        getHostName: () => url.hostname,
-                        getHref: () => url.href,
-                        getOrigin: () => url.origin,
-                        getPathName: () => url.pathname,
-                        getSearch: () => url.search,
-                    },
-                };
-                return myWindow;
-            },
         });
 
         setMockResolvesSession({
             userId: "mock-user-id",
             accessTokenPayload: {},
+            invalidClaims: [],
             doesSessionExist: true,
             loading: false,
         });
     });
 
     test("redirect if session exists", async () => {
-        const spy = jest.spyOn(myWindow.location, "setHref");
         // when
         render(<SignInAndUp />);
         // then
         await waitFor(() => {
-            expect(spy).toHaveBeenCalledTimes(1);
-            expect(spy).toHaveBeenCalledWith("/");
+            expect(MockSession.validateGlobalClaimsAndHandleSuccessRedirection).toHaveBeenCalledTimes(1);
+            expect(MockSession.validateGlobalClaimsAndHandleSuccessRedirection).toHaveBeenCalledWith(
+                {
+                    rid: "thirdparty",
+                    successRedirectContext: { action: "SUCCESS", isNewUser: false, redirectToPath: undefined },
+                },
+                {},
+                undefined
+            );
         });
     });
 
     test("not redirect if session exists but redirectOnSessionExists=false", async () => {
-        const spy = jest.spyOn(myWindow.location, "setHref");
         // when
         const result = render(<SignInAndUp redirectOnSessionExists={false}> mockRenderedText </SignInAndUp>);
 
         expect(await result.findByText(`mockRenderedText`)).toBeInTheDocument();
         // then
         await waitFor(() => {
-            expect(spy).toHaveBeenCalledTimes(0);
+            expect(MockSession.validateGlobalClaimsAndHandleSuccessRedirection).toHaveBeenCalledTimes(0);
         });
     });
 });

--- a/test/unit/recipe/thirdpartyemailpassword/signInUp.test.tsx
+++ b/test/unit/recipe/thirdpartyemailpassword/signInUp.test.tsx
@@ -6,13 +6,14 @@ import Session from "../../../../lib/ts/recipe/session/recipe";
 import Recipe from "../../../../lib/ts/recipe/thirdpartyemailpassword/recipe";
 import { SignInAndUp } from "../../../../lib/ts/recipe/thirdpartyemailpassword";
 import { SessionContextType } from "../../../../lib/ts/recipe/session";
-import { WindowHandlerInterface } from "supertokens-website/utils/windowHandler/types";
 
 const MockSession = {
     addEventListener: jest.fn(),
     getUserId: jest.fn(),
     getAccessTokenPayloadSecurely: jest.fn(),
     doesSessionExist: jest.fn(),
+    validateClaims: jest.fn(),
+    validateGlobalClaimsAndHandleSuccessRedirection: jest.fn(),
 };
 
 const setMockResolvesSession = (ctx: SessionContextType) => {
@@ -21,10 +22,12 @@ const setMockResolvesSession = (ctx: SessionContextType) => {
         MockSession.getUserId.mockReturnValue(new Promise<any>(() => {}));
         MockSession.getAccessTokenPayloadSecurely.mockReturnValue(new Promise<any>(() => {}));
         MockSession.doesSessionExist.mockReturnValue(new Promise<any>(() => {}));
+        MockSession.validateClaims.mockReturnValue(new Promise<any>(() => {}));
     } else {
         MockSession.getUserId.mockResolvedValue(ctx.userId);
         MockSession.getAccessTokenPayloadSecurely.mockResolvedValue(ctx.accessTokenPayload);
         MockSession.doesSessionExist.mockResolvedValue(ctx.doesSessionExist);
+        MockSession.validateClaims.mockReturnValue(ctx.invalidClaims);
     }
 };
 
@@ -32,7 +35,6 @@ jest.spyOn(Session, "getInstanceOrThrow").mockImplementation(() => MockSession a
 
 describe("ThirdPartyEmailPassword.SignInAndUp", () => {
     const websiteDomain = "http://localhost:3000";
-    let myWindow: WindowHandlerInterface;
     beforeEach(() => {
         jest.clearAllMocks();
         Recipe.reset();
@@ -51,58 +53,42 @@ describe("ThirdPartyEmailPassword.SignInAndUp", () => {
                     useShadowDom: false,
                 }),
             ],
-            windowHandler: (orig) => {
-                let url = new URL(websiteDomain + "/start");
-
-                myWindow = {
-                    ...orig,
-                    location: {
-                        assign: (val) => {
-                            url = new URL(typeof val === "string" && val.startsWith("/") ? websiteDomain + val : val);
-                        },
-                        setHref: (val) => {
-                            myWindow.location.assign(val);
-                        },
-                        getHash: () => url.hash,
-                        getHostName: () => url.hostname,
-                        getHref: () => url.href,
-                        getOrigin: () => url.origin,
-                        getPathName: () => url.pathname,
-                        getSearch: () => url.search,
-                    },
-                };
-                return myWindow;
-            },
         });
 
         setMockResolvesSession({
             userId: "mock-user-id",
             accessTokenPayload: {},
+            invalidClaims: [],
             doesSessionExist: true,
             loading: false,
         });
     });
 
     test("redirect if session exists", async () => {
-        const spy = jest.spyOn(myWindow.location, "setHref");
         // when
         render(<SignInAndUp />);
         // then
         await waitFor(() => {
-            expect(spy).toHaveBeenCalledTimes(1);
-            expect(spy).toHaveBeenCalledWith("/");
+            expect(MockSession.validateGlobalClaimsAndHandleSuccessRedirection).toHaveBeenCalledTimes(1);
+            expect(MockSession.validateGlobalClaimsAndHandleSuccessRedirection).toHaveBeenCalledWith(
+                {
+                    rid: "thirdpartyemailpassword",
+                    successRedirectContext: { action: "SUCCESS", isNewUser: false, redirectToPath: undefined },
+                },
+                {},
+                undefined
+            );
         });
     });
 
     test("not redirect if session exists but redirectOnSessionExists=false", async () => {
-        const spy = jest.spyOn(myWindow.location, "setHref");
         // when
         const result = render(<SignInAndUp redirectOnSessionExists={false}> mockRenderedText </SignInAndUp>);
 
         expect(await result.findByText(`mockRenderedText`)).toBeInTheDocument();
         // then
         await waitFor(() => {
-            expect(spy).toHaveBeenCalledTimes(0);
+            expect(MockSession.validateGlobalClaimsAndHandleSuccessRedirection).toHaveBeenCalledTimes(0);
         });
     });
 });

--- a/test/unit/recipe/thirdpartypasswordless/signInUp.test.tsx
+++ b/test/unit/recipe/thirdpartypasswordless/signInUp.test.tsx
@@ -6,13 +6,14 @@ import Session from "../../../../lib/ts/recipe/session/recipe";
 import Recipe from "../../../../lib/ts/recipe/thirdpartypasswordless/recipe";
 import { SignInAndUp } from "../../../../lib/ts/recipe/thirdpartypasswordless";
 import { SessionContextType } from "../../../../lib/ts/recipe/session";
-import { WindowHandlerInterface } from "supertokens-website/utils/windowHandler/types";
 
 const MockSession = {
     addEventListener: jest.fn(),
     getUserId: jest.fn(),
     getAccessTokenPayloadSecurely: jest.fn(),
     doesSessionExist: jest.fn(),
+    validateClaims: jest.fn(),
+    validateGlobalClaimsAndHandleSuccessRedirection: jest.fn(),
 };
 
 const setMockResolvesSession = (ctx: SessionContextType) => {
@@ -21,10 +22,12 @@ const setMockResolvesSession = (ctx: SessionContextType) => {
         MockSession.getUserId.mockReturnValue(new Promise<any>(() => {}));
         MockSession.getAccessTokenPayloadSecurely.mockReturnValue(new Promise<any>(() => {}));
         MockSession.doesSessionExist.mockReturnValue(new Promise<any>(() => {}));
+        MockSession.validateClaims.mockReturnValue(new Promise<any>(() => {}));
     } else {
         MockSession.getUserId.mockResolvedValue(ctx.userId);
         MockSession.getAccessTokenPayloadSecurely.mockResolvedValue(ctx.accessTokenPayload);
         MockSession.doesSessionExist.mockResolvedValue(ctx.doesSessionExist);
+        MockSession.validateClaims.mockReturnValue(ctx.invalidClaims);
     }
 };
 
@@ -32,7 +35,6 @@ jest.spyOn(Session, "getInstanceOrThrow").mockImplementation(() => MockSession a
 
 describe("ThirdPartyPasswordless.SignInAndUp", () => {
     const websiteDomain = "http://localhost:3000";
-    let myWindow: WindowHandlerInterface;
     beforeEach(() => {
         jest.clearAllMocks();
         Recipe.reset();
@@ -52,58 +54,42 @@ describe("ThirdPartyPasswordless.SignInAndUp", () => {
                     contactMethod: "EMAIL_OR_PHONE",
                 }),
             ],
-            windowHandler: (orig) => {
-                let url = new URL(websiteDomain + "/start");
-
-                myWindow = {
-                    ...orig,
-                    location: {
-                        assign: (val) => {
-                            url = new URL(typeof val === "string" && val.startsWith("/") ? websiteDomain + val : val);
-                        },
-                        setHref: (val) => {
-                            myWindow.location.assign(val);
-                        },
-                        getHash: () => url.hash,
-                        getHostName: () => url.hostname,
-                        getHref: () => url.href,
-                        getOrigin: () => url.origin,
-                        getPathName: () => url.pathname,
-                        getSearch: () => url.search,
-                    },
-                };
-                return myWindow;
-            },
         });
 
         setMockResolvesSession({
             userId: "mock-user-id",
             accessTokenPayload: {},
+            invalidClaims: [],
             doesSessionExist: true,
             loading: false,
         });
     });
 
     test("redirect if session exists", async () => {
-        const spy = jest.spyOn(myWindow.location, "setHref");
         // when
         render(<SignInAndUp />);
         // then
         await waitFor(() => {
-            expect(spy).toHaveBeenCalledTimes(1);
-            expect(spy).toHaveBeenCalledWith("/");
+            expect(MockSession.validateGlobalClaimsAndHandleSuccessRedirection).toHaveBeenCalledTimes(1);
+            expect(MockSession.validateGlobalClaimsAndHandleSuccessRedirection).toHaveBeenCalledWith(
+                {
+                    rid: "thirdpartypasswordless",
+                    successRedirectContext: { action: "SUCCESS", isNewUser: false, redirectToPath: undefined },
+                },
+                {},
+                undefined
+            );
         });
     });
 
     test("not redirect if session exists but redirectOnSessionExists=false", async () => {
-        const spy = jest.spyOn(myWindow.location, "setHref");
         // when
         const result = render(<SignInAndUp redirectOnSessionExists={false}> mockRenderedText </SignInAndUp>);
 
         expect(await result.findByText(`mockRenderedText`)).toBeInTheDocument();
         // then
         await waitFor(() => {
-            expect(spy).toHaveBeenCalledTimes(0);
+            expect(MockSession.validateGlobalClaimsAndHandleSuccessRedirection).toHaveBeenCalledTimes(0);
         });
     });
 });


### PR DESCRIPTION
## Summary of change

Adding `doRedirection` to `SessionAuth` as discussed. 
It defaults to true, controlling if invalid claims and missing session/the UNAUTHORISED event should redirect.

## Related issues

-   

## Test Plan

Added unit tests.

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
