### PR TITLE
fix: do not render send verify without session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Update to web-js interface version
 -   Updated supertokens-web-js dependency, which made SessionClaimValidator a type instead of an abstract class
 -   Added `textGray` to the palette variables (used in the default access denied screen)
+-   Now the email verification feature component will never render `SendVerifyEmail` without a session
 
 ## [0.32.4] - 2023-05-31
 

--- a/examples/for-tests-react-16/package.json
+++ b/examples/for-tests-react-16/package.json
@@ -6,7 +6,7 @@
         "axios": "^0.21.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "react-router-dom": "^6.2.1",
+        "react-router-dom": "6.11.2",
         "react-router-domv5": "npm:react-router-dom@^5.2.0",
         "react-scripts": "^5.0.1"
     },

--- a/examples/for-tests/package.json
+++ b/examples/for-tests/package.json
@@ -6,7 +6,7 @@
         "axios": "^0.21.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "react-router-dom": "^6.2.1",
+        "react-router-dom": "6.11.2",
         "react-scripts": "^5.0.1"
     },
     "scripts": {

--- a/lib/build/emailverificationprebuiltui.js
+++ b/lib/build/emailverificationprebuiltui.js
@@ -687,19 +687,18 @@ var VerifyEmailLinkClicked = translations.withOverride(
     EmailVerificationVerifyEmailLinkClicked
 );
 
-/*
- * Component.
- */
 function EmailVerificationTheme(props) {
-    /*
-     * Render.
-     */
-    // If no token, return SendVerifyEmail.
-    if (props.verifyEmailLinkClickedScreen === undefined) {
+    var sessionContext = session.useSessionContext$1();
+    // If we have a token, return VerifyEmailLinkClicked.
+    if (props.verifyEmailLinkClickedScreen !== undefined) {
+        return jsxRuntime.jsx(VerifyEmailLinkClicked, utils.__assign({}, props.verifyEmailLinkClickedScreen));
+    }
+    // If we have an active session, we want to send the verification email
+    if (sessionContext.loading === false && sessionContext.doesSessionExist === true) {
         return jsxRuntime.jsx(SendVerifyEmail, utils.__assign({}, props.sendVerifyEmailScreen));
     }
-    // Otherwise, return VerifyEmailLinkClicked.
-    return jsxRuntime.jsx(VerifyEmailLinkClicked, utils.__assign({}, props.verifyEmailLinkClickedScreen));
+    // Otherwise, return an empty screen, waiting for the feature component to redirection to complete.
+    return jsxRuntime.jsx(jsxRuntime.Fragment, {});
 }
 function EmailVerificationThemeWrapper(props) {
     var hasFont = translations.hasFontDefined(props.config.rootStyle);

--- a/lib/ts/recipe/emailverification/components/themes/emailVerification/index.tsx
+++ b/lib/ts/recipe/emailverification/components/themes/emailVerification/index.tsx
@@ -19,28 +19,28 @@
 import { hasFontDefined } from "../../../../../styles/styles";
 import UserContextWrapper from "../../../../../usercontext/userContextWrapper";
 import { ThemeBase } from "../../../../emailpassword/components/themes/themeBase";
+import { useSessionContext } from "../../../../session";
 
 import { SendVerifyEmail } from "./sendVerifyEmail";
 import { VerifyEmailLinkClicked } from "./verifyEmailLinkClicked";
 
 import type { EmailVerificationThemeProps } from "../../../types";
 
-/*
- * Component.
- */
-
 export function EmailVerificationTheme(props: EmailVerificationThemeProps): JSX.Element {
-    /*
-     * Render.
-     */
+    const sessionContext = useSessionContext();
 
-    // If no token, return SendVerifyEmail.
-    if (props.verifyEmailLinkClickedScreen === undefined) {
+    // If we have a token, return VerifyEmailLinkClicked.
+    if (props.verifyEmailLinkClickedScreen !== undefined) {
+        return <VerifyEmailLinkClicked {...props.verifyEmailLinkClickedScreen} />;
+    }
+
+    // If we have an active session, we want to send the verification email
+    if (sessionContext.loading === false && sessionContext.doesSessionExist === true) {
         return <SendVerifyEmail {...props.sendVerifyEmailScreen} />;
     }
 
-    // Otherwise, return VerifyEmailLinkClicked.
-    return <VerifyEmailLinkClicked {...props.verifyEmailLinkClickedScreen} />;
+    // Otherwise, return an empty screen, waiting for the feature component to redirection to complete.
+    return <></>;
 }
 
 function EmailVerificationThemeWrapper(props: EmailVerificationThemeProps): JSX.Element {

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
                 "puppeteer": "^11.0.0",
                 "react": "^18.0.0",
                 "react-dom": "^18.0.0",
-                "react-router-dom": "^6.2.1",
+                "react-router-dom": "6.11.2",
                 "regenerator-runtime": "0.13.7",
                 "rollup": "^3.1.0",
                 "rollup-plugin-import-css": "^3.1.0",
@@ -3459,9 +3459,9 @@
             }
         },
         "node_modules/@remix-run/router": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.1.tgz",
-            "integrity": "sha512-+eun1Wtf72RNRSqgU7qM2AMX/oHp+dnx7BHk1qhK5ZHzdHTUU4LA1mGG1vT+jMc8sbhG3orvsfOmryjzx2PzQw==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
+            "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==",
             "dev": true,
             "engines": {
                 "node": ">=14"
@@ -14806,12 +14806,12 @@
             "dev": true
         },
         "node_modules/react-router": {
-            "version": "6.8.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.0.tgz",
-            "integrity": "sha512-760bk7y3QwabduExtudhWbd88IBbuD1YfwzpuDUAlJUJ7laIIcqhMvdhSVh1Fur1PE8cGl84L0dxhR3/gvHF7A==",
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
+            "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
             "dev": true,
             "dependencies": {
-                "@remix-run/router": "1.3.1"
+                "@remix-run/router": "1.6.2"
             },
             "engines": {
                 "node": ">=14"
@@ -14821,13 +14821,13 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "6.8.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.0.tgz",
-            "integrity": "sha512-hQouduSTywGJndE86CXJ2h7YEy4HYC6C/uh19etM+79FfQ6cFFFHnHyDlzO4Pq0eBUI96E4qVE5yUjA00yJZGQ==",
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.2.tgz",
+            "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
             "dev": true,
             "dependencies": {
-                "@remix-run/router": "1.3.1",
-                "react-router": "6.8.0"
+                "@remix-run/router": "1.6.2",
+                "react-router": "6.11.2"
             },
             "engines": {
                 "node": ">=14"
@@ -19789,9 +19789,9 @@
             "dev": true
         },
         "@remix-run/router": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.1.tgz",
-            "integrity": "sha512-+eun1Wtf72RNRSqgU7qM2AMX/oHp+dnx7BHk1qhK5ZHzdHTUU4LA1mGG1vT+jMc8sbhG3orvsfOmryjzx2PzQw==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
+            "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==",
             "dev": true
         },
         "@rollup/plugin-commonjs": {
@@ -28134,22 +28134,22 @@
             "dev": true
         },
         "react-router": {
-            "version": "6.8.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.0.tgz",
-            "integrity": "sha512-760bk7y3QwabduExtudhWbd88IBbuD1YfwzpuDUAlJUJ7laIIcqhMvdhSVh1Fur1PE8cGl84L0dxhR3/gvHF7A==",
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
+            "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
             "dev": true,
             "requires": {
-                "@remix-run/router": "1.3.1"
+                "@remix-run/router": "1.6.2"
             }
         },
         "react-router-dom": {
-            "version": "6.8.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.0.tgz",
-            "integrity": "sha512-hQouduSTywGJndE86CXJ2h7YEy4HYC6C/uh19etM+79FfQ6cFFFHnHyDlzO4Pq0eBUI96E4qVE5yUjA00yJZGQ==",
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.2.tgz",
+            "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
             "dev": true,
             "requires": {
-                "@remix-run/router": "1.3.1",
-                "react-router": "6.8.0"
+                "@remix-run/router": "1.6.2",
+                "react-router": "6.11.2"
             }
         },
         "read-cache": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "puppeteer": "^11.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "react-router-dom": "^6.2.1",
+        "react-router-dom": "6.11.2",
         "regenerator-runtime": "0.13.7",
         "rollup": "^3.1.0",
         "rollup-plugin-import-css": "^3.1.0",


### PR DESCRIPTION
## Summary of change

- locks react-router-dom version at 6.11.2 (we need to provide a proper fix for issues with 6.12)
- blocks rendering the send verify screen without a session (partial fix for react-router-dom 6.12 issues)

## Related issues

-   https://app.circleci.com/pipelines/github/supertokens/supertokens-auth-react/3572/workflows/42048692-2744-4206-aa7c-626f49fe7f11

## Test Plan

Fixes only

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [x] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`