### PR TITLE
refactor: Refactors EmailVerification recipe types to not require a config object during init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.32.4] - 2023-05-31
+
+-   Fixed the types for EmailVerification.init to not require a config to be passed.
+
 ## [0.32.3] - 2023-05-10
 
 -   Changed email verification index.tsx to use index.ts instead so that auto generated docs add it.

--- a/examples/with-no-session-on-sign-up-thirdpartyemailpassword/api-server/index.js
+++ b/examples/with-no-session-on-sign-up-thirdpartyemailpassword/api-server/index.js
@@ -96,6 +96,7 @@ supertokens.init({
                                     getUserId: () => "",
                                     revokeSession: () => {},
                                     updateSessionDataInDatabase: () => {},
+                                    attachToRequestResponse: () => {},
                                 }; // this is an empty session
                             } else {
                                 return oI.createNewSession(input);

--- a/lib/build/recipe/emailverification/index.d.ts
+++ b/lib/build/recipe/emailverification/index.d.ts
@@ -6,7 +6,7 @@ import type { RecipeFunctionOptions } from "supertokens-web-js/recipe/emailverif
 export default class Wrapper {
     static EmailVerificationClaim: import("supertokens-web-js/recipe/emailverification").EmailVerificationClaimClass;
     static init(
-        config: UserInput
+        config?: UserInput
     ): import("../../types").RecipeInitResult<
         GetRedirectionURLContext,
         import("./types").PreAndPostAPIHookAction,

--- a/lib/build/recipe/emailverification/recipe.d.ts
+++ b/lib/build/recipe/emailverification/recipe.d.ts
@@ -24,7 +24,7 @@ export default class EmailVerification extends RecipeModule<
         webJSRecipe?: WebJSRecipeInterface<typeof EmailVerificationWebJS>
     );
     static init(
-        config: UserInput
+        config?: UserInput
     ): RecipeInitResult<GetRedirectionURLContext, PreAndPostAPIHookAction, OnHandleEventContext, NormalisedConfig>;
     static getInstanceOrThrow(): EmailVerification;
     isEmailVerified(userContext: any): Promise<{

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.32.3";
+export declare const package_version = "0.32.4";

--- a/lib/ts/recipe/emailverification/index.ts
+++ b/lib/ts/recipe/emailverification/index.ts
@@ -30,7 +30,7 @@ import type { RecipeFunctionOptions } from "supertokens-web-js/recipe/emailverif
 export default class Wrapper {
     static EmailVerificationClaim = EmailVerificationRecipe.EmailVerificationClaim;
 
-    static init(config: UserInput) {
+    static init(config?: UserInput) {
         return EmailVerificationRecipe.init(config);
     }
 

--- a/lib/ts/recipe/emailverification/recipe.tsx
+++ b/lib/ts/recipe/emailverification/recipe.tsx
@@ -76,7 +76,7 @@ export default class EmailVerification extends RecipeModule<
     }
 
     static init(
-        config: UserInput
+        config?: UserInput
     ): RecipeInitResult<GetRedirectionURLContext, PreAndPostAPIHookAction, OnHandleEventContext, NormalisedConfig> {
         const normalisedConfig = normaliseEmailVerificationFeature(config);
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.32.3";
+export const package_version = "0.32.4";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.32.3",
+    "version": "0.32.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.32.3",
+            "version": "0.32.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.32.3",
+    "version": "0.32.4",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {


### PR DESCRIPTION
## Summary of change

- Makes config optional during email verification init
- Fixes examples/with-no-session-on-sign-up-thirdpartyemailpassword/api-server/index.js to add attachToRequestResponse in the mocked session object to fix tests

## Related issues


## Test Plan


## Documentation changes

WIP

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`

## Remaining TODOs for this PR

-   [ ] ...
