### PR TITLE
chore: switch dep from mocha-split-tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.31.4] - 2023-03-29
+
+### Changes
+
+-   Switched dependency away from the removed/unpublished `mocha-split-tests` package
+
 ## [0.31.3] - 2023-03-23
 
 ### Changes

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.31.3";
+export declare const package_version = "0.31.4";

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.31.3";
+export const package_version = "0.31.4";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.31.3",
+    "version": "0.31.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.31.3",
+            "version": "0.31.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",
@@ -19,7 +19,6 @@
                 "@babel/preset-env": "7.12.1",
                 "@babel/preset-react": "7.12.1",
                 "@babel/register": "7.12.1",
-                "@peakon/mocha-split-tests": "^1.4.0",
                 "@percy/cli": "^1.16.0",
                 "@percy/puppeteer": "^2.0.2",
                 "@rollup/plugin-commonjs": "^23.0.3",
@@ -55,6 +54,7 @@
                 "mocha": "6.1.4",
                 "mocha-junit-reporter": "^2.0.2",
                 "mocha-multi": "1.1.6",
+                "mocha-split-tests": "github:rishabhpoddar/mocha-split-tests",
                 "npm-run-all": "^4.1.5",
                 "postcss": "^8.4.19",
                 "postcss-import": "^15.0.0",
@@ -82,7 +82,7 @@
             },
             "engines": {
                 "node": ">=16.0.0",
-                "npm": "^8"
+                "npm": ">=8"
             },
             "peerDependencies": {
                 "react": ">=16.8.0",
@@ -3236,23 +3236,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/@peakon/mocha-split-tests": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@peakon/mocha-split-tests/-/mocha-split-tests-1.4.0.tgz",
-            "integrity": "sha512-M5p8peb7bMcXZN1bhVKDMAXzmq505SZcHzfUA+HJS5mVTJuHza0R8iP/ugfsIwOseg6OaTF4DgId+cQKVxec5g==",
-            "dev": true,
-            "dependencies": {
-                "commander": "^7.0.0",
-                "glob": "^7.1.6"
-            },
-            "bin": {
-                "mocha-split-tests": "bin/mocha-split-tests"
-            },
-            "peerDependencies": {
-                "@wdio/reporter": ">=5",
-                "mocha": ">=6"
             }
         },
         "node_modules/@percy/cli": {
@@ -11992,6 +11975,23 @@
                 "mocha": ">=2.2.0 <7 || ^9"
             }
         },
+        "node_modules/mocha-split-tests": {
+            "version": "1.4.0",
+            "resolved": "git+ssh://git@github.com/rishabhpoddar/mocha-split-tests.git#b0bd99a7d5870493dbe921dbdd5195b47e555035",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^7.0.0",
+                "glob": "^7.1.6"
+            },
+            "bin": {
+                "mocha-split-tests": "bin/mocha-split-tests"
+            },
+            "peerDependencies": {
+                "@wdio/reporter": ">=5",
+                "mocha": ">=6"
+            }
+        },
         "node_modules/mocha/node_modules/ansi-regex": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
@@ -19423,16 +19423,6 @@
                 "fastq": "^1.6.0"
             }
         },
-        "@peakon/mocha-split-tests": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@peakon/mocha-split-tests/-/mocha-split-tests-1.4.0.tgz",
-            "integrity": "sha512-M5p8peb7bMcXZN1bhVKDMAXzmq505SZcHzfUA+HJS5mVTJuHza0R8iP/ugfsIwOseg6OaTF4DgId+cQKVxec5g==",
-            "dev": true,
-            "requires": {
-                "commander": "^7.0.0",
-                "glob": "^7.1.6"
-            }
-        },
         "@percy/cli": {
             "version": "1.18.0",
             "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.18.0.tgz",
@@ -26214,6 +26204,15 @@
                 "lodash.once": "^4.1.1",
                 "mkdirp": "^1.0.4",
                 "object-assign": "^4.1.1"
+            }
+        },
+        "mocha-split-tests": {
+            "version": "git+ssh://git@github.com/rishabhpoddar/mocha-split-tests.git#b0bd99a7d5870493dbe921dbdd5195b47e555035",
+            "dev": true,
+            "from": "mocha-split-tests@github:rishabhpoddar/mocha-split-tests",
+            "requires": {
+                "commander": "^7.0.0",
+                "glob": "^7.1.6"
             }
         },
         "module-definition": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.31.3",
+    "version": "0.31.4",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {
@@ -13,7 +13,6 @@
         "@babel/preset-env": "7.12.1",
         "@babel/preset-react": "7.12.1",
         "@babel/register": "7.12.1",
-        "@peakon/mocha-split-tests": "^1.4.0",
         "@percy/cli": "^1.16.0",
         "@percy/puppeteer": "^2.0.2",
         "@rollup/plugin-commonjs": "^23.0.3",
@@ -49,6 +48,7 @@
         "mocha": "6.1.4",
         "mocha-junit-reporter": "^2.0.2",
         "mocha-multi": "1.1.6",
+        "mocha-split-tests": "github:rishabhpoddar/mocha-split-tests",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.19",
         "postcss-import": "^15.0.0",


### PR DESCRIPTION
## Summary of change

chore: switch dep from mocha-split-tests

## Related issues
- https://app.circleci.com/pipelines/github/supertokens/supertokens-node/3177/workflows/5b59582c-c005-4ec6-8179-862251a41ced/jobs/1492
- https://app.circleci.com/pipelines/github/supertokens/supertokens-node/3177/workflows/5b59582c-c005-4ec6-8179-862251a41ced/jobs/1493

## Test Plan

Test only change

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [x] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
