### PR TITLE
test: update test server to support renamed getSessionData

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.32.0",
+            "version": "0.32.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -176,21 +176,18 @@ app.post("/stopstst", async (req, res) => {
 // custom API that requires session verification
 app.get("/sessioninfo", verifySession(), async (req, res) => {
     let session = req.session;
-    if (session.getJWTPayload !== undefined) {
-        res.send({
-            sessionHandle: session.getHandle(),
-            userId: session.getUserId(),
-            accessTokenPayload: session.getJWTPayload(),
-            sessionData: await session.getSessionData(),
-        });
-    } else {
-        res.send({
-            sessionHandle: session.getHandle(),
-            userId: session.getUserId(),
-            accessTokenPayload: session.getAccessTokenPayload(),
-            sessionData: await session.getSessionData(),
-        });
-    }
+    const accessTokenPayload =
+        session.getJWTPayload !== undefined ? session.getJWTPayload() : session.getAccessTokenPayload();
+
+    const sessionData = session.getSessionData
+        ? await session.getSessionData()
+        : await session.getSessionDataFromDatabase();
+    res.send({
+        sessionHandle: session.getHandle(),
+        userId: session.getUserId(),
+        accessTokenPayload,
+        sessionData,
+    });
 });
 
 app.post("/deleteUser", async (req, res) => {


### PR DESCRIPTION
## Summary of change

- update test server to support renamed getSessionData

## Related issues

-   https://app.circleci.com/pipelines/github/supertokens/supertokens-auth-react/3469/workflows/9fe8a434-2bba-4280-b1f6-a7139c4934e6/jobs/1946

## Test Plan

Test only update

## Documentation changes

Test only update

## Checklist for important updates

-   [ ] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [x] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
