### PR TITLE
test: update test to match new website version

### DIFF
--- a/test/end-to-end/refresherrors.test.js
+++ b/test/end-to-end/refresherrors.test.js
@@ -19,14 +19,14 @@
 import assert from "assert";
 import puppeteer from "puppeteer";
 
-import { clearBrowserCookiesWithoutAffectingConsole, screenshotOnFailure } from "../helpers";
+import { clearBrowserCookiesWithoutAffectingConsole, getTextInDashboardNoAuth, screenshotOnFailure } from "../helpers";
 
 // Run the tests in a DOM environment.
 require("jsdom-global")();
 import { TEST_CLIENT_BASE_URL } from "../constants";
 
-describe("Rethrowing errors", function () {
-    describe("500 on refresh", function () {
+describe("Refresh errors", function () {
+    describe("500", function () {
         let browser;
         let page;
 
@@ -50,7 +50,7 @@ describe("Rethrowing errors", function () {
             await clearBrowserCookiesWithoutAffectingConsole(page, []);
         });
 
-        it("rethrow error on refresh", async function () {
+        it("should be handled as logged out", async function () {
             await page.evaluate(() => {
                 document.cookie = "sAccessToken=asdfasdf;expires=Fri, 31 Dec 9999 23:59:59 GMT;path=/;samesite=lax";
                 document.cookie = "sIdRefreshToken=asdfasdf;expires=Fri, 31 Dec 9999 23:59:59 GMT;path=/;samesite=lax";
@@ -67,13 +67,13 @@ describe("Rethrowing errors", function () {
                 }
             });
             await Promise.all([
-                page.goto(`${TEST_CLIENT_BASE_URL}/auth`),
+                page.goto(`${TEST_CLIENT_BASE_URL}/dashboard-no-auth`),
                 page.waitForNavigation({ waitUntil: "networkidle0" }),
             ]);
-            await new Promise((res) => setTimeout(res, 1500));
 
-            // The last thing logged should be the error from the error boundary
-            assert.strictEqual(consoleLogs.pop(), "ST_THROWN_ERROR");
+            // We don't rethrow from doesSessionExist
+            let text = await getTextInDashboardNoAuth(page);
+            assert.strictEqual(text, "Not logged in");
         });
     });
 });


### PR DESCRIPTION
## Summary of change

Updated the refresh 500 test to match the new behaviour of the website SDK: not rethrowing errors.

## Related issues

-   

## Test Plan

Test update only

## Documentation changes

Test update only

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
