### PR TITLE
fix: only add shadow root if there is none attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## [unreleased]
+## [0.35.5] - 2023-10-05
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixes
+
+-   Fixed shadow dom issue in nextjs dev mode by checking if a shadow root is already attached to the div before creating one.
+
 ### Example changes
 
 -   Updated dev/start script in netlify example

--- a/lib/build/index2.js
+++ b/lib/build/index2.js
@@ -156,7 +156,11 @@ function WithShadowDom(_a) {
             if (rootDiv.current) {
                 // defaults from react-shadow
                 setShadowRoot(function (os) {
-                    return os || rootDiv.current.attachShadow({ mode: "open", delegatesFocus: false });
+                    return (
+                        os ||
+                        rootDiv.current.shadowRoot ||
+                        rootDiv.current.attachShadow({ mode: "open", delegatesFocus: false })
+                    );
                 });
             }
         },

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.35.4";
+export declare const package_version = "0.35.5";

--- a/lib/ts/components/featureWrapper.tsx
+++ b/lib/ts/components/featureWrapper.tsx
@@ -94,7 +94,12 @@ function WithShadowDom({ children }: PropsWithChildren<unknown>) {
     useEffect(() => {
         if (rootDiv.current) {
             // defaults from react-shadow
-            setShadowRoot((os) => os || rootDiv.current!.attachShadow({ mode: "open", delegatesFocus: false }));
+            setShadowRoot(
+                (os) =>
+                    os ||
+                    rootDiv.current!.shadowRoot ||
+                    rootDiv.current!.attachShadow({ mode: "open", delegatesFocus: false })
+            );
         }
     }, [rootDiv]);
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.35.4";
+export const package_version = "0.35.5";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.35.4",
+    "version": "0.35.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.35.4",
+            "version": "0.35.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.35.4",
+    "version": "0.35.5",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {


### PR DESCRIPTION
## Summary of change

Only attach a shadow root if it hasn't been one already attached. This fixes an issue in NextJS dev mode that required disabling shadowDom

## Related issues

- 

## Test Plan

Manual testing in NextJS example dev mode

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [x] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
