### PR TITLE
test: fix pwless e2e tests react 16

### DIFF
--- a/test/end-to-end/passwordless.test.js
+++ b/test/end-to-end/passwordless.test.js
@@ -273,6 +273,11 @@ export function getPasswordlessTestCases({ authRecipe, logId, generalErrorRecipe
                 });
 
                 it("should guess correctly for a local number with general error", async function () {
+                    const _isGeneralErrorSupported = await isGeneralErrorSupported();
+                    if (!_isGeneralErrorSupported) {
+                        this.skip();
+                    }
+
                     await Promise.all([
                         page.goto(`${TEST_CLIENT_BASE_URL}/auth`),
                         page.waitForNavigation({ waitUntil: "networkidle0" }),
@@ -2097,7 +2102,7 @@ async function initBrowser(contactMethod, consoleLogs, authRecipe, { defaultCoun
     const page = await browser.newPage();
     page.on("console", (consoleObj) => {
         const log = consoleObj.text();
-        console.log(log);
+
         if (log.startsWith("ST_LOGS")) {
             consoleLogs.push(log);
         }


### PR DESCRIPTION
## Summary of change

Skipping the new passwordless test case in react 16.

## Related issues

-   #605 

## Test Plan

N/A

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
