### PR TITLE
feat: make the thirdparty login form header overrideable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Added
+
+-   Made the header of the third party sign in/up form overrideable
+
 ## [0.26.5] - 2022-10-11
 
 ### Fixes

--- a/lib/build/recipe/thirdparty/components/themes/signInAndUp/index.js
+++ b/lib/build/recipe/thirdparty/components/themes/signInAndUp/index.js
@@ -86,11 +86,10 @@ var signUpFooter_1 = require("./signUpFooter");
 var themeBase_1 = require("../themeBase");
 var providersForm_1 = require("./providersForm");
 var SuperTokensBranding_1 = require("../../../../../components/SuperTokensBranding");
-var __1 = require("../../../../..");
 var generalError_1 = __importDefault(require("../../../../emailpassword/components/library/generalError"));
 var userContextWrapper_1 = __importDefault(require("../../../../../usercontext/userContextWrapper"));
+var signInAndUpHeader_1 = require("./signInAndUpHeader");
 var SignInAndUpTheme = function (props) {
-    var t = (0, __1.useTranslation)();
     var styles = (0, react_1.useContext)(styleContext_1.default);
     return (0, jsx_runtime_1.jsxs)(
         "div",
@@ -104,13 +103,7 @@ var SignInAndUpTheme = function (props) {
                             { "data-supertokens": "row", css: styles.row },
                             {
                                 children: [
-                                    (0, jsx_runtime_1.jsx)(
-                                        "div",
-                                        __assign(
-                                            { "data-supertokens": "headerTitle", css: styles.headerTitle },
-                                            { children: t("THIRD_PARTY_SIGN_IN_AND_UP_HEADER_TITLE") }
-                                        )
-                                    ),
+                                    (0, jsx_runtime_1.jsx)(signInAndUpHeader_1.SignInAndUpHeader, {}),
                                     (0, jsx_runtime_1.jsx)("div", {
                                         "data-supertokens": "divider",
                                         css: styles.divider,

--- a/lib/build/recipe/thirdparty/components/themes/signInAndUp/signInAndUpHeader.d.ts
+++ b/lib/build/recipe/thirdparty/components/themes/signInAndUp/signInAndUpHeader.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="react" />
+export declare const SignInAndUpHeader: import("react").ComponentType<unknown>;

--- a/lib/build/recipe/thirdparty/components/themes/signInAndUp/signInAndUpHeader.js
+++ b/lib/build/recipe/thirdparty/components/themes/signInAndUp/signInAndUpHeader.js
@@ -1,0 +1,55 @@
+"use strict";
+var __assign =
+    (this && this.__assign) ||
+    function () {
+        __assign =
+            Object.assign ||
+            function (t) {
+                for (var s, i = 1, n = arguments.length; i < n; i++) {
+                    s = arguments[i];
+                    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+                }
+                return t;
+            };
+        return __assign.apply(this, arguments);
+    };
+var __importDefault =
+    (this && this.__importDefault) ||
+    function (mod) {
+        return mod && mod.__esModule ? mod : { default: mod };
+    };
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.SignInAndUpHeader = void 0;
+var jsx_runtime_1 = require("@emotion/react/jsx-runtime");
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+var react_1 = require("react");
+var styleContext_1 = __importDefault(require("../../../../../styles/styleContext"));
+var withOverride_1 = require("../../../../../components/componentOverride/withOverride");
+var translationContext_1 = require("../../../../../translation/translationContext");
+exports.SignInAndUpHeader = (0, withOverride_1.withOverride)(
+    "ThirdPartySignInAndUpHeader",
+    function ThirdPartySignInAndUpHeader() {
+        var styles = (0, react_1.useContext)(styleContext_1.default);
+        var t = (0, translationContext_1.useTranslation)();
+        return (0, jsx_runtime_1.jsx)(
+            "div",
+            __assign(
+                { "data-supertokens": "headerTitle", css: styles.headerTitle },
+                { children: t("THIRD_PARTY_SIGN_IN_AND_UP_HEADER_TITLE") }
+            )
+        );
+    }
+);

--- a/lib/build/recipe/thirdparty/types.d.ts
+++ b/lib/build/recipe/thirdparty/types.d.ts
@@ -15,8 +15,10 @@ import { SignUpFooter } from "./components/themes/signInAndUp/signUpFooter";
 import { SignInAndUpCallbackTheme } from "./components/themes/signInAndUpCallback";
 import OverrideableBuilder from "supertokens-js-override";
 import { StateObject as WebJsStateObject, RecipeInterface } from "supertokens-web-js/recipe/thirdparty";
+import { SignInAndUpHeader } from "./components/themes/signInAndUp/signInAndUpHeader";
 export declare type ComponentOverrideMap = {
     ThirdPartySignUpFooter_Override?: ComponentOverride<typeof SignUpFooter>;
+    ThirdPartySignInAndUpHeader_Override?: ComponentOverride<typeof SignInAndUpHeader>;
     ThirdPartySignInAndUpProvidersForm_Override?: ComponentOverride<typeof ProvidersForm>;
     ThirdPartySignInAndUpCallbackTheme_Override?: ComponentOverride<typeof SignInAndUpCallbackTheme>;
 };

--- a/lib/build/recipe/thirdpartypasswordless/types.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/types.d.ts
@@ -47,7 +47,7 @@ declare type WithRenamedOptionalProp<T, K extends keyof T, L extends string> = O
     [P in L]?: T[K];
 };
 export declare type ComponentOverrideMap = Omit<PasswordlessOverrideMap, "PasswordlessSignInUpHeader_Override"> &
-    Omit<ThirdPartyOverrideMap, "ThirdPartySignUpFooter_Override" | "ThirdPartySignUpHeader_Override"> & {
+    Omit<ThirdPartyOverrideMap, "ThirdPartySignUpFooter_Override" | "ThirdPartySignInAndUpHeader_Override"> & {
         ThirdPartyPasswordlessHeader_Override?: ComponentOverride<typeof Header>;
     };
 export declare type SignInUpFeatureConfigInput = WithRenamedOptionalProp<

--- a/lib/ts/recipe/thirdparty/components/themes/signInAndUp/index.tsx
+++ b/lib/ts/recipe/thirdparty/components/themes/signInAndUp/index.tsx
@@ -25,20 +25,17 @@ import { SignInAndUpThemeProps } from "../../../types";
 import { ThemeBase } from "../themeBase";
 import { ProvidersForm } from "./providersForm";
 import { SuperTokensBranding } from "../../../../../components/SuperTokensBranding";
-import { useTranslation } from "../../../../..";
 import GeneralError from "../../../../emailpassword/components/library/generalError";
 import UserContextWrapper from "../../../../../usercontext/userContextWrapper";
+import { SignInAndUpHeader } from "./signInAndUpHeader";
 
 const SignInAndUpTheme: React.FC<SignInAndUpThemeProps> = (props) => {
-    const t = useTranslation();
     const styles = useContext(StyleContext);
 
     return (
         <div data-supertokens="container" css={styles.container}>
             <div data-supertokens="row" css={styles.row}>
-                <div data-supertokens="headerTitle" css={styles.headerTitle}>
-                    {t("THIRD_PARTY_SIGN_IN_AND_UP_HEADER_TITLE")}
-                </div>
+                <SignInAndUpHeader />
 
                 <div data-supertokens="divider" css={styles.divider}></div>
 

--- a/lib/ts/recipe/thirdparty/components/themes/signInAndUp/signInAndUpHeader.tsx
+++ b/lib/ts/recipe/thirdparty/components/themes/signInAndUp/signInAndUpHeader.tsx
@@ -1,0 +1,33 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useContext } from "react";
+import StyleContext from "../../../../../styles/styleContext";
+import { withOverride } from "../../../../../components/componentOverride/withOverride";
+import { useTranslation } from "../../../../../translation/translationContext";
+
+export const SignInAndUpHeader = withOverride(
+    "ThirdPartySignInAndUpHeader",
+    function ThirdPartySignInAndUpHeader(): JSX.Element | null {
+        const styles = useContext(StyleContext);
+        const t = useTranslation();
+
+        return (
+            <div data-supertokens="headerTitle" css={styles.headerTitle}>
+                {t("THIRD_PARTY_SIGN_IN_AND_UP_HEADER_TITLE")}
+            </div>
+        );
+    }
+);

--- a/lib/ts/recipe/thirdparty/types.ts
+++ b/lib/ts/recipe/thirdparty/types.ts
@@ -30,9 +30,11 @@ import { SignUpFooter } from "./components/themes/signInAndUp/signUpFooter";
 import { SignInAndUpCallbackTheme } from "./components/themes/signInAndUpCallback";
 import OverrideableBuilder from "supertokens-js-override";
 import { StateObject as WebJsStateObject, RecipeInterface } from "supertokens-web-js/recipe/thirdparty";
+import { SignInAndUpHeader } from "./components/themes/signInAndUp/signInAndUpHeader";
 
 export type ComponentOverrideMap = {
     ThirdPartySignUpFooter_Override?: ComponentOverride<typeof SignUpFooter>;
+    ThirdPartySignInAndUpHeader_Override?: ComponentOverride<typeof SignInAndUpHeader>;
     ThirdPartySignInAndUpProvidersForm_Override?: ComponentOverride<typeof ProvidersForm>;
     ThirdPartySignInAndUpCallbackTheme_Override?: ComponentOverride<typeof SignInAndUpCallbackTheme>;
 };

--- a/lib/ts/recipe/thirdpartypasswordless/types.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/types.ts
@@ -70,7 +70,7 @@ type WithRenamedOptionalProp<T, K extends keyof T, L extends string> = Omit<T, K
 };
 
 export type ComponentOverrideMap = Omit<PasswordlessOverrideMap, "PasswordlessSignInUpHeader_Override"> &
-    Omit<ThirdPartyOverrideMap, "ThirdPartySignUpFooter_Override" | "ThirdPartySignUpHeader_Override"> & {
+    Omit<ThirdPartyOverrideMap, "ThirdPartySignUpFooter_Override" | "ThirdPartySignInAndUpHeader_Override"> & {
         ThirdPartyPasswordlessHeader_Override?: ComponentOverride<typeof Header>;
     };
 

--- a/test/unit/componentOverrides.test.tsx
+++ b/test/unit/componentOverrides.test.tsx
@@ -21,6 +21,7 @@ import { SignUpFooter as EmailPasswordSignUpFooter } from "../../lib/ts/recipe/e
 import { SignUpForm } from "../../lib/ts/recipe/emailpassword/components/themes/signInAndUp/signUpForm";
 import { SubmitNewPassword } from "../../lib/ts/recipe/emailpassword/components/themes/resetPasswordUsingToken/submitNewPassword";
 import { SignUpFooter as ThirdPartySignUpFooter } from "../../lib/ts/recipe/thirdparty/components/themes/signInAndUp/signUpFooter";
+import { SignInAndUpHeader as ThirdPartySignInAndUpHeader } from "../../lib/ts/recipe/thirdparty/components/themes/signInAndUp/signInUpHeader";
 import { ProvidersForm } from "../../lib/ts/recipe/thirdparty/components/themes/signInAndUp/providersForm";
 import { SignInAndUpCallbackTheme } from "../../lib/ts/recipe/thirdparty/components/themes/signInAndUpCallback";
 import { SendVerifyEmail } from "../../lib/ts/recipe/emailverification/components/themes/emailVerification/sendVerifyEmail";
@@ -68,6 +69,7 @@ describe("Theme component overrides", () => {
         EmailPasswordSignUpForm_Override: SignUpForm,
         EmailPasswordSubmitNewPassword_Override: SubmitNewPassword,
         ThirdPartySignUpFooter_Override: ThirdPartySignUpFooter,
+        ThirdPartySignInAndUpHeader_Override: ThirdPartySignInAndUpHeader,
         ThirdPartySignInAndUpProvidersForm_Override: ProvidersForm,
         ThirdPartySignInAndUpCallbackTheme_Override: SignInAndUpCallbackTheme,
         EmailVerificationSendVerifyEmail_Override: SendVerifyEmail,


### PR DESCRIPTION
## Summary of change

make the thirdparty login form header overrideable

## Related issues

-  

## Test Plan

Added to override tests.
Manually tested in the thirdparty example

## Documentation changes

Not necessary (the example in the documentation uses the footer)

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
