### PR TITLE
refactor: Allow SDK to be initialised without window being defined

### DIFF
--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -408,7 +408,7 @@ function validateForm(inputs, configFormFields) {
  */
 function getCurrentNormalisedUrlPath() {
     try {
-        windowHandler.WindowHandlerReference.getReferenceOrThrow();
+        windowHandler.WindowHandlerReference.getReferenceOrThrow().windowHandler.getWindowUnsafe();
     } catch (_) {
         return new NormalisedURLPath__default.default("/");
     }

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -407,6 +407,11 @@ function validateForm(inputs, configFormFields) {
  * getCurrentNormalisedUrlPath
  */
 function getCurrentNormalisedUrlPath() {
+    try {
+        windowHandler.WindowHandlerReference.getReferenceOrThrow();
+    } catch (_) {
+        return new NormalisedURLPath__default.default("/");
+    }
     return new NormalisedURLPath__default.default(
         windowHandler.WindowHandlerReference.getReferenceOrThrow().windowHandler.location.getPathName()
     );

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -180,7 +180,7 @@ export async function validateForm(
  */
 export function getCurrentNormalisedUrlPath(): NormalisedURLPath {
     try {
-        WindowHandlerReference.getReferenceOrThrow();
+        WindowHandlerReference.getReferenceOrThrow().windowHandler.getWindowUnsafe();
     } catch (_) {
         return new NormalisedURLPath("/");
     }

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -179,6 +179,12 @@ export async function validateForm(
  * getCurrentNormalisedUrlPath
  */
 export function getCurrentNormalisedUrlPath(): NormalisedURLPath {
+    try {
+        WindowHandlerReference.getReferenceOrThrow();
+    } catch (_) {
+        return new NormalisedURLPath("/");
+    }
+
     return new NormalisedURLPath(WindowHandlerReference.getReferenceOrThrow().windowHandler.location.getPathName());
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15968,7 +15968,7 @@
         },
         "node_modules/supertokens-web-js": {
             "version": "0.6.0",
-            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#2c3aae9a71ca8d356f07d4b085a17717b8ba552e",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#50724a64ccd5bd137044635f90bab2b40a2aea02",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
@@ -29008,7 +29008,7 @@
             "integrity": "sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg=="
         },
         "supertokens-web-js": {
-            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#2c3aae9a71ca8d356f07d4b085a17717b8ba552e",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#50724a64ccd5bd137044635f90bab2b40a2aea02",
             "from": "supertokens-web-js@github:supertokens/supertokens-web-js#refactor/init-without-window",
             "peer": true,
             "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
             "peerDependencies": {
                 "react": ">=16.8.0",
                 "react-dom": ">=16.8.0",
-                "supertokens-web-js": "^0.6.0"
+                "supertokens-web-js": "github:supertokens/supertokens-web-js#refactor/init-without-window"
             }
         },
         "eslint": {
@@ -15968,18 +15968,18 @@
         },
         "node_modules/supertokens-web-js": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/supertokens-web-js/-/supertokens-web-js-0.6.0.tgz",
-            "integrity": "sha512-2KOgWNGanh+/zpdaFQgiA9dQa6T9wA6LcoB6m1BTZ7JIqR3mYmpLD5uu8ERtISNAGUjcXziON/Fp5ZnlBByCcw==",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#220a3cc84fdc49b30792f181dbb17921a9a14054",
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "supertokens-js-override": "0.0.4",
-                "supertokens-website": "^17.0.0"
+                "supertokens-website": "github:supertokens/supertokens-website#refactor/init-without-window"
             }
         },
         "node_modules/supertokens-website": {
             "version": "17.0.0",
-            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-17.0.0.tgz",
-            "integrity": "sha512-9f1LeiAkfEvA98SF5/c8pKBlvtWBT2Nx6wwylGQqrWYVD2HrCJ1cSsrwznXs160a8zynpF74oBRKKvg9V07WFw==",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-website.git#d9ad97aef212c4d85d0cc67e6fa5991f8146651d",
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "browser-tabs-lock": "^1.3.0",
@@ -29008,19 +29008,17 @@
             "integrity": "sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg=="
         },
         "supertokens-web-js": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/supertokens-web-js/-/supertokens-web-js-0.6.0.tgz",
-            "integrity": "sha512-2KOgWNGanh+/zpdaFQgiA9dQa6T9wA6LcoB6m1BTZ7JIqR3mYmpLD5uu8ERtISNAGUjcXziON/Fp5ZnlBByCcw==",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#220a3cc84fdc49b30792f181dbb17921a9a14054",
+            "from": "supertokens-web-js@github:supertokens/supertokens-web-js#refactor/init-without-window",
             "peer": true,
             "requires": {
                 "supertokens-js-override": "0.0.4",
-                "supertokens-website": "^17.0.0"
+                "supertokens-website": "github:supertokens/supertokens-website#refactor/init-without-window"
             }
         },
         "supertokens-website": {
-            "version": "17.0.0",
-            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-17.0.0.tgz",
-            "integrity": "sha512-9f1LeiAkfEvA98SF5/c8pKBlvtWBT2Nx6wwylGQqrWYVD2HrCJ1cSsrwznXs160a8zynpF74oBRKKvg9V07WFw==",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-website.git#d9ad97aef212c4d85d0cc67e6fa5991f8146651d",
+            "from": "supertokens-website@github:supertokens/supertokens-website#refactor/init-without-window",
             "peer": true,
             "requires": {
                 "browser-tabs-lock": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15968,7 +15968,7 @@
         },
         "node_modules/supertokens-web-js": {
             "version": "0.6.0",
-            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#220a3cc84fdc49b30792f181dbb17921a9a14054",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#204e261459d7055652cd2ecdbf7705c601951b92",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
@@ -29008,7 +29008,7 @@
             "integrity": "sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg=="
         },
         "supertokens-web-js": {
-            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#220a3cc84fdc49b30792f181dbb17921a9a14054",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#204e261459d7055652cd2ecdbf7705c601951b92",
             "from": "supertokens-web-js@github:supertokens/supertokens-web-js#refactor/init-without-window",
             "peer": true,
             "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15968,7 +15968,7 @@
         },
         "node_modules/supertokens-web-js": {
             "version": "0.6.0",
-            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#204e261459d7055652cd2ecdbf7705c601951b92",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#b83680413880085b5a498c019aaf7caccb1c59b0",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
@@ -29008,7 +29008,7 @@
             "integrity": "sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg=="
         },
         "supertokens-web-js": {
-            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#204e261459d7055652cd2ecdbf7705c601951b92",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#b83680413880085b5a498c019aaf7caccb1c59b0",
             "from": "supertokens-web-js@github:supertokens/supertokens-web-js#refactor/init-without-window",
             "peer": true,
             "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15968,7 +15968,7 @@
         },
         "node_modules/supertokens-web-js": {
             "version": "0.6.0",
-            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#b83680413880085b5a498c019aaf7caccb1c59b0",
+            "resolved": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#2c3aae9a71ca8d356f07d4b085a17717b8ba552e",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
@@ -29008,7 +29008,7 @@
             "integrity": "sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg=="
         },
         "supertokens-web-js": {
-            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#b83680413880085b5a498c019aaf7caccb1c59b0",
+            "version": "git+ssh://git@github.com/supertokens/supertokens-web-js.git#2c3aae9a71ca8d356f07d4b085a17717b8ba552e",
             "from": "supertokens-web-js@github:supertokens/supertokens-web-js#refactor/init-without-window",
             "peer": true,
             "requires": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "supertokens-web-js": "^0.6.0"
+        "supertokens-web-js": "github:supertokens/supertokens-web-js#refactor/init-without-window"
     },
     "scripts": {
         "init": "bash ./init.sh",


### PR DESCRIPTION
## Summary of change

- Refactors the init logic to not throw if window is not defined

## Related issues

- ...

## Test Plan



## Documentation changes

WIP

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`

## Remaining TODOs for this PR

-   [ ] Update CHANGELOG and package version
- [ ] Update install path for web-js once its released
