### PR TITLE
test: add tests checking if clientType is applied in tp, tpep and tppwless recipes

### DIFF
--- a/examples/for-tests-react-16/src/App.js
+++ b/examples/for-tests-react-16/src/App.js
@@ -272,6 +272,7 @@ if (emailVerificationMode !== "OFF") {
 }
 SuperTokens.init({
     usesDynamicLoginMethods: testContext.usesDynamicLoginMethods,
+    clientType: testContext.clientType,
     appInfo: {
         appName: "SuperTokens",
         websiteDomain: getWebsiteDomain(),

--- a/examples/for-tests-react-16/src/testContext.js
+++ b/examples/for-tests-react-16/src/testContext.js
@@ -13,6 +13,7 @@ export function getTestContext() {
         mockLoginMethodsForDynamicLogin: localStorage.getItem("mockLoginMethodsForDynamicLogin"),
         staticProviderList: localStorage.getItem("staticProviderList"),
         mockTenantId: localStorage.getItem("mockTenantId"),
+        clientType: localStorage.getItem("clientType"),
     };
     return ret;
 }

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -279,6 +279,7 @@ if (emailVerificationMode !== "OFF") {
 
 SuperTokens.init({
     usesDynamicLoginMethods: testContext.usesDynamicLoginMethods,
+    clientType: testContext.clientType,
     appInfo: {
         appName: "SuperTokens",
         websiteDomain: getWebsiteDomain(),

--- a/examples/for-tests/src/testContext.js
+++ b/examples/for-tests/src/testContext.js
@@ -13,6 +13,7 @@ export function getTestContext() {
         mockLoginMethodsForDynamicLogin: localStorage.getItem("mockLoginMethodsForDynamicLogin"),
         staticProviderList: localStorage.getItem("staticProviderList"),
         mockTenantId: localStorage.getItem("mockTenantId"),
+        clientType: localStorage.getItem("clientType"),
     };
     return ret;
 }


### PR DESCRIPTION
## Summary of change

add tests checking if clientType is applied in tp, tpep and tppwless recipes

## Related issues

-   https://github.com/supertokens/supertokens-web-js/pull/96

## Test Plan

Tests only change

## Documentation changes

Tests only change

## Checklist for important updates

-   [ ] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [x] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
