### PR TITLE
Include implicit deps in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.27.1",
             "license": "Apache-2.0",
             "dependencies": {
+                "@emotion/cache": "^11.4.0",
                 "@emotion/react": "^11.4.1",
                 "chroma-js": "2.1.2",
                 "libphonenumber-js": "1.9.43",
@@ -17,7 +18,8 @@
                 "react-select": "5.2.1",
                 "react-shadow": "19.0.3",
                 "supertokens-js-override": "^0.0.4",
-                "supertokens-web-js": "^0.3.0"
+                "supertokens-web-js": "^0.3.0",
+                "supertokens-website": "^14.0.2"
             },
             "devDependencies": {
                 "@babel/core": "7.12.1",
@@ -1780,16 +1782,21 @@
             }
         },
         "node_modules/@emotion/cache": {
-            "version": "11.10.3",
-            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.3.tgz",
-            "integrity": "sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==",
+            "version": "11.10.5",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
+            "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
             "dependencies": {
                 "@emotion/memoize": "^0.8.0",
-                "@emotion/sheet": "^1.2.0",
+                "@emotion/sheet": "^1.2.1",
                 "@emotion/utils": "^1.2.0",
                 "@emotion/weak-memoize": "^0.3.0",
-                "stylis": "4.0.13"
+                "stylis": "4.1.3"
             }
+        },
+        "node_modules/@emotion/cache/node_modules/stylis": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+            "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
         },
         "node_modules/@emotion/eslint-plugin": {
             "version": "11.10.0",
@@ -1853,9 +1860,9 @@
             }
         },
         "node_modules/@emotion/sheet": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.0.tgz",
-            "integrity": "sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+            "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
         },
         "node_modules/@emotion/unitless": {
             "version": "0.8.0",
@@ -17839,15 +17846,22 @@
             }
         },
         "@emotion/cache": {
-            "version": "11.10.3",
-            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.3.tgz",
-            "integrity": "sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==",
+            "version": "11.10.5",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.5.tgz",
+            "integrity": "sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==",
             "requires": {
                 "@emotion/memoize": "^0.8.0",
-                "@emotion/sheet": "^1.2.0",
+                "@emotion/sheet": "^1.2.1",
                 "@emotion/utils": "^1.2.0",
                 "@emotion/weak-memoize": "^0.3.0",
-                "stylis": "4.0.13"
+                "stylis": "4.1.3"
+            },
+            "dependencies": {
+                "stylis": {
+                    "version": "4.1.3",
+                    "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+                    "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
+                }
             }
         },
         "@emotion/eslint-plugin": {
@@ -17894,9 +17908,9 @@
             }
         },
         "@emotion/sheet": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.0.tgz",
-            "integrity": "sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+            "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
         },
         "@emotion/unitless": {
             "version": "0.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,6 +141,7 @@
             "version": "7.12.1",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.1.tgz",
             "integrity": "sha512-6bGmltqzIJrinwRRdczQsMhruSi9Sqty9Te+/5hudn4Izx/JYRhW1QELpR+CIL0gC/c9A7WroH6FmkDGxmWx3w==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/generator": "^7.12.1",
@@ -171,6 +172,7 @@
             "version": "7.19.0",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
             "integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.19.0",
                 "@jridgewell/gen-mapping": "^0.3.2",
@@ -273,6 +275,7 @@
             "version": "7.18.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
             "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -293,6 +296,7 @@
             "version": "7.19.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
             "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.18.10",
                 "@babel/types": "^7.19.0"
@@ -305,6 +309,7 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
             "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.18.6"
             },
@@ -339,6 +344,7 @@
             "version": "7.19.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
             "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
+            "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-module-imports": "^7.18.6",
@@ -411,6 +417,7 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
             "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.18.6"
             },
@@ -434,6 +441,7 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
             "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.18.6"
             },
@@ -485,6 +493,7 @@
             "version": "7.19.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
             "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
+            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.18.10",
                 "@babel/traverse": "^7.19.0",
@@ -511,6 +520,7 @@
             "version": "7.19.1",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
             "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
+            "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -1678,6 +1688,7 @@
             "version": "7.18.10",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
             "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/parser": "^7.18.10",
@@ -1691,6 +1702,7 @@
             "version": "7.19.1",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
             "integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/generator": "^7.19.0",
@@ -2505,6 +2517,7 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
             "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.0.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -2518,6 +2531,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
             "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -2526,6 +2540,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
             "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -2543,12 +2558,14 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.4.14",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.15",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
             "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -5581,6 +5598,7 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -7199,6 +7217,7 @@
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -7336,6 +7355,7 @@
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -10330,6 +10350,7 @@
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -10376,6 +10397,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
             "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "dev": true,
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -11460,7 +11482,8 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "node_modules/multimatch": {
             "version": "4.0.0",
@@ -13535,6 +13558,7 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
             "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -13546,6 +13570,7 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
             "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.0"
@@ -14222,6 +14247,7 @@
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
             "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             }
@@ -14294,6 +14320,7 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver"
             }
@@ -16674,6 +16701,7 @@
             "version": "7.12.1",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.1.tgz",
             "integrity": "sha512-6bGmltqzIJrinwRRdczQsMhruSi9Sqty9Te+/5hudn4Izx/JYRhW1QELpR+CIL0gC/c9A7WroH6FmkDGxmWx3w==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/generator": "^7.12.1",
@@ -16697,6 +16725,7 @@
             "version": "7.19.0",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.0.tgz",
             "integrity": "sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.19.0",
                 "@jridgewell/gen-mapping": "^0.3.2",
@@ -16770,7 +16799,8 @@
         "@babel/helper-environment-visitor": {
             "version": "7.18.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-            "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
+            "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+            "dev": true
         },
         "@babel/helper-explode-assignable-expression": {
             "version": "7.18.6",
@@ -16785,6 +16815,7 @@
             "version": "7.19.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
             "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+            "dev": true,
             "requires": {
                 "@babel/template": "^7.18.10",
                 "@babel/types": "^7.19.0"
@@ -16794,6 +16825,7 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
             "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.18.6"
             }
@@ -16819,6 +16851,7 @@
             "version": "7.19.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
             "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
+            "dev": true,
             "requires": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-module-imports": "^7.18.6",
@@ -16873,6 +16906,7 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
             "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.18.6"
             }
@@ -16890,6 +16924,7 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
             "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.18.6"
             }
@@ -16926,6 +16961,7 @@
             "version": "7.19.0",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
             "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
+            "dev": true,
             "requires": {
                 "@babel/template": "^7.18.10",
                 "@babel/traverse": "^7.19.0",
@@ -16945,7 +16981,8 @@
         "@babel/parser": {
             "version": "7.19.1",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
-            "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A=="
+            "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
+            "dev": true
         },
         "@babel/plugin-proposal-async-generator-functions": {
             "version": "7.19.1",
@@ -17729,6 +17766,7 @@
             "version": "7.18.10",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
             "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/parser": "^7.18.10",
@@ -17739,6 +17777,7 @@
             "version": "7.19.1",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
             "integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/generator": "^7.19.0",
@@ -17815,8 +17854,7 @@
             "version": "11.10.0",
             "resolved": "https://registry.npmjs.org/@emotion/eslint-plugin/-/eslint-plugin-11.10.0.tgz",
             "integrity": "sha512-nWpuoQQrzI9aM9fgn+Pbb0pOau4BhheXyVqHcOYKFq46uSuSR2ivZaDwwCJKI6ScA8Pm7OcoOpwdRH2iisf9cg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@emotion/hash": {
             "version": "0.9.0",
@@ -17868,8 +17906,7 @@
         "@emotion/use-insertion-effect-with-fallbacks": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
-            "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
-            "requires": {}
+            "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A=="
         },
         "@emotion/utils": {
             "version": "1.2.0",
@@ -18366,6 +18403,7 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
             "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "dev": true,
             "requires": {
                 "@jridgewell/set-array": "^1.0.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -18375,12 +18413,14 @@
         "@jridgewell/resolve-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "dev": true
         },
         "@jridgewell/set-array": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "dev": true
         },
         "@jridgewell/source-map": {
             "version": "0.3.2",
@@ -18395,12 +18435,14 @@
         "@jridgewell/sourcemap-codec": {
             "version": "1.4.14",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "dev": true
         },
         "@jridgewell/trace-mapping": {
             "version": "0.3.15",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
             "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+            "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -19483,8 +19525,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -19546,8 +19587,7 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "ansi-colors": {
             "version": "3.2.3",
@@ -20576,8 +20616,7 @@
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
             "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "css-in-js-utils": {
             "version": "2.0.1",
@@ -20736,8 +20775,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
             "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "csso": {
             "version": "4.2.0",
@@ -20800,6 +20838,7 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -21550,8 +21589,7 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
             "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-plugin-supertokens-auth-react": {
             "version": "file:eslint"
@@ -22007,7 +22045,8 @@
         "gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true
         },
         "get-amd-module-type": {
             "version": "3.0.2",
@@ -22108,7 +22147,8 @@
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true
         },
         "globby": {
             "version": "11.1.0",
@@ -22344,8 +22384,7 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
             "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "ieee754": {
             "version": "1.2.1",
@@ -23716,8 +23755,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
             "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "jest-regex-util": {
             "version": "27.5.1",
@@ -24328,13 +24366,13 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
             "integrity": "sha512-t1KMcBkz/pT5JrvcJbpUR2u/w1kO9jXctaaGJ0vZDzwFnIvGWw9IDSRciT83kIs8Bnw4qpOl8bQK08V01YgMPg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
         },
         "json-parse-better-errors": {
             "version": "1.0.2",
@@ -24374,7 +24412,8 @@
         "json5": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "dev": true
         },
         "jsonc-parser": {
             "version": "3.2.0",
@@ -25222,7 +25261,8 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "multimatch": {
             "version": "4.0.0",
@@ -26032,29 +26072,25 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
             "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "postcss-discard-duplicates": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
             "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "postcss-discard-empty": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
             "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "postcss-discard-overridden": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
             "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "postcss-merge-longhand": {
             "version": "5.1.6",
@@ -26122,8 +26158,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
             "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "postcss-modules-local-by-default": {
             "version": "4.0.0",
@@ -26158,8 +26193,7 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
             "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "postcss-normalize-display-values": {
             "version": "5.1.0",
@@ -26640,8 +26674,7 @@
                     "version": "8.2.3",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
                     "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-                    "dev": true,
-                    "requires": {}
+                    "dev": true
                 }
             }
         },
@@ -26702,6 +26735,7 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
             "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0"
             }
@@ -26710,6 +26744,7 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
             "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.0"
@@ -26810,8 +26845,7 @@
         "react-universal-interface": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
-            "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
-            "requires": {}
+            "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="
         },
         "read-pkg": {
             "version": "3.0.0",
@@ -27221,6 +27255,7 @@
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
             "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0"
             }
@@ -27274,7 +27309,8 @@
         "semver": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true
         },
         "serialize-javascript": {
             "version": "6.0.0",
@@ -27720,8 +27756,7 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
             "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "stylehacks": {
             "version": "5.1.0",
@@ -28597,8 +28632,7 @@
                     "version": "1.8.0",
                     "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
                     "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-                    "dev": true,
-                    "requires": {}
+                    "dev": true
                 },
                 "schema-utils": {
                     "version": "3.1.1",
@@ -28814,8 +28848,7 @@
             "version": "7.5.9",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
             "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "xml": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "typescript": "4.7.3"
     },
     "dependencies": {
+        "@emotion/cache": "^11.4.0",
         "@emotion/react": "^11.4.1",
         "chroma-js": "2.1.2",
         "libphonenumber-js": "1.9.43",
@@ -69,7 +70,8 @@
         "react-select": "5.2.1",
         "react-shadow": "19.0.3",
         "supertokens-js-override": "^0.0.4",
-        "supertokens-web-js": "^0.3.0"
+        "supertokens-web-js": "^0.3.0",
+        "supertokens-website": "^14.0.2"
     },
     "peerDependencies": {
         "react": ">=16.8.0"


### PR DESCRIPTION
supertokens-auth-react [imports supertokens-website](https://github.com/supertokens/supertokens-auth-react/blob/e1995f65c08690586b802218efdd4876183aa87a/lib/ts/utils.ts#L18) (through supertokens-web-js), and [imports @emotion/cache](https://github.com/supertokens/supertokens-auth-react/blob/bfefc2983b0d21f6f3b0f2539fb66e0a88973b62/lib/ts/components/featureWrapper.tsx#L24) (through react-select); while none of these dependencies appear in [its package.json](https://github.com/supertokens/supertokens-auth-react/blob/bfefc2983b0d21f6f3b0f2539fb66e0a88973b62/package.json#L63-L73).

Implicit dependencies are disallowed and simply will not work with [pnpm](https://github.com/pnpm/pnpm).

Causes https://github.com/kamilkisiela/graphql-hive/pull/590.

P.S. I had to [update the lockfile](https://github.com/supertokens/supertokens-auth-react/commit/134bd37821ca7118ff49e90c7e49a6e91d01b289) because it was outdated apparently; and I have to use `--legacy-peer-deps` flag while installing because just `npm i` wont work due to some resolution conficts.