### PR TITLE
test: fix ci&scripts to use updated website version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Build/Test changes
+
+-   Fixes how our CI testing procedure (alway using latest)
+
 ## [0.26.2] - 2022-09-22
 
 -   Fixes parameter type for Passwordless `consumeCode`

--- a/init.sh
+++ b/init.sh
@@ -6,6 +6,9 @@
 # export PUPPETEER_EXECUTABLE_PATH=`which chromium`
 # And run brew install chromium --no-quarantine
 
+echo "Updating supertokens-web-js supertokens-website patch versions"
+npm up --legacy-peer-deps supertokens-web-js supertokens-website
+
 echo "Install in root"
 npm i -d --force || exit $?
 

--- a/test/end-to-end/emailverification.test.js
+++ b/test/end-to-end/emailverification.test.js
@@ -159,6 +159,7 @@ describe("SuperTokens Email Verification", function () {
                 "ST_LOGS EMAIL_VERIFICATION OVERRIDE IS_EMAIL_VERIFIED",
                 "ST_LOGS EMAIL_VERIFICATION PRE_API_HOOKS IS_EMAIL_VERIFIED",
                 "ST_LOGS SESSION ON_HANDLE_EVENT UNAUTHORISED",
+                "ST_LOGS SESSION OVERRIDE GET_JWT_PAYLOAD_SECURELY",
                 "ST_LOGS SUPERTOKENS GET_REDIRECTION_URL TO_AUTH",
             ]);
         });

--- a/test/prepTestApp.sh
+++ b/test/prepTestApp.sh
@@ -21,9 +21,9 @@ rm -rf node_modules/supertokens-web-js || true
 rm -rf node_modules/supertokens-website || true
 
 # We symlink the supertokens-web-js dep to ensure it's the same version (maybe linked locally)
-ln -s ../../../../node_modules/supertokens-web-js node_modules/supertokens-web-js
+ln -s ../../../../../node_modules/supertokens-web-js node_modules/supertokens-web-js
 
 # We symlink the supertokens-website dep to ensure it's the same version (maybe linked locally)
-ln -s ../../../../node_modules/supertokens-website node_modules/supertokens-website
+ln -s ../../../../../node_modules/supertokens-website node_modules/supertokens-website
 
 echo "$1 prepped."


### PR DESCRIPTION
## Summary of change

Fix test & CI scripts to use updated website version

## Related issues

-   

## Test Plan

N/A

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
