### PR TITLE
feat: add custom logo property on custom providers

### DIFF
--- a/lib/build/recipe/thirdparty/providers/custom.d.ts
+++ b/lib/build/recipe/thirdparty/providers/custom.d.ts
@@ -1,7 +1,9 @@
+/// <reference types="react" />
 import type { CustomProviderConfig } from "./types";
 import Provider from ".";
 export default class Custom extends Provider {
+    private logo;
     constructor(config: CustomProviderConfig);
-    getLogo: () => undefined;
+    getLogo: () => JSX.Element | undefined;
     static init(config: CustomProviderConfig): Provider;
 }

--- a/lib/build/recipe/thirdparty/providers/types.d.ts
+++ b/lib/build/recipe/thirdparty/providers/types.d.ts
@@ -21,6 +21,10 @@ export declare type BuiltInProviderConfig = {
 export declare type CustomProviderConfig = {
     id: string;
     name: string;
+    /**
+     * Provider Logo.
+     */
+    logo?: JSX.Element;
     buttonComponent?:
         | FC<{
               name: string;

--- a/lib/build/thirdparty-shared.js
+++ b/lib/build/thirdparty-shared.js
@@ -1114,8 +1114,9 @@ var Custom = /** @class */ (function (_super) {
     function Custom(config) {
         var _this = _super.call(this, config) || this;
         _this.getLogo = function () {
-            return undefined;
+            return _this.logo;
         };
+        _this.logo = config.logo;
         return _this;
     }
     /*

--- a/lib/ts/recipe/thirdparty/providers/custom.tsx
+++ b/lib/ts/recipe/thirdparty/providers/custom.tsx
@@ -23,15 +23,17 @@ import Provider from ".";
  * Class.
  */
 export default class Custom extends Provider {
+    private logo: JSX.Element | undefined;
     /*
      * Constructor.
      */
     constructor(config: CustomProviderConfig) {
         super(config);
+        this.logo = config.logo;
     }
 
-    getLogo = (): undefined => {
-        return undefined;
+    getLogo = (): JSX.Element | undefined => {
+        return this.logo;
     };
 
     /*

--- a/lib/ts/recipe/thirdparty/providers/types.ts
+++ b/lib/ts/recipe/thirdparty/providers/types.ts
@@ -56,6 +56,11 @@ export type CustomProviderConfig = {
      */
     name: string;
 
+    /**
+     * Provider Logo.
+     */
+    logo?: JSX.Element;
+
     /*
      * Button Component
      */


### PR DESCRIPTION
## Summary of change

Adds logo property on Thirdparty Custom providers.

## Related issues

-   #709 

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
