### PR TITLE
refactor: Fix types for thirdpartypasswordless consumePasswordlessCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changes
+
+-   Makes the input argument for `consumePasswordlessCode` in ThirdPartyPasswordless optional.
+
 ## [0.24.6] - 2022-08-17
 
 ### Bug fixes

--- a/lib/build/recipe/thirdpartypasswordless/index.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/index.d.ts
@@ -106,7 +106,7 @@ export default class Wrapper {
         fetchResponse: Response;
     }>;
     static consumePasswordlessCode(
-        input:
+        input?:
             | {
                   userInputCode: string;
                   userContext?: any;

--- a/lib/ts/recipe/thirdpartypasswordless/index.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/index.ts
@@ -253,7 +253,7 @@ export default class Wrapper {
     }
 
     static async consumePasswordlessCode(
-        input:
+        input?:
             | {
                   userInputCode: string;
                   userContext?: any;

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -1483,10 +1483,6 @@ ThirdPartyPasswordless.consumePasswordlessCode({
         preAPIHook: undefined,
     },
 });
-// @ts-expect-error
-ThirdPartyPasswordless.consumePasswordlessCode(undefined);
-// @ts-expect-error
-ThirdPartyPasswordless.consumePasswordlessCode();
 
 ThirdPartyPasswordless.createPasswordlessCode({
     email: "",


### PR DESCRIPTION
## Summary of change

`ThirdPartyPasswordless.consumePasswordlessCode` expects an input even though it can be called without passing any arguments. This PR makes the input optional to make this experience better

## Related issues

-   

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Remaining TODOs for this PR

-   [ ] ...
