### PR TITLE
fix: Fix node plugins config for electron example app

### DIFF
--- a/examples/with-thirdpartypasswordless-electron/package.json
+++ b/examples/with-thirdpartypasswordless-electron/package.json
@@ -61,9 +61,9 @@
                 }
             ],
             "plugins": [
-                [
-                    "@electron-forge/plugin-webpack",
-                    {
+                {
+                    "name": "@electron-forge/plugin-webpack",
+                    "config": {
                         "mainConfig": "./webpack.main.config.js",
                         "devContentSecurityPolicy": "style-src-elem *",
                         "renderer": {
@@ -78,7 +78,7 @@
                         },
                         "port": 3000
                     }
-                ]
+                }
             ]
         }
     },


### PR DESCRIPTION
## Summary of change

- Fixes the plugins structure in the package json for the electron example app

## Related issues

- ...

## Test Plan

NA

## Documentation changes

NA

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`

## Remaining TODOs for this PR

-   [ ] ...
