### PR TITLE
feat: pwless phone or email call API with guessed phone number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+
+-   Updated passwordless login to first try calling the API if it could guess a valid international phone number
+
 ## [0.27.0] - 2022-10-18
 
 ### Added

--- a/lib/build/recipe/passwordless/components/themes/signInUp/emailOrPhoneForm.js
+++ b/lib/build/recipe/passwordless/components/themes/signInUp/emailOrPhoneForm.js
@@ -182,7 +182,14 @@ exports.EmailOrPhoneForm = (0, withOverride_1.withOverride)(
             onSuccess: props.onSuccess,
             callAPI: function (formFields, setValue) {
                 return __awaiter(_this, void 0, void 0, function () {
-                    var emailOrPhone, emailValidationRes, response, phoneValidationRes, response, intPhoneNumber;
+                    var emailOrPhone,
+                        emailValidationRes,
+                        response,
+                        phoneValidationRes,
+                        response,
+                        intPhoneNumber,
+                        phoneValidationResAfterGuess,
+                        response;
                     var _a;
                     return __generator(this, function (_b) {
                         switch (_b.label) {
@@ -216,7 +223,7 @@ exports.EmailOrPhoneForm = (0, withOverride_1.withOverride)(
                             case 4:
                                 throw new error_1.default(emailValidationRes);
                             case 5:
-                                return [3 /*break*/, 11];
+                                return [3 /*break*/, 19];
                             case 6:
                                 return [4 /*yield*/, props.config.validatePhoneNumber(emailOrPhone)];
                             case 7:
@@ -242,15 +249,38 @@ exports.EmailOrPhoneForm = (0, withOverride_1.withOverride)(
                                 ];
                             case 10:
                                 intPhoneNumber = _b.sent();
-                                if (intPhoneNumber && isPhoneNumber !== true) {
-                                    setValue("emailOrPhone", intPhoneNumber);
-                                    setIsPhoneNumber(true);
-                                    throw new error_1.default("PWLESS_EMAIL_OR_PHONE_INVALID_INPUT_GUESS_PHONE_ERR");
-                                } else {
-                                    throw new error_1.default(phoneValidationRes);
-                                }
-                                _b.label = 11;
+                                if (!(intPhoneNumber && isPhoneNumber !== true)) return [3 /*break*/, 18];
+                                return [4 /*yield*/, props.config.validatePhoneNumber(intPhoneNumber)];
                             case 11:
+                                phoneValidationResAfterGuess = _b.sent();
+                                _b.label = 12;
+                            case 12:
+                                _b.trys.push([12, , 16, 17]);
+                                if (!(phoneValidationResAfterGuess === undefined)) return [3 /*break*/, 14];
+                                return [
+                                    4 /*yield*/,
+                                    props.recipeImplementation.createCode({
+                                        phoneNumber: intPhoneNumber,
+                                        userContext: userContext,
+                                    }),
+                                ];
+                            case 13:
+                                response = _b.sent();
+                                return [2 /*return*/, response];
+                            case 14:
+                                throw new error_1.default("PWLESS_EMAIL_OR_PHONE_INVALID_INPUT_GUESS_PHONE_ERR");
+                            case 15:
+                                return [3 /*break*/, 17];
+                            case 16:
+                                // We set these in finally since general errors from the API can make createCode throw
+                                setValue("emailOrPhone", intPhoneNumber);
+                                setIsPhoneNumber(true);
+                                return [7 /*endfinally*/];
+                            case 17:
+                                return [3 /*break*/, 19];
+                            case 18:
+                                throw new error_1.default(phoneValidationRes);
+                            case 19:
                                 return [2 /*return*/];
                         }
                     });

--- a/lib/ts/recipe/passwordless/components/themes/signInUp/emailOrPhoneForm.tsx
+++ b/lib/ts/recipe/passwordless/components/themes/signInUp/emailOrPhoneForm.tsx
@@ -96,9 +96,22 @@ export const EmailOrPhoneForm = withOverride(
                             );
 
                         if (intPhoneNumber && isPhoneNumber !== true) {
-                            setValue("emailOrPhone", intPhoneNumber);
-                            setIsPhoneNumber(true);
-                            throw new STGeneralError("PWLESS_EMAIL_OR_PHONE_INVALID_INPUT_GUESS_PHONE_ERR");
+                            const phoneValidationResAfterGuess = await props.config.validatePhoneNumber(intPhoneNumber);
+                            try {
+                                if (phoneValidationResAfterGuess === undefined) {
+                                    const response = await props.recipeImplementation.createCode({
+                                        phoneNumber: intPhoneNumber,
+                                        userContext,
+                                    });
+                                    return response;
+                                } else {
+                                    throw new STGeneralError("PWLESS_EMAIL_OR_PHONE_INVALID_INPUT_GUESS_PHONE_ERR");
+                                }
+                            } finally {
+                                // We set these in finally since general errors from the API can make createCode throw
+                                setValue("emailOrPhone", intPhoneNumber);
+                                setIsPhoneNumber(true);
+                            }
                         } else {
                             throw new STGeneralError(phoneValidationRes);
                         }


### PR DESCRIPTION
## Summary of change

Updated passwordless login to first try calling the API if it could guess a valid international phone number

## Related issues

-   #602 

## Test Plan

Updated test + added unit test

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x]Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
