### PR TITLE
fix: session claims 2fa example

### DIFF
--- a/examples/with-phone-password/src/PhoneVerification/index.tsx
+++ b/examples/with-phone-password/src/PhoneVerification/index.tsx
@@ -1,21 +1,18 @@
 import { useState, useEffect } from "react";
-import { redirectToAuth } from "supertokens-auth-react";
-import Session from "supertokens-auth-react/recipe/session";
+import Session, { useSessionContext } from "supertokens-auth-react/recipe/session";
 import { SignInUp, SignInUpTheme } from "supertokens-auth-react/recipe/passwordless";
 
 const CustomSignInUpTheme: typeof SignInUpTheme = (props) => {
     let [showDefaultUI, setShowDefaultUI] = useState(false);
+    const session = useSessionContext();
     useEffect(() => {
         let aborting = false;
         async function effect() {
-            // We only show this inside a SessionAuth, so this should never throw
-            const payload = await Session.getAccessTokenPayloadSecurely();
-
-            if (aborting) {
+            if (session.loading === true) {
                 return;
             }
 
-            let phoneNumber = payload.phoneNumber;
+            let phoneNumber = session.accessTokenPayload.phoneNumber;
             // If don't have a phone number we show the default UI (which should be the phone form)
             if (phoneNumber === undefined) {
                 setShowDefaultUI(true);

--- a/examples/with-thirdpartyemailpassword-2fa-passwordless/src/App.tsx
+++ b/examples/with-thirdpartyemailpassword-2fa-passwordless/src/App.tsx
@@ -6,7 +6,7 @@ import SuperTokens, {
     redirectToAuth,
 } from "supertokens-auth-react";
 import ThirdPartyEmailPassword from "supertokens-auth-react/recipe/thirdpartyemailpassword";
-import Session, { SessionAuth } from "supertokens-auth-react/recipe/session";
+import Session, { SessionAuth, useSessionContext } from "supertokens-auth-react/recipe/session";
 import Home from "./Home";
 import { Routes, BrowserRouter as Router, Route, useLocation } from "react-router-dom";
 import Footer from "./Footer";
@@ -80,28 +80,9 @@ SuperTokens.init({
                     },
                     // we override the component which shows the change phone number button
                     PasswordlessUserInputCodeFormFooter_Override: ({ DefaultComponent, ...props }) => {
-                        // the logic here is very similar to the previous step's logic
-                        let [showDefaultUI, setShowDefaultUI] = useState(false);
-                        useEffect(() => {
-                            Session.getAccessTokenPayloadSecurely()
-                                .then(async (accessTokenPayload) => {
-                                    let phoneNumber = accessTokenPayload.phoneNumber;
-                                    if (phoneNumber === undefined) {
-                                        // since the phone number does not exist in the access token's
-                                        // payload, we want to show the button
-                                        setShowDefaultUI(true);
-                                    }
-                                })
-                                .catch((err) => {
-                                    // it can come here if a session doesn't exist.
-                                    // in this case, the screen we should redirect to the
-                                    // first login challenge
-                                    SuperTokens.redirectToAuth({
-                                        redirectBack: false,
-                                    });
-                                });
-                        }, []);
-                        if (showDefaultUI) {
+                        const session = useSessionContext();
+
+                        if (session.loading !== true && session.accessTokenPayload.phoneNumber === undefined) {
                             // this will show the change phone number button
                             return <DefaultComponent {...props} />;
                         }

--- a/examples/with-thirdpartyemailpassword-2fa-passwordless/src/App.tsx
+++ b/examples/with-thirdpartyemailpassword-2fa-passwordless/src/App.tsx
@@ -78,6 +78,37 @@ SuperTokens.init({
                             </div>
                         );
                     },
+                    // we override the component which shows the change phone number button
+                    PasswordlessUserInputCodeFormFooter_Override: ({ DefaultComponent, ...props }) => {
+                        // the logic here is very similar to the previous step's logic
+                        let [showDefaultUI, setShowDefaultUI] = useState(false);
+                        useEffect(() => {
+                            Session.getAccessTokenPayloadSecurely()
+                                .then(async (accessTokenPayload) => {
+                                    let phoneNumber = accessTokenPayload.phoneNumber;
+                                    if (phoneNumber === undefined) {
+                                        // since the phone number does not exist in the access token's
+                                        // payload, we want to show the button
+                                        setShowDefaultUI(true);
+                                    }
+                                })
+                                .catch((err) => {
+                                    // it can come here if a session doesn't exist.
+                                    // in this case, the screen we should redirect to the
+                                    // first login challenge
+                                    SuperTokens.redirectToAuth({
+                                        redirectBack: false,
+                                    });
+                                });
+                        }, []);
+                        if (showDefaultUI) {
+                            // this will show the change phone number button
+                            return <DefaultComponent {...props} />;
+                        }
+
+                        // this will hide the change phone number button
+                        return null;
+                    },
                 },
             },
         }),

--- a/examples/with-thirdpartyemailpassword-2fa-passwordless/src/SecondFactor/index.tsx
+++ b/examples/with-thirdpartyemailpassword-2fa-passwordless/src/SecondFactor/index.tsx
@@ -6,17 +6,16 @@ import Session, { useSessionContext } from "supertokens-auth-react/recipe/sessio
 
 const CustomSignInUpTheme: typeof Passwordless.SignInUpTheme = (props) => {
     let [showDefaultUI, setShowDefaultUI] = useState(false);
+    const session = useSessionContext();
+
     useEffect(() => {
         let aborting = false;
         async function effect() {
-            // We only show this inside a SessionAuth, so this should never throw
-            const payload = await Session.getAccessTokenPayloadSecurely();
-
-            if (aborting) {
+            if (session.loading === true) {
                 return;
             }
 
-            let phoneNumber = payload.phoneNumber;
+            const phoneNumber = session.accessTokenPayload.phoneNumber;
             // If don't have a phone number we show the default UI (which should be the phone form)
             if (phoneNumber === undefined) {
                 setShowDefaultUI(true);


### PR DESCRIPTION
## Summary of change

Re-add removing the change phone number footer to the 2fa example.

## Related issues

-   

## Test Plan

N/A example only test

## Documentation changes

N/A example only test

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
