### PR TITLE
chore: update deps in package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,6 @@
             }
         },
         "eslint": {
-            "name": "eslint-plugin-supertokens-auth-react",
             "version": "1.0.0",
             "dev": true
         },
@@ -129,9 +128,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.0.tgz",
-            "integrity": "sha512-y5rqgTTPTmaF5e2nVhOxw+Ur9HDJLsWb6U/KpgUzRZEdPfE6VOubXBKLdbcUTijzRptednSBDQbYZBOSqJxpJw==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.1.tgz",
+            "integrity": "sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -206,14 +205,14 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.0.tgz",
-            "integrity": "sha512-Ai5bNWXIvwDvWM7njqsG3feMlL9hCVQsPYXodsZyLwshYkZVJt59Gftau4VrE8S9IT9asd2uSP1hG6wCNw+sXA==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.1.tgz",
+            "integrity": "sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.19.0",
+                "@babel/compat-data": "^7.19.1",
                 "@babel/helper-validator-option": "^7.18.6",
-                "browserslist": "^4.20.2",
+                "browserslist": "^4.21.3",
                 "semver": "^6.3.0"
             },
             "engines": {
@@ -392,16 +391,16 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.18.9.tgz",
-            "integrity": "sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.19.1.tgz",
+            "integrity": "sha512-T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-member-expression-to-functions": "^7.18.9",
                 "@babel/helper-optimise-call-expression": "^7.18.6",
-                "@babel/traverse": "^7.18.9",
-                "@babel/types": "^7.18.9"
+                "@babel/traverse": "^7.19.1",
+                "@babel/types": "^7.19.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -450,9 +449,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-            "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+            "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -508,9 +507,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.0.tgz",
-            "integrity": "sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
+            "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -519,9 +518,9 @@
             }
         },
         "node_modules/@babel/plugin-proposal-async-generator-functions": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.19.0.tgz",
-            "integrity": "sha512-nhEByMUTx3uZueJ/QkJuSlCfN4FGg+xy+vRsfGQGzSauq5ks2Deid2+05Q3KhfaUjvec1IGhw/Zm3cFm8JigTQ==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.19.1.tgz",
+            "integrity": "sha512-0yu8vNATgLy4ivqMNBIwb1HebCelqN7YX8SL3FDXORv/RqT0zEEWUCH4GH44JsSrvCu6GqnAdR5EBFAPeNBB4Q==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.18.9",
@@ -1227,9 +1226,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.19.0.tgz",
-            "integrity": "sha512-HDSuqOQzkU//kfGdiHBt71/hkDTApw4U/cMVgKgX7PqfB3LOaK+2GtCEsBu1dL9CkswDm0Gwehht1dCr421ULQ==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.19.1.tgz",
+            "integrity": "sha512-oWk9l9WItWBQYS4FgXD4Uyy5kq898lvkXpXQxoJEY1RnvPk4R/Dvu2ebXU9q8lP+rlMwUQTFf2Ok6d78ODa0kw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-create-regexp-features-plugin": "^7.19.0",
@@ -1688,9 +1687,9 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.0.tgz",
-            "integrity": "sha512-4pKpFRDh+utd2mbRC8JLnlsMUii3PMHjpL6a0SZ4NMZy7YFP9aXORxEhdMVOc9CpWtDF09IkciQLEhK7Ml7gRA==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
+            "integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/generator": "^7.19.0",
@@ -1698,7 +1697,7 @@
                 "@babel/helper-function-name": "^7.19.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.19.0",
+                "@babel/parser": "^7.19.1",
                 "@babel/types": "^7.19.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
@@ -2606,6 +2605,15 @@
                 "mocha": ">=6"
             }
         },
+        "node_modules/@remix-run/router": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.0.tgz",
+            "integrity": "sha512-SCR1cxRSMNKjaVYptCzBApPDqGwa3FGdjVHc+rOToocNPHQdIYLZBfv/3f+KvYuXDkUGVIW9IAzmPNZDRL1I4A==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@sindresorhus/is": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -3441,9 +3449,9 @@
             "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
         },
         "node_modules/@types/react": {
-            "version": "17.0.49",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.49.tgz",
-            "integrity": "sha512-CCBPMZaPhcKkYUTqFs/hOWqKjPxhTEmnZWjlHHgIMop67DsXywf9B5Os9Hz8KSacjNOgIdnZVJamwl232uxoPg==",
+            "version": "17.0.50",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.50.tgz",
+            "integrity": "sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==",
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -3770,9 +3778,9 @@
             }
         },
         "node_modules/@wdio/reporter/node_modules/@types/node": {
-            "version": "18.7.17",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.17.tgz",
-            "integrity": "sha512-0UyfUnt02zIuqp7yC8RYtDkp/vo8bFaQ13KkSEvUAohPOAlnVNbj5Fi3fgPSuwzakS+EvvnnZ4x9y7i6ASaSPQ==",
+            "version": "18.7.18",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+            "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
             "dev": true,
             "peer": true
         },
@@ -3799,9 +3807,9 @@
             }
         },
         "node_modules/@wdio/types/node_modules/@types/node": {
-            "version": "18.7.17",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.17.tgz",
-            "integrity": "sha512-0UyfUnt02zIuqp7yC8RYtDkp/vo8bFaQ13KkSEvUAohPOAlnVNbj5Fi3fgPSuwzakS+EvvnnZ4x9y7i6ASaSPQ==",
+            "version": "18.7.18",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+            "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
             "dev": true,
             "peer": true
         },
@@ -6350,9 +6358,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.248",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.248.tgz",
-            "integrity": "sha512-qShjzEYpa57NnhbW2K+g+Fl+eNoDvQ7I+2MRwWnU6Z6F0HhXekzsECCLv+y2OJUsRodjqoSfwHkIX42VUFtUzg==",
+            "version": "1.4.250",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.250.tgz",
+            "integrity": "sha512-KDLKcPEKPK+Q3/LdKX6knDzqyh8B82EaHccTYuGJR2qp1ymyGAo5HMH2x2OwDgzOPHlINSLIIeVhlFdq6aJgNA==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -7822,15 +7830,6 @@
                 "he": "bin/he"
             }
         },
-        "node_modules/history": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-            "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.7.6"
-            }
-        },
         "node_modules/hoist-non-react-statics": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -8647,20 +8646,20 @@
             }
         },
         "node_modules/istanbul-lib-instrument/node_modules/@babel/core": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.0.tgz",
-            "integrity": "sha512-reM4+U7B9ss148rh2n1Qs9ASS+w94irYXga7c2jaQv9RVzpS7Mv1a9rnYYwuDa45G+DkORt9g6An2k/V4d9LbQ==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
+            "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
                 "@babel/generator": "^7.19.0",
-                "@babel/helper-compilation-targets": "^7.19.0",
+                "@babel/helper-compilation-targets": "^7.19.1",
                 "@babel/helper-module-transforms": "^7.19.0",
                 "@babel/helpers": "^7.19.0",
-                "@babel/parser": "^7.19.0",
+                "@babel/parser": "^7.19.1",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.0",
+                "@babel/traverse": "^7.19.1",
                 "@babel/types": "^7.19.0",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
@@ -13954,25 +13953,30 @@
             }
         },
         "node_modules/react-router": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
-            "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.0.tgz",
+            "integrity": "sha512-B+5bEXFlgR1XUdHYR6P94g299SjrfCBMmEDJNcFbpAyRH1j1748yt9NdDhW3++nw1lk3zQJ6aOO66zUx3KlTZg==",
             "dev": true,
             "dependencies": {
-                "history": "^5.2.0"
+                "@remix-run/router": "1.0.0"
+            },
+            "engines": {
+                "node": ">=14"
             },
             "peerDependencies": {
                 "react": ">=16.8"
             }
         },
         "node_modules/react-router-dom": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
-            "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.0.tgz",
+            "integrity": "sha512-4Aw1xmXKeleYYQ3x0Lcl2undHR6yMjXZjd9DKZd53SGOYqirrUThyUb0wwAX5VZAyvSuzjNJmZlJ3rR9+/vzqg==",
             "dev": true,
             "dependencies": {
-                "history": "^5.2.0",
-                "react-router": "6.3.0"
+                "react-router": "6.4.0"
+            },
+            "engines": {
+                "node": ">=14"
             },
             "peerDependencies": {
                 "react": ">=16.8",
@@ -14141,9 +14145,9 @@
             "dev": true
         },
         "node_modules/regenerate-unicode-properties": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz",
-            "integrity": "sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
+            "integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
             "dev": true,
             "dependencies": {
                 "regenerate": "^1.4.2"
@@ -14196,15 +14200,15 @@
             }
         },
         "node_modules/regexpu-core": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.1.0.tgz",
-            "integrity": "sha512-bb6hk+xWd2PEOkj5It46A16zFMs2mv86Iwpdu94la4S3sJ7C973h2dHpYKwIBGaWSO7cIRJ+UX0IeMaWcO4qwA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.2.1.tgz",
+            "integrity": "sha512-HrnlNtpvqP1Xkb28tMhBUO2EbyUHdQlsnlAhzWcwHy8WJR53UWr7/MAvqrsQKMbV4qdpv03oTMG8iIhfsPFktQ==",
             "dev": true,
             "dependencies": {
                 "regenerate": "^1.4.2",
-                "regenerate-unicode-properties": "^10.0.1",
-                "regjsgen": "^0.6.0",
-                "regjsparser": "^0.8.2",
+                "regenerate-unicode-properties": "^10.1.0",
+                "regjsgen": "^0.7.1",
+                "regjsparser": "^0.9.1",
                 "unicode-match-property-ecmascript": "^2.0.0",
                 "unicode-match-property-value-ecmascript": "^2.0.0"
             },
@@ -14213,15 +14217,15 @@
             }
         },
         "node_modules/regjsgen": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.6.0.tgz",
-            "integrity": "sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.7.1.tgz",
+            "integrity": "sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA==",
             "dev": true
         },
         "node_modules/regjsparser": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.8.4.tgz",
-            "integrity": "sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==",
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+            "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
             "dev": true,
             "dependencies": {
                 "jsesc": "~0.5.0"
@@ -15305,17 +15309,17 @@
             "integrity": "sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg=="
         },
         "node_modules/supertokens-web-js": {
-            "version": "0.1.6",
-            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#5cc61fe5c89a7a747a033909b28f4c08aeaa9323",
+            "version": "0.2.0",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#f12da81d3571cb31522c9c245debd386b8695dee",
             "license": "Apache-2.0",
             "dependencies": {
                 "supertokens-js-override": "0.0.4",
-                "supertokens-website": "github:supertokens/supertokens-website#session_claims_base"
+                "supertokens-website": "github:supertokens/supertokens-website#13.1"
             }
         },
         "node_modules/supertokens-website": {
-            "version": "13.0.2",
-            "resolved": "git+ssh://git@github.com/supertokens/supertokens-website.git#a709bbc511ed332ab2be25709008d4ab47d9cfc6",
+            "version": "13.1.0",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-website.git#e6ab890eaf8cbfdbfcc90531063388a11c8931b7",
             "license": "Apache-2.0",
             "dependencies": {
                 "browser-tabs-lock": "^1.2.14",
@@ -16147,9 +16151,9 @@
             }
         },
         "node_modules/unicode-property-aliases-ecmascript": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
-            "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+            "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
             "dev": true,
             "engines": {
                 "node": ">=4"
@@ -17068,9 +17072,9 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.0.tgz",
-            "integrity": "sha512-y5rqgTTPTmaF5e2nVhOxw+Ur9HDJLsWb6U/KpgUzRZEdPfE6VOubXBKLdbcUTijzRptednSBDQbYZBOSqJxpJw==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.1.tgz",
+            "integrity": "sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==",
             "dev": true
         },
         "@babel/core": {
@@ -17126,14 +17130,14 @@
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.0.tgz",
-            "integrity": "sha512-Ai5bNWXIvwDvWM7njqsG3feMlL9hCVQsPYXodsZyLwshYkZVJt59Gftau4VrE8S9IT9asd2uSP1hG6wCNw+sXA==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.1.tgz",
+            "integrity": "sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.19.0",
+                "@babel/compat-data": "^7.19.1",
                 "@babel/helper-validator-option": "^7.18.6",
-                "browserslist": "^4.20.2",
+                "browserslist": "^4.21.3",
                 "semver": "^6.3.0"
             },
             "dependencies": {
@@ -17260,16 +17264,16 @@
             }
         },
         "@babel/helper-replace-supers": {
-            "version": "7.18.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.18.9.tgz",
-            "integrity": "sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.19.1.tgz",
+            "integrity": "sha512-T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==",
             "dev": true,
             "requires": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-member-expression-to-functions": "^7.18.9",
                 "@babel/helper-optimise-call-expression": "^7.18.6",
-                "@babel/traverse": "^7.18.9",
-                "@babel/types": "^7.18.9"
+                "@babel/traverse": "^7.19.1",
+                "@babel/types": "^7.19.0"
             }
         },
         "@babel/helper-simple-access": {
@@ -17303,9 +17307,9 @@
             "integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw=="
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-            "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g=="
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+            "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
         },
         "@babel/helper-validator-option": {
             "version": "7.18.6",
@@ -17346,14 +17350,14 @@
             }
         },
         "@babel/parser": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.0.tgz",
-            "integrity": "sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw=="
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
+            "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A=="
         },
         "@babel/plugin-proposal-async-generator-functions": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.19.0.tgz",
-            "integrity": "sha512-nhEByMUTx3uZueJ/QkJuSlCfN4FGg+xy+vRsfGQGzSauq5ks2Deid2+05Q3KhfaUjvec1IGhw/Zm3cFm8JigTQ==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.19.1.tgz",
+            "integrity": "sha512-0yu8vNATgLy4ivqMNBIwb1HebCelqN7YX8SL3FDXORv/RqT0zEEWUCH4GH44JsSrvCu6GqnAdR5EBFAPeNBB4Q==",
             "dev": true,
             "requires": {
                 "@babel/helper-environment-visitor": "^7.18.9",
@@ -17816,9 +17820,9 @@
             }
         },
         "@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.19.0.tgz",
-            "integrity": "sha512-HDSuqOQzkU//kfGdiHBt71/hkDTApw4U/cMVgKgX7PqfB3LOaK+2GtCEsBu1dL9CkswDm0Gwehht1dCr421ULQ==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.19.1.tgz",
+            "integrity": "sha512-oWk9l9WItWBQYS4FgXD4Uyy5kq898lvkXpXQxoJEY1RnvPk4R/Dvu2ebXU9q8lP+rlMwUQTFf2Ok6d78ODa0kw==",
             "dev": true,
             "requires": {
                 "@babel/helper-create-regexp-features-plugin": "^7.19.0",
@@ -18139,9 +18143,9 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.0.tgz",
-            "integrity": "sha512-4pKpFRDh+utd2mbRC8JLnlsMUii3PMHjpL6a0SZ4NMZy7YFP9aXORxEhdMVOc9CpWtDF09IkciQLEhK7Ml7gRA==",
+            "version": "7.19.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
+            "integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
             "requires": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/generator": "^7.19.0",
@@ -18149,7 +18153,7 @@
                 "@babel/helper-function-name": "^7.19.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.19.0",
+                "@babel/parser": "^7.19.1",
                 "@babel/types": "^7.19.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
@@ -18844,6 +18848,12 @@
                 "commander": "^7.0.0",
                 "glob": "^7.1.6"
             }
+        },
+        "@remix-run/router": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.0.tgz",
+            "integrity": "sha512-SCR1cxRSMNKjaVYptCzBApPDqGwa3FGdjVHc+rOToocNPHQdIYLZBfv/3f+KvYuXDkUGVIW9IAzmPNZDRL1I4A==",
+            "dev": true
         },
         "@sindresorhus/is": {
             "version": "4.6.0",
@@ -19560,9 +19570,9 @@
             "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
         },
         "@types/react": {
-            "version": "17.0.49",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.49.tgz",
-            "integrity": "sha512-CCBPMZaPhcKkYUTqFs/hOWqKjPxhTEmnZWjlHHgIMop67DsXywf9B5Os9Hz8KSacjNOgIdnZVJamwl232uxoPg==",
+            "version": "17.0.50",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.50.tgz",
+            "integrity": "sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==",
             "requires": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -19796,9 +19806,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "18.7.17",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.17.tgz",
-                    "integrity": "sha512-0UyfUnt02zIuqp7yC8RYtDkp/vo8bFaQ13KkSEvUAohPOAlnVNbj5Fi3fgPSuwzakS+EvvnnZ4x9y7i6ASaSPQ==",
+                    "version": "18.7.18",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+                    "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
                     "dev": true,
                     "peer": true
                 }
@@ -19816,9 +19826,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "18.7.17",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.17.tgz",
-                    "integrity": "sha512-0UyfUnt02zIuqp7yC8RYtDkp/vo8bFaQ13KkSEvUAohPOAlnVNbj5Fi3fgPSuwzakS+EvvnnZ4x9y7i6ASaSPQ==",
+                    "version": "18.7.18",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+                    "integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
                     "dev": true,
                     "peer": true
                 }
@@ -21783,9 +21793,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.248",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.248.tgz",
-            "integrity": "sha512-qShjzEYpa57NnhbW2K+g+Fl+eNoDvQ7I+2MRwWnU6Z6F0HhXekzsECCLv+y2OJUsRodjqoSfwHkIX42VUFtUzg==",
+            "version": "1.4.250",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.250.tgz",
+            "integrity": "sha512-KDLKcPEKPK+Q3/LdKX6knDzqyh8B82EaHccTYuGJR2qp1ymyGAo5HMH2x2OwDgzOPHlINSLIIeVhlFdq6aJgNA==",
             "dev": true
         },
         "emittery": {
@@ -22882,15 +22892,6 @@
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true
         },
-        "history": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-            "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-            "dev": true,
-            "requires": {
-                "@babel/runtime": "^7.7.6"
-            }
-        },
         "hoist-non-react-statics": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -23484,20 +23485,20 @@
             },
             "dependencies": {
                 "@babel/core": {
-                    "version": "7.19.0",
-                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.0.tgz",
-                    "integrity": "sha512-reM4+U7B9ss148rh2n1Qs9ASS+w94irYXga7c2jaQv9RVzpS7Mv1a9rnYYwuDa45G+DkORt9g6An2k/V4d9LbQ==",
+                    "version": "7.19.1",
+                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
+                    "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
                     "dev": true,
                     "requires": {
                         "@ampproject/remapping": "^2.1.0",
                         "@babel/code-frame": "^7.18.6",
                         "@babel/generator": "^7.19.0",
-                        "@babel/helper-compilation-targets": "^7.19.0",
+                        "@babel/helper-compilation-targets": "^7.19.1",
                         "@babel/helper-module-transforms": "^7.19.0",
                         "@babel/helpers": "^7.19.0",
-                        "@babel/parser": "^7.19.0",
+                        "@babel/parser": "^7.19.1",
                         "@babel/template": "^7.18.10",
-                        "@babel/traverse": "^7.19.0",
+                        "@babel/traverse": "^7.19.1",
                         "@babel/types": "^7.19.0",
                         "convert-source-map": "^1.7.0",
                         "debug": "^4.1.0",
@@ -27444,22 +27445,21 @@
             }
         },
         "react-router": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
-            "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.0.tgz",
+            "integrity": "sha512-B+5bEXFlgR1XUdHYR6P94g299SjrfCBMmEDJNcFbpAyRH1j1748yt9NdDhW3++nw1lk3zQJ6aOO66zUx3KlTZg==",
             "dev": true,
             "requires": {
-                "history": "^5.2.0"
+                "@remix-run/router": "1.0.0"
             }
         },
         "react-router-dom": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
-            "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.0.tgz",
+            "integrity": "sha512-4Aw1xmXKeleYYQ3x0Lcl2undHR6yMjXZjd9DKZd53SGOYqirrUThyUb0wwAX5VZAyvSuzjNJmZlJ3rR9+/vzqg==",
             "dev": true,
             "requires": {
-                "history": "^5.2.0",
-                "react-router": "6.3.0"
+                "react-router": "6.4.0"
             }
         },
         "react-select": {
@@ -27590,9 +27590,9 @@
             "dev": true
         },
         "regenerate-unicode-properties": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz",
-            "integrity": "sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
+            "integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
             "dev": true,
             "requires": {
                 "regenerate": "^1.4.2"
@@ -27630,29 +27630,29 @@
             "dev": true
         },
         "regexpu-core": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.1.0.tgz",
-            "integrity": "sha512-bb6hk+xWd2PEOkj5It46A16zFMs2mv86Iwpdu94la4S3sJ7C973h2dHpYKwIBGaWSO7cIRJ+UX0IeMaWcO4qwA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.2.1.tgz",
+            "integrity": "sha512-HrnlNtpvqP1Xkb28tMhBUO2EbyUHdQlsnlAhzWcwHy8WJR53UWr7/MAvqrsQKMbV4qdpv03oTMG8iIhfsPFktQ==",
             "dev": true,
             "requires": {
                 "regenerate": "^1.4.2",
-                "regenerate-unicode-properties": "^10.0.1",
-                "regjsgen": "^0.6.0",
-                "regjsparser": "^0.8.2",
+                "regenerate-unicode-properties": "^10.1.0",
+                "regjsgen": "^0.7.1",
+                "regjsparser": "^0.9.1",
                 "unicode-match-property-ecmascript": "^2.0.0",
                 "unicode-match-property-value-ecmascript": "^2.0.0"
             }
         },
         "regjsgen": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.6.0.tgz",
-            "integrity": "sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.7.1.tgz",
+            "integrity": "sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA==",
             "dev": true
         },
         "regjsparser": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.8.4.tgz",
-            "integrity": "sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==",
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+            "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
             "dev": true,
             "requires": {
                 "jsesc": "~0.5.0"
@@ -28491,16 +28491,16 @@
             "integrity": "sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg=="
         },
         "supertokens-web-js": {
-            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#5cc61fe5c89a7a747a033909b28f4c08aeaa9323",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#f12da81d3571cb31522c9c245debd386b8695dee",
             "from": "supertokens-web-js@github:supertokens/supertokens-web-js#0.2",
             "requires": {
                 "supertokens-js-override": "0.0.4",
-                "supertokens-website": "github:supertokens/supertokens-website#session_claims_base"
+                "supertokens-website": "github:supertokens/supertokens-website#13.1"
             }
         },
         "supertokens-website": {
-            "version": "git+ssh://git@github.com/supertokens/supertokens-website.git#a709bbc511ed332ab2be25709008d4ab47d9cfc6",
-            "from": "supertokens-website@github:supertokens/supertokens-website#session_claims_base",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-website.git#e6ab890eaf8cbfdbfcc90531063388a11c8931b7",
+            "from": "supertokens-website@github:supertokens/supertokens-website#13.1",
             "requires": {
                 "browser-tabs-lock": "^1.2.14",
                 "supertokens-js-override": "^0.0.4"
@@ -29114,9 +29114,9 @@
             "dev": true
         },
         "unicode-property-aliases-ecmascript": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
-            "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+            "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
             "dev": true
         },
         "uniq": {


### PR DESCRIPTION
## Summary of change

Update dependencies in package-lock, to remove references of not existing branches

## Related issues

-   

## Test Plan

N/A

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
    -   Along with the associated array in `lib/ts/version.ts`
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
