### PR TITLE
fix: guess phone number ux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.30.1] - 2023-01-20
+
+### Bugfixes
+
+-   Fixed guessing internation phone number in passwordless with EMAIL_OR_PHONE contact method if the number starts with a valid country dial code
+
 ## [0.30.0] - 2023-01-20
 
 ### Changes

--- a/lib/build/passwordless-shared.js
+++ b/lib/build/passwordless-shared.js
@@ -198,7 +198,7 @@ function defaultGuessInternationPhoneNumberFromInputPhoneNumber(value, defaultCo
         var intlTelInputUtils,
             libGuess,
             phoneNumberCharCount,
-            onlyNumbers,
+            filteredInput,
             countryData,
             matchingCountryCodes,
             _i,
@@ -228,12 +228,12 @@ function defaultGuessInternationPhoneNumberFromInputPhoneNumber(value, defaultCo
                     if (value.includes("@") || phoneNumberCharCount < value.length / 2) {
                         return [2 /*return*/, undefined];
                     }
-                    onlyNumbers = value.replace(/\D/g, "");
-                    if (intlTelInputUtils.isValidNumber(onlyNumbers, defaultCountryFromConfig)) {
+                    filteredInput = "+" + value.replace(/\D/g, "").replace(/^00/, "");
+                    if (intlTelInputUtils.isValidNumber(filteredInput, defaultCountryFromConfig)) {
                         return [
                             2 /*return*/,
                             intlTelInputUtils.formatNumber(
-                                onlyNumbers,
+                                filteredInput,
                                 defaultCountryFromConfig,
                                 intlTelInputUtils.numberFormat.E164
                             ),
@@ -244,7 +244,7 @@ function defaultGuessInternationPhoneNumberFromInputPhoneNumber(value, defaultCo
                         .intlTelInputGlobals.getCountryData();
                     matchingCountryCodes = countryData
                         .filter(function (c) {
-                            return onlyNumbers.startsWith(c.dialCode);
+                            return filteredInput.startsWith("+" + c.dialCode);
                         })
                         .map(function (c) {
                             return c.iso2;
@@ -255,10 +255,14 @@ function defaultGuessInternationPhoneNumberFromInputPhoneNumber(value, defaultCo
                         _i++
                     ) {
                         code = matchingCountryCodes_1[_i];
-                        if (intlTelInputUtils.isValidNumber(onlyNumbers, code)) {
+                        if (intlTelInputUtils.isValidNumber(filteredInput, code)) {
                             return [
                                 2 /*return*/,
-                                intlTelInputUtils.formatNumber(onlyNumbers, code, intlTelInputUtils.numberFormat.E164),
+                                intlTelInputUtils.formatNumber(
+                                    filteredInput,
+                                    code,
+                                    intlTelInputUtils.numberFormat.E164
+                                ),
                             ];
                         }
                     }
@@ -267,11 +271,11 @@ function defaultGuessInternationPhoneNumberFromInputPhoneNumber(value, defaultCo
                             return c.iso2 === defaultCountryFromConfig.toLowerCase();
                         });
                         if (defaultCountry) {
-                            return [2 /*return*/, "+" + defaultCountry.dialCode + onlyNumbers];
+                            return [2 /*return*/, "+" + defaultCountry.dialCode + filteredInput.substring(1)];
                         }
                     }
                     // We want to return the value as an international number because the phone number input lib expects it this way
-                    return [2 /*return*/, "+" + onlyNumbers];
+                    return [2 /*return*/, filteredInput];
             }
         });
     });

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.30.0";
+export declare const package_version = "0.30.1";

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.30.0";
+export const package_version = "0.30.1";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.30.0",
+    "version": "0.30.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.30.0",
+            "version": "0.30.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.30.0",
+    "version": "0.30.1",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {

--- a/test/end-to-end/passwordless.test.js
+++ b/test/end-to-end/passwordless.test.js
@@ -326,6 +326,18 @@ export function getPasswordlessTestCases({ authRecipe, logId, generalErrorRecipe
                     const input = await waitForSTElement(page, `[data-supertokens~=input][name=emailOrPhone_text]`);
                     await checkInputValue(page, input, "+36654");
                 });
+
+                it("should prepend default country code for invalid phone numbers that start with a valid dial code", async function () {
+                    await Promise.all([
+                        page.goto(`${TEST_CLIENT_BASE_URL}/auth`),
+                        page.waitForNavigation({ waitUntil: "networkidle0" }),
+                    ]);
+
+                    await setInputValues(page, [{ name: inputName, value: "7021123145" }]);
+                    await submitForm(page);
+                    const input = await waitForSTElement(page, `[data-supertokens~=input][name=emailOrPhone_text]`);
+                    await checkInputValue(page, input, "+367021123145");
+                });
             });
 
             describe("without default country defined", () => {
@@ -414,6 +426,18 @@ export function getPasswordlessTestCases({ authRecipe, logId, generalErrorRecipe
                     await submitForm(page);
                     const input = await waitForSTElement(page, `[data-supertokens~=input][name=emailOrPhone_text]`);
                     await checkInputValue(page, input, "+654");
+                });
+
+                it("should prepend + sign for invalid phone numbers that start with a valid dial code", async function () {
+                    await Promise.all([
+                        page.goto(`${TEST_CLIENT_BASE_URL}/auth`),
+                        page.waitForNavigation({ waitUntil: "networkidle0" }),
+                    ]);
+
+                    await setInputValues(page, [{ name: inputName, value: "7021123145" }]);
+                    await submitForm(page);
+                    const input = await waitForSTElement(page, `[data-supertokens~=input][name=emailOrPhone_text]`);
+                    await checkInputValue(page, input, "+7021123145");
                 });
             });
 


### PR DESCRIPTION
## Summary of change

-   Fixed guessing internation phone number in passwordless with EMAIL_OR_PHONE contact method if the number starts with a valid country dial code

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

Added tests for invalid phone numbers that start with a valid dial code

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [x] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
