### PR TITLE
fix: Fix type for passwordless consume code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.26.2] - 2022-09-22
+
+-   Fixes parameter type for Passwordless `consumeCode`
+
 ## [0.26.1] - 2022-09-22
 
 ### Changes

--- a/lib/build/recipe/passwordless/index.d.ts
+++ b/lib/build/recipe/passwordless/index.d.ts
@@ -38,7 +38,7 @@ export default class Wrapper {
         fetchResponse: Response;
     }>;
     static consumeCode(
-        input:
+        input?:
             | {
                   userInputCode: string;
                   userContext?: any;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.26.1";
+export declare const package_version = "0.26.2";

--- a/lib/build/version.js
+++ b/lib/build/version.js
@@ -15,4 +15,4 @@ exports.package_version = void 0;
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-exports.package_version = "0.26.1";
+exports.package_version = "0.26.2";

--- a/lib/ts/recipe/passwordless/index.ts
+++ b/lib/ts/recipe/passwordless/index.ts
@@ -63,7 +63,7 @@ export default class Wrapper {
     }
 
     static async consumeCode(
-        input:
+        input?:
             | {
                   userInputCode: string;
                   userContext?: any;

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.26.1";
+export const package_version = "0.26.2";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.26.1",
+    "version": "0.26.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.26.1",
+            "version": "0.26.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@emotion/react": "^11.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.26.1",
+    "version": "0.26.2",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -623,9 +623,7 @@ Passwordless.consumeCode({
         preAPIHook: undefined,
     },
 });
-// @ts-expect-error
 Passwordless.consumeCode(undefined);
-// @ts-expect-error
 Passwordless.consumeCode();
 
 Passwordless.createCode({


### PR DESCRIPTION
## Summary of change

Fixes parameter type for Passwordless consume code to allow for calling the function without any input

## Related issues

## Test Plan

## Documentation changes

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.

## Remaining TODOs for this PR

-   [ ] 
