### PR TITLE
fix: fix color of prefilled inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Bug fixes
+
+-   Input colors now follow `inputBackground` and `textInput` even while being pre-filled
+
 ### Changes
 
 -   Updates `supertokens-node` version in example apps

--- a/lib/build/recipe/emailpassword/components/themes/styles/styles.js
+++ b/lib/build/recipe/emailpassword/components/themes/styles/styles.js
@@ -23,6 +23,7 @@ exports.getStyles = void 0;
 var chroma_js_1 = __importDefault(require("chroma-js"));
 var styles_1 = require("../../../../../styles/styles");
 function getStyles(palette) {
+    var _a;
     var baseStyles = (0, styles_1.getDefaultStyles)(palette);
     var recipeStyles = {
         inputContainer: {
@@ -54,25 +55,33 @@ function getStyles(palette) {
                 outline: "none",
             },
         },
-        input: {
-            boxSizing: "border-box",
-            paddingLeft: "15px",
-            filter: "none",
-            color: palette.colors.textInput,
-            backgroundColor: "transparent",
-            borderRadius: "6px",
-            fontSize: palette.fonts.size[1],
-            border: "none",
-            paddingRight: "25px",
-            letterSpacing: "1.2px",
-            flex: "9 1 75%",
-            width: "75%",
-            height: "32px",
-            "&:focus": {
+        input:
+            ((_a = {
+                boxSizing: "border-box",
+                paddingLeft: "15px",
+                filter: "none",
+                color: palette.colors.textInput,
+                backgroundColor: "transparent",
+                borderRadius: "6px",
+                fontSize: palette.fonts.size[1],
                 border: "none",
-                outline: "none",
-            },
-        },
+                paddingRight: "25px",
+                letterSpacing: "1.2px",
+                flex: "9 1 75%",
+                width: "75%",
+                height: "32px",
+                "&:focus": {
+                    border: "none",
+                    outline: "none",
+                },
+            }),
+            (_a[
+                "&:-webkit-autofill,\n            &:-webkit-autofill:hover, \n            &:-webkit-autofill:focus, \n            &:-webkit-autofill:active"
+            ] = {
+                "-webkit-text-fill-color": palette.colors.textInput,
+                "-webkit-box-shadow": "0 0 0 30px ".concat(palette.colors.inputBackground, " inset"),
+            }),
+            _a),
         inputAdornment: {
             justifyContent: "center",
             marginRight: "5px",

--- a/lib/ts/recipe/emailpassword/components/themes/styles/styles.ts
+++ b/lib/ts/recipe/emailpassword/components/themes/styles/styles.ts
@@ -70,6 +70,13 @@ export function getStyles(palette: NormalisedPalette): NormalisedDefaultStyles {
                 border: "none",
                 outline: "none",
             },
+            [`&:-webkit-autofill,
+            &:-webkit-autofill:hover, 
+            &:-webkit-autofill:focus, 
+            &:-webkit-autofill:active`]: {
+                "-webkit-text-fill-color": palette.colors.textInput,
+                "-webkit-box-shadow": `0 0 0 30px ${palette.colors.inputBackground} inset`,
+            },
         },
 
         inputAdornment: {


### PR DESCRIPTION
## Summary of change

Fixing the colors of prefilled inputs

## Related issues

-   #567

## Test Plan

Manual test (visual change only).

Before:
![image](https://user-images.githubusercontent.com/1129990/188122934-84f013ae-0104-4b96-ae83-77d9eab4582c.png)
After:
![image](https://user-images.githubusercontent.com/1129990/188122134-a9f6971a-de05-42f6-9f91-c5a506b0fd96.png)

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -  To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
