### PR TITLE
chore: update size-limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
                 "react-dom": "^18.0.0",
                 "react-router-dom": "^6.2.1",
                 "regenerator-runtime": "0.13.7",
-                "size-limit": "^6.0.3",
+                "size-limit": "^8.1.0",
                 "ts-jest": "^27.0.5",
                 "ts-prune": "^0.10.3",
                 "tslib": "^2.4.0",
@@ -141,6 +141,7 @@
             "version": "7.12.1",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.1.tgz",
             "integrity": "sha512-6bGmltqzIJrinwRRdczQsMhruSi9Sqty9Te+/5hudn4Izx/JYRhW1QELpR+CIL0gC/c9A7WroH6FmkDGxmWx3w==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/generator": "^7.12.1",
@@ -171,6 +172,7 @@
             "version": "7.20.4",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
             "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.20.2",
                 "@jridgewell/gen-mapping": "^0.3.2",
@@ -273,6 +275,7 @@
             "version": "7.18.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
             "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -293,6 +296,7 @@
             "version": "7.19.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
             "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.18.10",
                 "@babel/types": "^7.19.0"
@@ -305,6 +309,7 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
             "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.18.6"
             },
@@ -339,6 +344,7 @@
             "version": "7.20.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
             "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
+            "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-module-imports": "^7.18.6",
@@ -411,6 +417,7 @@
             "version": "7.20.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
             "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.20.2"
             },
@@ -434,6 +441,7 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
             "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+            "dev": true,
             "dependencies": {
                 "@babel/types": "^7.18.6"
             },
@@ -485,6 +493,7 @@
             "version": "7.20.1",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.1.tgz",
             "integrity": "sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==",
+            "dev": true,
             "dependencies": {
                 "@babel/template": "^7.18.10",
                 "@babel/traverse": "^7.20.1",
@@ -511,6 +520,7 @@
             "version": "7.20.3",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
             "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
+            "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -1680,6 +1690,7 @@
             "version": "7.18.10",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
             "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/parser": "^7.18.10",
@@ -1693,6 +1704,7 @@
             "version": "7.20.1",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
             "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+            "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/generator": "^7.20.1",
@@ -2565,6 +2577,7 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
             "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.0.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -2578,6 +2591,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
             "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -2586,6 +2600,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
             "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -2593,12 +2608,14 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.4.14",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.17",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
             "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "3.1.0",
                 "@jridgewell/sourcemap-codec": "1.4.14"
@@ -5015,6 +5032,7 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -7036,6 +7054,7 @@
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -7164,6 +7183,7 @@
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -10345,6 +10365,7 @@
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -10391,6 +10412,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
             "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "dev": true,
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -11427,7 +11449,8 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "node_modules/multimatch": {
             "version": "4.0.0",
@@ -11483,9 +11506,9 @@
             }
         },
         "node_modules/nanospinner": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-0.4.0.tgz",
-            "integrity": "sha512-FhxiB9PcEztMw6XfQDSLJBMlmN4n7B2hl/oiK4Hy9479r1+df0i2099DgcEx+m6yBfBJVUuKpILvP8fM3rK3Sw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.1.0.tgz",
+            "integrity": "sha512-yFvNYMig4AthKYfHFl1sLj7B2nkHL4lzdig4osvl9/LdGbXwrdFRoqBS98gsEsOakr0yH+r5NZ/1Y9gdVB8trA==",
             "dev": true,
             "dependencies": {
                 "picocolors": "^1.0.0"
@@ -13024,6 +13047,7 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
             "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -13035,6 +13059,7 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
             "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.0"
@@ -13733,6 +13758,7 @@
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
             "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             }
@@ -13752,6 +13778,7 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver"
             }
@@ -13836,24 +13863,25 @@
             "dev": true
         },
         "node_modules/size-limit": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-6.0.4.tgz",
-            "integrity": "sha512-zo/9FrXzetvZGFJnd1LC4mR9GvirElALlerMY3EOwEGdW7Lwgl2WT0hTRC2559ZR2PGfRpnXEgAFkayGAJOebg==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-8.1.0.tgz",
+            "integrity": "sha512-bUL+Uyyt/G+a1XzKlI2WKHVDepmXtqMDhF65pdtjccheiQTNjExWW4nFefgbRL2QgNTzRfK6ayFKjO3o4ER4gg==",
             "dev": true,
             "dependencies": {
                 "bytes-iec": "^3.1.1",
-                "chokidar": "^3.5.2",
+                "chokidar": "^3.5.3",
                 "ci-job-number": "^1.2.2",
-                "globby": "^11.0.4",
-                "lilconfig": "^2.0.3",
-                "nanospinner": "^0.4.0",
+                "globby": "^11.1.0",
+                "lilconfig": "^2.0.6",
+                "mkdirp": "^1.0.4",
+                "nanospinner": "^1.1.0",
                 "picocolors": "^1.0.0"
             },
             "bin": {
                 "size-limit": "bin.js"
             },
             "engines": {
-                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+                "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
             }
         },
         "node_modules/slash": {
@@ -15928,6 +15956,7 @@
             "version": "7.12.1",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.1.tgz",
             "integrity": "sha512-6bGmltqzIJrinwRRdczQsMhruSi9Sqty9Te+/5hudn4Izx/JYRhW1QELpR+CIL0gC/c9A7WroH6FmkDGxmWx3w==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/generator": "^7.12.1",
@@ -15951,6 +15980,7 @@
             "version": "7.20.4",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
             "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.20.2",
                 "@jridgewell/gen-mapping": "^0.3.2",
@@ -16024,7 +16054,8 @@
         "@babel/helper-environment-visitor": {
             "version": "7.18.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-            "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
+            "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+            "dev": true
         },
         "@babel/helper-explode-assignable-expression": {
             "version": "7.18.6",
@@ -16039,6 +16070,7 @@
             "version": "7.19.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
             "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+            "dev": true,
             "requires": {
                 "@babel/template": "^7.18.10",
                 "@babel/types": "^7.19.0"
@@ -16048,6 +16080,7 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
             "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.18.6"
             }
@@ -16073,6 +16106,7 @@
             "version": "7.20.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
             "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
+            "dev": true,
             "requires": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-module-imports": "^7.18.6",
@@ -16127,6 +16161,7 @@
             "version": "7.20.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
             "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.20.2"
             }
@@ -16144,6 +16179,7 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
             "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+            "dev": true,
             "requires": {
                 "@babel/types": "^7.18.6"
             }
@@ -16180,6 +16216,7 @@
             "version": "7.20.1",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.1.tgz",
             "integrity": "sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==",
+            "dev": true,
             "requires": {
                 "@babel/template": "^7.18.10",
                 "@babel/traverse": "^7.20.1",
@@ -16199,7 +16236,8 @@
         "@babel/parser": {
             "version": "7.20.3",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-            "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg=="
+            "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
+            "dev": true
         },
         "@babel/plugin-proposal-async-generator-functions": {
             "version": "7.20.1",
@@ -16987,6 +17025,7 @@
             "version": "7.18.10",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
             "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/parser": "^7.18.10",
@@ -16997,6 +17036,7 @@
             "version": "7.20.1",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
             "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
+            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
                 "@babel/generator": "^7.20.1",
@@ -17061,8 +17101,7 @@
             "version": "11.10.0",
             "resolved": "https://registry.npmjs.org/@emotion/eslint-plugin/-/eslint-plugin-11.10.0.tgz",
             "integrity": "sha512-nWpuoQQrzI9aM9fgn+Pbb0pOau4BhheXyVqHcOYKFq46uSuSR2ivZaDwwCJKI6ScA8Pm7OcoOpwdRH2iisf9cg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@emotion/hash": {
             "version": "0.9.0",
@@ -17114,8 +17153,7 @@
         "@emotion/use-insertion-effect-with-fallbacks": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
-            "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
-            "requires": {}
+            "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A=="
         },
         "@emotion/utils": {
             "version": "1.2.0",
@@ -17656,6 +17694,7 @@
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
             "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "dev": true,
             "requires": {
                 "@jridgewell/set-array": "^1.0.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -17665,22 +17704,26 @@
         "@jridgewell/resolve-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "dev": true
         },
         "@jridgewell/set-array": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "dev": true
         },
         "@jridgewell/sourcemap-codec": {
             "version": "1.4.14",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "dev": true
         },
         "@jridgewell/trace-mapping": {
             "version": "0.3.17",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
             "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+            "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "3.1.0",
                 "@jridgewell/sourcemap-codec": "1.4.14"
@@ -18415,8 +18458,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -19551,6 +19593,7 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -20500,8 +20543,7 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
             "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-plugin-supertokens-auth-react": {
             "version": "file:eslint"
@@ -20968,7 +21010,8 @@
         "gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true
         },
         "get-amd-module-type": {
             "version": "3.0.2",
@@ -21060,7 +21103,8 @@
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true
         },
         "globby": {
             "version": "11.1.0",
@@ -22752,8 +22796,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
             "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "jest-regex-util": {
             "version": "27.5.1",
@@ -23414,13 +23457,13 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
             "integrity": "sha512-t1KMcBkz/pT5JrvcJbpUR2u/w1kO9jXctaaGJ0vZDzwFnIvGWw9IDSRciT83kIs8Bnw4qpOl8bQK08V01YgMPg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "jsesc": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
         },
         "json-parse-better-errors": {
             "version": "1.0.2",
@@ -23460,7 +23503,8 @@
         "json5": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "dev": true
         },
         "jsonc-parser": {
             "version": "3.2.0",
@@ -24266,7 +24310,8 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "multimatch": {
             "version": "4.0.0",
@@ -24309,9 +24354,9 @@
             "dev": true
         },
         "nanospinner": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-0.4.0.tgz",
-            "integrity": "sha512-FhxiB9PcEztMw6XfQDSLJBMlmN4n7B2hl/oiK4Hy9479r1+df0i2099DgcEx+m6yBfBJVUuKpILvP8fM3rK3Sw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.1.0.tgz",
+            "integrity": "sha512-yFvNYMig4AthKYfHFl1sLj7B2nkHL4lzdig4osvl9/LdGbXwrdFRoqBS98gsEsOakr0yH+r5NZ/1Y9gdVB8trA==",
             "dev": true,
             "requires": {
                 "picocolors": "^1.0.0"
@@ -25389,8 +25434,7 @@
                     "version": "8.2.3",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
                     "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-                    "dev": true,
-                    "requires": {}
+                    "dev": true
                 }
             }
         },
@@ -25442,6 +25486,7 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
             "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0"
             }
@@ -25450,6 +25495,7 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
             "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.0"
@@ -25528,8 +25574,7 @@
         "react-universal-interface": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
-            "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
-            "requires": {}
+            "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="
         },
         "react-use": {
             "version": "15.3.8",
@@ -25967,6 +26012,7 @@
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
             "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0"
             }
@@ -25979,7 +26025,8 @@
         "semver": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true
         },
         "set-blocking": {
             "version": "2.0.0",
@@ -26046,17 +26093,18 @@
             "dev": true
         },
         "size-limit": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-6.0.4.tgz",
-            "integrity": "sha512-zo/9FrXzetvZGFJnd1LC4mR9GvirElALlerMY3EOwEGdW7Lwgl2WT0hTRC2559ZR2PGfRpnXEgAFkayGAJOebg==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-8.1.0.tgz",
+            "integrity": "sha512-bUL+Uyyt/G+a1XzKlI2WKHVDepmXtqMDhF65pdtjccheiQTNjExWW4nFefgbRL2QgNTzRfK6ayFKjO3o4ER4gg==",
             "dev": true,
             "requires": {
                 "bytes-iec": "^3.1.1",
-                "chokidar": "^3.5.2",
+                "chokidar": "^3.5.3",
                 "ci-job-number": "^1.2.2",
-                "globby": "^11.0.4",
-                "lilconfig": "^2.0.3",
-                "nanospinner": "^0.4.0",
+                "globby": "^11.1.0",
+                "lilconfig": "^2.0.6",
+                "mkdirp": "^1.0.4",
+                "nanospinner": "^1.1.0",
                 "picocolors": "^1.0.0"
             }
         },
@@ -27396,8 +27444,7 @@
             "version": "7.5.9",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
             "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "xml": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.2.1",
         "regenerator-runtime": "0.13.7",
-        "size-limit": "^6.0.3",
+        "size-limit": "^8.1.0",
         "ts-jest": "^27.0.5",
         "ts-prune": "^0.10.3",
         "tslib": "^2.4.0",
@@ -105,31 +105,31 @@
     "size-limit": [
         {
             "path": "lib/build/index.js",
-            "limit": "36kb"
+            "limit": "42kb"
         },
         {
             "path": "recipe/session/index.js",
-            "limit": "36kb"
+            "limit": "42kb"
         },
         {
             "path": "recipe/thirdpartyemailpassword/index.js",
-            "limit": "130kb"
+            "limit": "145kb"
         },
         {
             "path": "recipe/thirdparty/index.js",
-            "limit": "115kb"
+            "limit": "125kb"
         },
         {
             "path": "recipe/emailpassword/index.js",
-            "limit": "115.04kb"
+            "limit": "130kb"
         },
         {
             "path": "recipe/passwordless/index.js",
-            "limit": "215kb"
+            "limit": "220kb"
         },
         {
             "path": "recipe/thirdpartypasswordless/index.js",
-            "limit": "230kb"
+            "limit": "235kb"
         }
     ],
     "repository": {


### PR DESCRIPTION
## Summary of change

Update the main size-limit dependency to match the preset

## Related issues

-   

## Test Plan

N/A

## Documentation changes

N/A

## Checklist for important updates

-   [ ] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
