### PR TITLE
feat: add getDefaultValue to signin & signup form fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,9 @@ EmailPassword.init({
                             onChange={(e) => onChange(e.target.value)}
                             placeholder="Select Option"
                         >
-                            <option value="" disabled hidden> Select an option </option>
-                            <option value="option 1"> Option 1</option>
-                            <option value="option 2"> Option 2</option>
+                            <option value="" disabled hidden>Select an option</option>
+                            <option value="option 1">Option 1</option>
+                            <option value="option 2">Option 2</option>
                             <option value="option 3">Option 3</option>
                         </select>
                     )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.35.7] - 2023-10-30
+
+### Added
+
+-   Introduced the capability to utilize custom components in the Email-Password signup form fields by exposing inputComponent types.
+-   Implemented the functionality to assign default values to the form fields in the Email-Password Sign Up process.
+-   Enhanced the onChange function to operate independently without requiring an id field.
+-   Accompanied the new features with comprehensive tests to ensure their proper functionality and reliability.
+
+Following is an example of how to use above features.
+
+```tsx
+EmailPassword.init({
+      signInAndUpFeature: {
+        signUpForm: {
+          formFields: [
+              {
+        id: "ratings",
+        label: "Ratings",
+        getDefaultValue: () => "best",
+        inputComponent: ({ value, name, onChange }) => (
+            <select value={value} name={name} onChange={(e) => onChange(e.target.value)} placeholder="Add Ratings">
+                <option value="" disabled hidden>
+                    Select an option
+                </option>
+                <option value="good">Good</option>
+                <option value="better">Better</option>
+                <option value="best">Best</option>
+            </select>
+        )}
+...
+```
+
 ## [0.35.6] - 2023-10-16
 
 ### Test changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,36 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## [0.35.7] - 2023-10-30
+## [0.36.0] - 2023-10-30
 
 ### Added
 
--   Introduced the capability to utilize custom components in the Email-Password signup form fields by exposing inputComponent types.
--   Implemented the functionality to assign default values to the form fields in the Email-Password Sign Up process.
+-   Introduced the capability to utilize custom components in the Email-Password based recipes' signup form fields by exposing inputComponent types.
+-   Implemented the functionality to assign default values to the form fields in the Email-Password based recipes.
 -   Enhanced the onChange function to operate independently without requiring an id field.
--   Accompanied the new features with comprehensive tests to ensure their proper functionality and reliability.
 
 Following is an example of how to use above features.
 
 ```tsx
 EmailPassword.init({
-      signInAndUpFeature: {
+    signInAndUpFeature: {
         signUpForm: {
-          formFields: [
-              {
-        id: "ratings",
-        label: "Ratings",
-        getDefaultValue: () => "best",
-        inputComponent: ({ value, name, onChange }) => (
-            <select value={value} name={name} onChange={(e) => onChange(e.target.value)} placeholder="Add Ratings">
-                <option value="" disabled hidden>
-                    Select an option
-                </option>
-                <option value="good">Good</option>
-                <option value="better">Better</option>
-                <option value="best">Best</option>
-            </select>
-        )}
+            formFields: [
+                {
+                    id: "select-dropdown",
+                    label: "Select Option",
+                    getDefaultValue: () => "option 2",
+                    inputComponent: ({ value, name, onChange }) => (
+                        <select
+                            value={value}
+                            name={name}
+                            onChange={(e) => onChange(e.target.value)}
+                            placeholder="Select Option"
+                        >
+                            <option value="" disabled hidden> Select an option </option>
+                            <option value="option 1"> Option 1</option>
+                            <option value="option 2"> Option 2</option>
+                            <option value="option 3">Option 3</option>
+                        </select>
+                    )
+                }
+            ]
+        }
+    }
+});
 ...
 ```
 

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -669,7 +669,7 @@ function getEmailVerificationConfigs({ disableDefaultUI }) {
 function getFormFields() {
     if (localStorage.getItem("SHOW_INCORRECT_FIELDS") === "YES") {
         return incorrectFormFields;
-    } else if (localStorage.getItem("SHOW_DEFAULT_FIELDS") === "YES") {
+    } else if (localStorage.getItem("SHOW_CUSTOM_FIELDS_WITH_DEFAULT_VALUES") === "YES") {
         return formFieldsWithDefault;
     } else if (localStorage.getItem("SHOW_CUSTOM_FIELDS") === "YES") {
         return customFields;

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -165,7 +165,6 @@ const formFields = [
         label: "Your Country",
         placeholder: "Where do you live?",
         optional: true,
-        getDefaultValue: "India",
     },
 ];
 
@@ -201,12 +200,12 @@ const incorrectFormFields = [
         label: "Your Country",
         placeholder: "Where do you live?",
         optional: true,
-        getDefaultValue: () => 23,
+        getDefaultValue: () => 23, // return should be a string
     },
     {
         id: "ratings",
         label: "Ratings",
-        getDefaultValue: "best",
+        getDefaultValue: "best", // should be function
         inputComponent: ({ value, name, onChange }) => (
             <select value={value} name={name} onChange={(e) => onChange(e.target.value)} placeholder="Add Ratings">
                 <option value="" disabled hidden>

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -172,12 +172,8 @@ const customFields = [
     {
         id: "ratings",
         label: "Ratings",
-        inputComponent: ({ value, name, ...rest }) => (
-            <select
-                name={name}
-                data-supertokens="inputComponent"
-                placeholder="Add Ratings"
-                onChange={(e) => rest.onChange({ id: name, value: e.target.value })}>
+        inputComponent: ({ name, onChange }) => (
+            <select name={name} onChange={(e) => onChange(e.target.value)} placeholder="Add Ratings">
                 <option value="" disabled hidden>
                     Select an option
                 </option>
@@ -190,25 +186,21 @@ const customFields = [
     },
     {
         id: "terms",
-        showLabels: false,
+        label: "",
         optional: false,
-        inputComponent: ({ value, name, ...rest }) => (
+        inputComponent: ({ name, onChange }) => (
             <div
-                data-supertokens="inputComponent"
                 style={{
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "left",
                 }}>
-                <input
-                    name={name}
-                    type="checkbox"
-                    onChange={(e) => rest.onChange({ id: name, value: e.target.checked })}></input>
+                <input name={name} type="checkbox" onChange={(e) => onChange(e.target.checked.toString())}></input>
                 <span style={{ marginLeft: 5 }}>I agree to the terms and conditions</span>
             </div>
         ),
         validate: async (value) => {
-            if (value === true) {
+            if (value === "true") {
                 return undefined;
             }
             return "Please check Terms and conditions";

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -181,9 +181,9 @@ const customFields = [
                 <option value="" disabled hidden>
                     Select an option
                 </option>
-                <option value={1}>1</option>
-                <option value={2}>2</option>
-                <option value={3}>3</option>
+                <option value="good">Good</option>
+                <option value="better">Better</option>
+                <option value="best">Best</option>
             </select>
         ),
         optional: true,

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -208,7 +208,9 @@ const customFields = [
             </div>
         ),
         validate: async (value) => {
-            if (value) return undefined;
+            if (value === true) {
+                return undefined;
+            }
             return "Please check Terms and conditions";
         },
     },

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -177,20 +177,58 @@ const formFieldsWithDefault = [
         getDefaultValue: () => "India",
     },
     {
-        id: "ratings",
-        label: "Ratings",
-        getDefaultValue: () => "best",
+        id: "select-dropdown",
+        label: "Select Option",
+        getDefaultValue: () => "option 2",
         inputComponent: ({ value, name, onChange }) => (
-            <select value={value} name={name} onChange={(e) => onChange(e.target.value)} placeholder="Add Ratings">
+            <select value={value} name={name} onChange={(e) => onChange(e.target.value)}>
                 <option value="" disabled hidden>
                     Select an option
                 </option>
-                <option value="good">Good</option>
-                <option value="better">Better</option>
-                <option value="best">Best</option>
+                <option value="option 1">Option 1</option>
+                <option value="option 2">Option 2</option>
+                <option value="option 3">Option 3</option>
             </select>
         ),
         optional: true,
+    },
+    {
+        id: "terms",
+        label: "",
+        optional: false,
+        getDefaultValue: () => "true",
+        inputComponent: ({ name, onChange, value }) => (
+            <div
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "left",
+                }}>
+                <input
+                    value={value}
+                    checked={value === "true"}
+                    name={name}
+                    type="checkbox"
+                    onChange={(e) => onChange(e.target.checked.toString())}></input>
+                <span style={{ marginLeft: 5 }}>I agree to the terms and conditions</span>
+            </div>
+        ),
+        validate: async (value) => {
+            if (value === "true") {
+                return undefined;
+            }
+            return "Please check Terms and conditions";
+        },
+    },
+    {
+        id: "email",
+        label: "Email",
+        getDefaultValue: () => "test@one.com",
+    },
+    {
+        id: "password",
+        label: "Password",
+        getDefaultValue: () => "fakepassword123",
     },
 ];
 
@@ -203,22 +241,23 @@ const incorrectFormFields = [
         getDefaultValue: () => 23, // return should be a string
     },
     {
-        id: "ratings",
-        label: "Ratings",
-        getDefaultValue: "best", // should be function
+        id: "select-dropdown",
+        label: "Select Dropdown",
+        getDefaultValue: "option 2", // should be function
         inputComponent: ({ value, name, onChange }) => (
-            <select value={value} name={name} onChange={(e) => onChange(e.target.value)} placeholder="Add Ratings">
+            <select value={value} name={name} onChange={(e) => onChange(e.target.value)}>
                 <option value="" disabled hidden>
                     Select an option
                 </option>
-                <option value="good">Good</option>
-                <option value="better">Better</option>
-                <option value="best">Best</option>
+                <option value="option 1">Option 1</option>
+                <option value="option 2">Option 2</option>
+                <option value="option 3">Option 3</option>
             </select>
         ),
         optional: true,
     },
     {
+        // onChange accepts only string value, here we pass boolean
         id: "terms",
         label: "",
         optional: false,
@@ -244,16 +283,16 @@ const incorrectFormFields = [
 
 const customFields = [
     {
-        id: "ratings",
-        label: "Ratings",
+        id: "select-dropdown",
+        label: "Select Dropdown",
         inputComponent: ({ value, name, onChange }) => (
-            <select value={value} name={name} onChange={(e) => onChange(e.target.value)} placeholder="Add Ratings">
+            <select value={value} name={name} onChange={(e) => onChange(e.target.value)}>
                 <option value="" disabled hidden>
                     Select an option
                 </option>
-                <option value="good">Good</option>
-                <option value="better">Better</option>
-                <option value="best">Best</option>
+                <option value="option 1">Option 1</option>
+                <option value="option 2">Option 2</option>
+                <option value="option 3">Option 3</option>
             </select>
         ),
         optional: true,
@@ -668,6 +707,11 @@ function getEmailVerificationConfigs({ disableDefaultUI }) {
 
 function getFormFields() {
     if (localStorage.getItem("SHOW_INCORRECT_FIELDS") === "YES") {
+        if (localStorage.getItem("INCORRECT_ONCHANGE") === "YES") {
+            // since page-error blocks all the other errors
+            // use this filter to test specific error
+            return incorrectFormFields.filter(({ id }) => id === "terms");
+        }
         return incorrectFormFields;
     } else if (localStorage.getItem("SHOW_CUSTOM_FIELDS_WITH_DEFAULT_VALUES") === "YES") {
         return formFieldsWithDefault;

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -168,6 +168,52 @@ const formFields = [
     },
 ];
 
+const customFields = [
+    {
+        id: "ratings",
+        label: "Ratings",
+        inputComponent: ({ value, name, ...rest }) => (
+            <select
+                name={name}
+                data-supertokens="inputComponent"
+                placeholder="Add Ratings"
+                onChange={(e) => rest.onChange({ id: name, value: e.target.value })}>
+                <option value="" disabled hidden>
+                    Select an option
+                </option>
+                <option value={1}>1</option>
+                <option value={2}>2</option>
+                <option value={3}>3</option>
+            </select>
+        ),
+        optional: true,
+    },
+    {
+        id: "terms",
+        showLabels: false,
+        optional: false,
+        inputComponent: ({ value, name, ...rest }) => (
+            <div
+                data-supertokens="inputComponent"
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "left",
+                }}>
+                <input
+                    name={name}
+                    type="checkbox"
+                    onChange={(e) => rest.onChange({ id: name, value: e.target.checked })}></input>
+                <span style={{ marginLeft: 5 }}>I agree to the terms and conditions</span>
+            </div>
+        ),
+        validate: async (value) => {
+            if (value) return undefined;
+            return "Please check Terms and conditions";
+        },
+    },
+];
+
 const testContext = getTestContext();
 
 let recipeList = [
@@ -637,7 +683,8 @@ function getEmailPasswordConfigs({ disableDefaultUI }) {
                 style: theme,
                 privacyPolicyLink: "https://supertokens.com/legal/privacy-policy",
                 termsOfServiceLink: "https://supertokens.com/legal/terms-and-conditions",
-                formFields,
+                formFields:
+                    localStorage.getItem("SHOW_CUSTOM_FIELDS") === "YES" ? formFields.concat(customFields) : formFields,
             },
         },
     });

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -165,6 +165,81 @@ const formFields = [
         label: "Your Country",
         placeholder: "Where do you live?",
         optional: true,
+        getDefaultValue: "India",
+    },
+];
+
+const formFieldsWithDefault = [
+    {
+        id: "country",
+        label: "Your Country",
+        placeholder: "Where do you live?",
+        optional: true,
+        getDefaultValue: () => "India",
+    },
+    {
+        id: "ratings",
+        label: "Ratings",
+        getDefaultValue: () => "best",
+        inputComponent: ({ value, name, onChange }) => (
+            <select value={value} name={name} onChange={(e) => onChange(e.target.value)} placeholder="Add Ratings">
+                <option value="" disabled hidden>
+                    Select an option
+                </option>
+                <option value="good">Good</option>
+                <option value="better">Better</option>
+                <option value="best">Best</option>
+            </select>
+        ),
+        optional: true,
+    },
+];
+
+const incorrectFormFields = [
+    {
+        id: "country",
+        label: "Your Country",
+        placeholder: "Where do you live?",
+        optional: true,
+        getDefaultValue: () => 23,
+    },
+    {
+        id: "ratings",
+        label: "Ratings",
+        getDefaultValue: "best",
+        inputComponent: ({ value, name, onChange }) => (
+            <select value={value} name={name} onChange={(e) => onChange(e.target.value)} placeholder="Add Ratings">
+                <option value="" disabled hidden>
+                    Select an option
+                </option>
+                <option value="good">Good</option>
+                <option value="better">Better</option>
+                <option value="best">Best</option>
+            </select>
+        ),
+        optional: true,
+    },
+    {
+        id: "terms",
+        label: "",
+        optional: false,
+        inputComponent: ({ name, onChange }) => (
+            <div
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "left",
+                }}>
+                <input name={name} type="checkbox" onChange={(e) => onChange(e.target.checked)}></input>
+                <span style={{ marginLeft: 5 }}>I agree to the terms and conditions</span>
+            </div>
+        ),
+        validate: async (value) => {
+            if (value === "true") {
+                return undefined;
+            }
+            return "Please check Terms and conditions";
+        },
     },
 ];
 
@@ -172,8 +247,8 @@ const customFields = [
     {
         id: "ratings",
         label: "Ratings",
-        inputComponent: ({ name, onChange }) => (
-            <select name={name} onChange={(e) => onChange(e.target.value)} placeholder="Add Ratings">
+        inputComponent: ({ value, name, onChange }) => (
+            <select value={value} name={name} onChange={(e) => onChange(e.target.value)} placeholder="Add Ratings">
                 <option value="" disabled hidden>
                     Select an option
                 </option>
@@ -678,7 +753,13 @@ function getEmailPasswordConfigs({ disableDefaultUI }) {
                 privacyPolicyLink: "https://supertokens.com/legal/privacy-policy",
                 termsOfServiceLink: "https://supertokens.com/legal/terms-and-conditions",
                 formFields:
-                    localStorage.getItem("SHOW_CUSTOM_FIELDS") === "YES" ? formFields.concat(customFields) : formFields,
+                    localStorage.getItem("SHOW_INCORRECT_FIELDS") === "YES"
+                        ? incorrectFormFields
+                        : localStorage.getItem("SHOW_DEFAULT_FIELDS") === "YES"
+                        ? formFieldsWithDefault
+                        : localStorage.getItem("SHOW_CUSTOM_FIELDS") === "YES"
+                        ? customFields
+                        : formFields,
             },
         },
     });

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -721,6 +721,25 @@ function getFormFields() {
     return formFields;
 }
 
+function getSignInFormFields() {
+    let showDefaultFields = localStorage.getItem("SHOW_SIGNIN_DEFAULT_FIELDS");
+    if (showDefaultFields === "YES") {
+        return {
+            formFields: [
+                {
+                    id: "email",
+                    getDefaultValue: () => "abc@xyz.com",
+                },
+                {
+                    id: "password",
+                    getDefaultValue: () => "fakepassword123",
+                },
+            ],
+        };
+    }
+    return {};
+}
+
 function getEmailPasswordConfigs({ disableDefaultUI }) {
     return EmailPassword.init({
         style: `          
@@ -801,6 +820,7 @@ function getEmailPasswordConfigs({ disableDefaultUI }) {
             defaultToSignUp,
             signInForm: {
                 style: theme,
+                ...getSignInFormFields(),
             },
             signUpForm: {
                 style: theme,

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -666,6 +666,17 @@ function getEmailVerificationConfigs({ disableDefaultUI }) {
     });
 }
 
+function getFormFields() {
+    if (localStorage.getItem("SHOW_INCORRECT_FIELDS") === "YES") {
+        return incorrectFormFields;
+    } else if (localStorage.getItem("SHOW_DEFAULT_FIELDS") === "YES") {
+        return formFieldsWithDefault;
+    } else if (localStorage.getItem("SHOW_CUSTOM_FIELDS") === "YES") {
+        return customFields;
+    }
+    return formFields;
+}
+
 function getEmailPasswordConfigs({ disableDefaultUI }) {
     return EmailPassword.init({
         style: `          
@@ -751,14 +762,7 @@ function getEmailPasswordConfigs({ disableDefaultUI }) {
                 style: theme,
                 privacyPolicyLink: "https://supertokens.com/legal/privacy-policy",
                 termsOfServiceLink: "https://supertokens.com/legal/terms-and-conditions",
-                formFields:
-                    localStorage.getItem("SHOW_INCORRECT_FIELDS") === "YES"
-                        ? incorrectFormFields
-                        : localStorage.getItem("SHOW_DEFAULT_FIELDS") === "YES"
-                        ? formFieldsWithDefault
-                        : localStorage.getItem("SHOW_CUSTOM_FIELDS") === "YES"
-                        ? customFields
-                        : formFields,
+                formFields: getFormFields(),
             },
         },
     });

--- a/lib/build/emailpassword-shared6.js
+++ b/lib/build/emailpassword-shared6.js
@@ -809,6 +809,7 @@ var SignInForm = uiEntry.withOverride("EmailPasswordSignInForm", function EmailP
 var SignInHeader = uiEntry.withOverride("EmailPasswordSignInHeader", function EmailPasswordSignInHeader(_a) {
     var onClick = _a.onClick;
     var t = translationContext.useTranslation();
+    var testing = "TESTING";
     return jsxRuntime.jsxs(React.Fragment, {
         children: [
             jsxRuntime.jsx(
@@ -829,7 +830,7 @@ var SignInHeader = uiEntry.withOverride("EmailPasswordSignInHeader", function Em
                                 { "data-supertokens": "secondaryText" },
                                 {
                                     children: [
-                                        t("EMAIL_PASSWORD_SIGN_IN_HEADER_SUBTITLE_START"),
+                                        testing,
                                         jsxRuntime.jsx(
                                             "span",
                                             genericComponentOverrideContext.__assign(

--- a/lib/build/emailpassword-shared6.js
+++ b/lib/build/emailpassword-shared6.js
@@ -809,7 +809,6 @@ var SignInForm = uiEntry.withOverride("EmailPasswordSignInForm", function EmailP
 var SignInHeader = uiEntry.withOverride("EmailPasswordSignInHeader", function EmailPasswordSignInHeader(_a) {
     var onClick = _a.onClick;
     var t = translationContext.useTranslation();
-    var testing = "TESTING";
     return jsxRuntime.jsxs(React.Fragment, {
         children: [
             jsxRuntime.jsx(
@@ -830,7 +829,7 @@ var SignInHeader = uiEntry.withOverride("EmailPasswordSignInHeader", function Em
                                 { "data-supertokens": "secondaryText" },
                                 {
                                     children: [
-                                        testing,
+                                        t("EMAIL_PASSWORD_SIGN_IN_HEADER_SUBTITLE_START"),
                                         jsxRuntime.jsx(
                                             "span",
                                             genericComponentOverrideContext.__assign(

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -436,24 +436,24 @@ function Label(_a) {
     );
 }
 
-var fetchDefaultValue = function (field) {
-    if (field && field.getDefaultValue) {
-        try {
-            if (typeof field.getDefaultValue !== "function") {
-                throw new Error("getDefaultValue for ".concat(field.id, " must be a function"));
-            }
-            var defaultValue = field.getDefaultValue();
-            if (typeof defaultValue !== "string") {
-                throw new Error("getDefaultValue for ".concat(field.id, " must return a string"));
-            } else {
-                return defaultValue;
-            }
-        } catch (error) {
-            console.error(error);
-        }
-    }
-    return "";
-};
+// const fetchDefaultValue = (field: FormFieldThemeProps): string => {
+//     if (field && field.getDefaultValue) {
+//         try {
+//             if (typeof field.getDefaultValue !== "function") {
+//                 throw new Error(`getDefaultValue for ${field.id} must be a function`);
+//             }
+//             const defaultValue = field.getDefaultValue();
+//             if (typeof defaultValue !== "string") {
+//                 throw new Error(`getDefaultValue for ${field.id} must return a string`);
+//             } else {
+//                 return defaultValue;
+//             }
+//         } catch (error) {
+//             console.error(error);
+//         }
+//     }
+//     return "";
+// };
 var FormBase = function (props) {
     var footer = props.footer,
         buttonLabel = props.buttonLabel,
@@ -481,15 +481,13 @@ var FormBase = function (props) {
     var _b = React.useState(false),
         isLoading = _b[0],
         setIsLoading = _b[1];
-    React.useEffect(function () {
-        var initialValues = props.formFields.map(function (f) {
-            return {
-                id: f.id,
-                value: fetchDefaultValue(f),
-            };
-        });
-        setFieldStates(initialValues);
-    }, []);
+    // useEffect(() => {
+    //     const initialValues = props.formFields.map((f) => ({
+    //         id: f.id,
+    //         value: fetchDefaultValue(f),
+    //     }));
+    //     setFieldStates(initialValues);
+    // }, []);
     var updateFieldState = React.useCallback(
         function (id, update) {
             setFieldStates(function (os) {

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -453,9 +453,15 @@ var FormBase = function (props) {
         },
         [unmounting]
     );
+    var fetchDefaultValue = function (field) {
+        if (field && field.getDefaultValue) {
+            return field.getDefaultValue();
+        }
+        return "";
+    };
     var _a = React.useState(
             props.formFields.map(function (f) {
-                return { id: f.id, value: "" };
+                return { id: f.id, value: fetchDefaultValue(f) };
             })
         ),
         fieldStates = _a[0],

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -556,14 +556,14 @@ var FormBase = function (props) {
     );
     var onInputChange = React.useCallback(
         function (field) {
-            try {
-                if (typeof field.value !== "string") {
-                    throw new Error("".concat(field.id, " value must be a string"));
-                }
-            } catch (error) {
-                console.error(error);
-                return props.onError("SOMETHING_WENT_WRONG_ERROR");
-            }
+            // try {
+            //     if (typeof field.value !== "string") {
+            //         throw new Error(`${field.id} value must be a string`);
+            //     }
+            // } catch (error) {
+            //     console.error(error);
+            //     return props.onError("SOMETHING_WENT_WRONG_ERROR");
+            // }
             updateFieldState(field.id, function (os) {
                 return genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, os), {
                     value: field.value,

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -320,18 +320,12 @@ var Input = function (_a) {
      */
     function handleFocus() {
         if (onInputFocus !== undefined) {
-            onInputFocus({
-                id: name,
-                value: value,
-            });
+            onInputFocus(value);
         }
     }
     function handleBlur() {
         if (onInputBlur !== undefined) {
-            onInputBlur({
-                id: name,
-                value: value,
-            });
+            onInputBlur(value);
         }
     }
     function handleChange(event) {
@@ -437,23 +431,78 @@ function Label(_a) {
 }
 
 var fetchDefaultValue = function (field) {
-    if (field && field.getDefaultValue) {
-        try {
-            if (typeof field.getDefaultValue !== "function") {
-                throw new Error("getDefaultValue for ".concat(field.id, " must be a function"));
-            }
-            var defaultValue = field.getDefaultValue();
-            if (typeof defaultValue !== "string") {
-                throw new Error("getDefaultValue for ".concat(field.id, " must return a string"));
-            } else {
-                return defaultValue;
-            }
-        } catch (error) {
-            console.error(error);
+    if (field.getDefaultValue !== undefined) {
+        var defaultValue = field.getDefaultValue();
+        if (typeof defaultValue !== "string") {
+            throw new Error("getDefaultValue for ".concat(field.id, " must return a string"));
+        } else {
+            return defaultValue;
         }
     }
     return "";
 };
+function InputComponentWrapper(props) {
+    var field = props.field,
+        type = props.type,
+        fstate = props.fstate,
+        onInputFocus = props.onInputFocus,
+        onInputBlur = props.onInputBlur,
+        onInputChange = props.onInputChange;
+    var useCallbackOnInputFocus = React.useCallback(
+        function (value) {
+            onInputFocus({
+                id: field.id,
+                value: value,
+            });
+        },
+        [onInputFocus, field]
+    );
+    var useCallbackOnInputBlur = React.useCallback(
+        function (value) {
+            onInputBlur({
+                id: field.id,
+                value: value,
+            });
+        },
+        [onInputBlur, field]
+    );
+    var useCallbackOnInputChange = React.useCallback(
+        function (value) {
+            onInputChange({
+                id: field.id,
+                value: value,
+            });
+        },
+        [onInputChange, field]
+    );
+    return field.inputComponent !== undefined
+        ? jsxRuntime.jsx(field.inputComponent, {
+              type: type,
+              name: field.id,
+              validated: fstate.validated === true,
+              placeholder: field.placeholder,
+              value: fstate.value,
+              autoComplete: field.autoComplete,
+              autofocus: field.autofocus,
+              onInputFocus: useCallbackOnInputFocus,
+              onInputBlur: useCallbackOnInputBlur,
+              onChange: useCallbackOnInputChange,
+              hasError: fstate.error !== undefined,
+          })
+        : jsxRuntime.jsx(Input, {
+              type: type,
+              name: field.id,
+              validated: fstate.validated === true,
+              placeholder: field.placeholder,
+              value: fstate.value,
+              autoComplete: field.autoComplete,
+              onInputFocus: useCallbackOnInputFocus,
+              onInputBlur: useCallbackOnInputBlur,
+              onChange: useCallbackOnInputChange,
+              autofocus: field.autofocus,
+              hasError: fstate.error !== undefined,
+          });
+}
 var FormBase = function (props) {
     var footer = props.footer,
         buttonLabel = props.buttonLabel,
@@ -551,13 +600,8 @@ var FormBase = function (props) {
     );
     var onInputChange = React.useCallback(
         function (field) {
-            try {
-                if (typeof field.value !== "string") {
-                    throw new Error("".concat(field.id, " value must be a string"));
-                }
-            } catch (error) {
-                console.error(error);
-                return props.onError("SOMETHING_WENT_WRONG_ERROR");
+            if (typeof field.value !== "string") {
+                throw new Error("".concat(field.id, " value must be a string"));
             }
             updateFieldState(field.id, function (os) {
                 return genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, os), {
@@ -713,12 +757,10 @@ var FormBase = function (props) {
                         }
                         var fstate = fieldStates.find(function (s) {
                             return s.id === field.id;
-                        }) || {
-                            id: field.id,
-                            validated: false,
-                            error: undefined,
-                            value: "",
-                        };
+                        });
+                        if (fstate === undefined) {
+                            throw new Error("Should never come here");
+                        }
                         return jsxRuntime.jsx(
                             FormRow,
                             genericComponentOverrideContext.__assign(
@@ -733,37 +775,14 @@ var FormBase = function (props) {
                                                           value: field.label,
                                                           showIsRequired: field.showIsRequired,
                                                       })),
-                                            field.inputComponent !== undefined
-                                                ? jsxRuntime.jsx(field.inputComponent, {
-                                                      type: type,
-                                                      name: field.id,
-                                                      validated: fstate.validated === true,
-                                                      placeholder: field.placeholder,
-                                                      value: fstate.value,
-                                                      autoComplete: field.autoComplete,
-                                                      autofocus: field.autofocus,
-                                                      onInputFocus: onInputFocus,
-                                                      onInputBlur: onInputBlur,
-                                                      onChange: function (value) {
-                                                          return onInputChange({ id: field.id, value: value });
-                                                      },
-                                                      hasError: fstate.error !== undefined,
-                                                  })
-                                                : jsxRuntime.jsx(Input, {
-                                                      type: type,
-                                                      name: field.id,
-                                                      validated: fstate.validated === true,
-                                                      placeholder: field.placeholder,
-                                                      value: fstate.value,
-                                                      autoComplete: field.autoComplete,
-                                                      onInputFocus: onInputFocus,
-                                                      onInputBlur: onInputBlur,
-                                                      onChange: function (value) {
-                                                          return onInputChange({ id: field.id, value: value });
-                                                      },
-                                                      autofocus: field.autofocus,
-                                                      hasError: fstate.error !== undefined,
-                                                  }),
+                                            jsxRuntime.jsx(InputComponentWrapper, {
+                                                type: type,
+                                                field: field,
+                                                fstate: fstate,
+                                                onInputFocus: onInputFocus,
+                                                onInputBlur: onInputBlur,
+                                                onInputChange: onInputChange,
+                                            }),
                                             fstate.error && jsxRuntime.jsx(InputError, { error: fstate.error }),
                                         ],
                                     }),

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -471,7 +471,11 @@ var FormBase = function (props) {
         },
         [unmounting]
     );
-    var _a = React.useState([]),
+    var _a = React.useState(
+            props.formFields.map(function (f) {
+                return { id: f.id, value: "" };
+            })
+        ),
         fieldStates = _a[0],
         setFieldStates = _a[1];
     var _b = React.useState(false),

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -336,10 +336,7 @@ var Input = function (_a) {
     }
     function handleChange(event) {
         if (onChange) {
-            onChange({
-                id: name,
-                value: event.target.value,
-            });
+            onChange(event.target.value);
         }
     }
     if (autoComplete === undefined) {
@@ -559,14 +556,14 @@ var FormBase = function (props) {
     );
     var onInputChange = React.useCallback(
         function (field) {
-            // try {
-            //     if (typeof field.value !== "string") {
-            //         throw new Error(`${field.id} value must be a string`);
-            //     }
-            // } catch (error) {
-            //     console.error(error);
-            //     return props.onError("SOMETHING_WENT_WRONG_ERROR");
-            // }
+            try {
+                if (typeof field.value !== "string") {
+                    throw new Error("".concat(field.id, " value must be a string"));
+                }
+            } catch (error) {
+                console.error(error);
+                return props.onError("SOMETHING_WENT_WRONG_ERROR");
+            }
             updateFieldState(field.id, function (os) {
                 return genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, os), {
                     value: field.value,
@@ -752,7 +749,9 @@ var FormBase = function (props) {
                                                       autofocus: field.autofocus,
                                                       onInputFocus: onInputFocus,
                                                       onInputBlur: onInputBlur,
-                                                      onChange: onInputChange,
+                                                      onChange: function (value) {
+                                                          return onInputChange({ id: field.id, value: value });
+                                                      },
                                                       hasError: fstate.error !== undefined,
                                                   })
                                                 : jsxRuntime.jsx(Input, {
@@ -764,7 +763,9 @@ var FormBase = function (props) {
                                                       autoComplete: field.autoComplete,
                                                       onInputFocus: onInputFocus,
                                                       onInputBlur: onInputBlur,
-                                                      onChange: onInputChange,
+                                                      onChange: function (value) {
+                                                          return onInputChange({ id: field.id, value: value });
+                                                      },
                                                       autofocus: field.autofocus,
                                                       hasError: fstate.error !== undefined,
                                                   }),

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -336,10 +336,7 @@ var Input = function (_a) {
     }
     function handleChange(event) {
         if (onChange) {
-            onChange({
-                id: name,
-                value: event.target.value,
-            });
+            onChange(event.target.value);
         }
     }
     if (autoComplete === undefined) {
@@ -549,7 +546,18 @@ var FormBase = function (props) {
     var onFormSubmit = React.useCallback(
         function (e) {
             return genericComponentOverrideContext.__awaiter(void 0, void 0, void 0, function () {
-                var apiFields, fieldUpdates, result, generalError, e_1, _loop_1, _i, formFields_1, field, errorFields_1;
+                var apiFields,
+                    fieldsWithIncorrectValues,
+                    errorFields,
+                    fieldUpdates,
+                    result,
+                    generalError,
+                    e_1,
+                    _loop_1,
+                    _i,
+                    formFields_1,
+                    field,
+                    errorFields_1;
                 return genericComponentOverrideContext.__generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
@@ -574,6 +582,25 @@ var FormBase = function (props) {
                                     value: fieldState === undefined ? "" : fieldState.value,
                                 };
                             });
+                            // field.value must be a string
+                            try {
+                                fieldsWithIncorrectValues = apiFields.filter(function (field) {
+                                    return typeof field.value !== "string";
+                                });
+                                if (fieldsWithIncorrectValues.length > 0) {
+                                    errorFields = fieldsWithIncorrectValues
+                                        .map(function (_a) {
+                                            var id = _a.id;
+                                            return id;
+                                        })
+                                        .join(", ");
+                                    throw new Error("".concat(errorFields, " value must be a string"));
+                                }
+                            } catch (error) {
+                                console.error(error);
+                                setIsLoading(false);
+                                return [2 /*return*/, props.onError("SOMETHING_WENT_WRONG_ERROR")];
+                            }
                             fieldUpdates = [];
                             _a.label = 1;
                         case 1:
@@ -721,7 +748,9 @@ var FormBase = function (props) {
                                                       autofocus: field.autofocus,
                                                       onInputFocus: onInputFocus,
                                                       onInputBlur: onInputBlur,
-                                                      onChange: onInputChange,
+                                                      onChange: function (value) {
+                                                          return onInputChange({ id: field.id, value: value });
+                                                      },
                                                       hasError: fstate.error !== undefined,
                                                   })
                                                 : jsxRuntime.jsx(Input, {
@@ -733,7 +762,9 @@ var FormBase = function (props) {
                                                       autoComplete: field.autoComplete,
                                                       onInputFocus: onInputFocus,
                                                       onInputBlur: onInputBlur,
-                                                      onChange: onInputChange,
+                                                      onChange: function (value) {
+                                                          return onInputChange({ id: field.id, value: value });
+                                                      },
                                                       autofocus: field.autofocus,
                                                       hasError: fstate.error !== undefined,
                                                   }),

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -336,7 +336,10 @@ var Input = function (_a) {
     }
     function handleChange(event) {
         if (onChange) {
-            onChange(event.target.value);
+            onChange({
+                id: name,
+                value: event.target.value,
+            });
         }
     }
     if (autoComplete === undefined) {
@@ -749,9 +752,7 @@ var FormBase = function (props) {
                                                       autofocus: field.autofocus,
                                                       onInputFocus: onInputFocus,
                                                       onInputBlur: onInputBlur,
-                                                      onChange: function (value) {
-                                                          return onInputChange({ id: field.id, value: value });
-                                                      },
+                                                      onChange: onInputChange,
                                                       hasError: fstate.error !== undefined,
                                                   })
                                                 : jsxRuntime.jsx(Input, {
@@ -763,9 +764,7 @@ var FormBase = function (props) {
                                                       autoComplete: field.autoComplete,
                                                       onInputFocus: onInputFocus,
                                                       onInputBlur: onInputBlur,
-                                                      onChange: function (value) {
-                                                          return onInputChange({ id: field.id, value: value });
-                                                      },
+                                                      onChange: onInputChange,
                                                       autofocus: field.autofocus,
                                                       hasError: fstate.error !== undefined,
                                                   }),

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -556,6 +556,14 @@ var FormBase = function (props) {
     );
     var onInputChange = React.useCallback(
         function (field) {
+            try {
+                if (typeof field.value !== "string") {
+                    throw new Error("".concat(field.id, " value must be a string"));
+                }
+            } catch (error) {
+                console.error(error);
+                return props.onError("SOMETHING_WENT_WRONG_ERROR");
+            }
             updateFieldState(field.id, function (os) {
                 return genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, os), {
                     value: field.value,
@@ -569,18 +577,7 @@ var FormBase = function (props) {
     var onFormSubmit = React.useCallback(
         function (e) {
             return genericComponentOverrideContext.__awaiter(void 0, void 0, void 0, function () {
-                var apiFields,
-                    fieldsWithIncorrectValues,
-                    errorFields,
-                    fieldUpdates,
-                    result,
-                    generalError,
-                    e_1,
-                    _loop_1,
-                    _i,
-                    formFields_1,
-                    field,
-                    errorFields_1;
+                var apiFields, fieldUpdates, result, generalError, e_1, _loop_1, _i, formFields_1, field, errorFields_1;
                 return genericComponentOverrideContext.__generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
@@ -605,25 +602,6 @@ var FormBase = function (props) {
                                     value: fieldState === undefined ? "" : fieldState.value,
                                 };
                             });
-                            // field.value must be a string
-                            try {
-                                fieldsWithIncorrectValues = apiFields.filter(function (field) {
-                                    return typeof field.value !== "string";
-                                });
-                                if (fieldsWithIncorrectValues.length > 0) {
-                                    errorFields = fieldsWithIncorrectValues
-                                        .map(function (_a) {
-                                            var id = _a.id;
-                                            return id;
-                                        })
-                                        .join(", ");
-                                    throw new Error("".concat(errorFields, " value must be a string"));
-                                }
-                            } catch (error) {
-                                console.error(error);
-                                setIsLoading(false);
-                                return [2 /*return*/, props.onError("SOMETHING_WENT_WRONG_ERROR")];
-                            }
                             fieldUpdates = [];
                             _a.label = 1;
                         case 1:

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -436,6 +436,24 @@ function Label(_a) {
     );
 }
 
+var fetchDefaultValue = function (field) {
+    if (field && field.getDefaultValue) {
+        try {
+            if (typeof field.getDefaultValue !== "function") {
+                throw new Error("getDefaultValue for ".concat(field.id, " must be a function"));
+            }
+            var defaultValue = field.getDefaultValue();
+            if (typeof defaultValue !== "string") {
+                throw new Error("getDefaultValue for ".concat(field.id, " must return a string"));
+            } else {
+                return defaultValue;
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    return "";
+};
 var FormBase = function (props) {
     var footer = props.footer,
         buttonLabel = props.buttonLabel,
@@ -453,22 +471,21 @@ var FormBase = function (props) {
         },
         [unmounting]
     );
-    var fetchDefaultValue = function (field) {
-        if (field && field.getDefaultValue) {
-            return field.getDefaultValue();
-        }
-        return "";
-    };
-    var _a = React.useState(
-            props.formFields.map(function (f) {
-                return { id: f.id, value: fetchDefaultValue(f) };
-            })
-        ),
+    var _a = React.useState([]),
         fieldStates = _a[0],
         setFieldStates = _a[1];
     var _b = React.useState(false),
         isLoading = _b[0],
         setIsLoading = _b[1];
+    React.useEffect(function () {
+        var initialValues = props.formFields.map(function (f) {
+            return {
+                id: f.id,
+                value: fetchDefaultValue(f),
+            };
+        });
+        setFieldStates(initialValues);
+    }, []);
     var updateFieldState = React.useCallback(
         function (id, update) {
             setFieldStates(function (os) {

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -436,24 +436,24 @@ function Label(_a) {
     );
 }
 
-// const fetchDefaultValue = (field: FormFieldThemeProps): string => {
-//     if (field && field.getDefaultValue) {
-//         try {
-//             if (typeof field.getDefaultValue !== "function") {
-//                 throw new Error(`getDefaultValue for ${field.id} must be a function`);
-//             }
-//             const defaultValue = field.getDefaultValue();
-//             if (typeof defaultValue !== "string") {
-//                 throw new Error(`getDefaultValue for ${field.id} must return a string`);
-//             } else {
-//                 return defaultValue;
-//             }
-//         } catch (error) {
-//             console.error(error);
-//         }
-//     }
-//     return "";
-// };
+var fetchDefaultValue = function (field) {
+    if (field && field.getDefaultValue) {
+        try {
+            if (typeof field.getDefaultValue !== "function") {
+                throw new Error("getDefaultValue for ".concat(field.id, " must be a function"));
+            }
+            var defaultValue = field.getDefaultValue();
+            if (typeof defaultValue !== "string") {
+                throw new Error("getDefaultValue for ".concat(field.id, " must return a string"));
+            } else {
+                return defaultValue;
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    return "";
+};
 var FormBase = function (props) {
     var footer = props.footer,
         buttonLabel = props.buttonLabel,
@@ -473,7 +473,7 @@ var FormBase = function (props) {
     );
     var _a = React.useState(
             props.formFields.map(function (f) {
-                return { id: f.id, value: "" };
+                return { id: f.id, value: fetchDefaultValue(f) };
             })
         ),
         fieldStates = _a[0],
@@ -481,13 +481,6 @@ var FormBase = function (props) {
     var _b = React.useState(false),
         isLoading = _b[0],
         setIsLoading = _b[1];
-    // useEffect(() => {
-    //     const initialValues = props.formFields.map((f) => ({
-    //         id: f.id,
-    //         value: fetchDefaultValue(f),
-    //     }));
-    //     setFieldStates(initialValues);
-    // }, []);
     var updateFieldState = React.useCallback(
         function (id, update) {
             setFieldStates(function (os) {

--- a/lib/build/passwordless-shared3.js
+++ b/lib/build/passwordless-shared3.js
@@ -2596,10 +2596,7 @@ function PhoneNumberInput(_a) {
     var handleChange = React.useCallback(
         function (newValue) {
             if (onChangeRef.current !== undefined) {
-                onChangeRef.current({
-                    id: name,
-                    value: newValue,
-                });
+                onChangeRef.current(newValue);
             }
         },
         [onChangeRef]
@@ -2607,10 +2604,7 @@ function PhoneNumberInput(_a) {
     var handleCountryChange = React.useCallback(
         function (ev) {
             if (onChangeRef.current !== undefined && phoneInputInstance !== undefined) {
-                onChangeRef.current({
-                    id: name,
-                    value: ev.target.value,
-                });
+                onChangeRef.current(ev.target.value);
             }
         },
         [onChangeRef]

--- a/lib/build/passwordless-shared3.js
+++ b/lib/build/passwordless-shared3.js
@@ -2569,18 +2569,12 @@ function PhoneNumberInput(_a) {
         value = _a.value;
     function handleFocus() {
         if (onInputFocus !== undefined) {
-            onInputFocus({
-                id: name,
-                value: value,
-            });
+            onInputFocus(value);
         }
     }
     function handleBlur() {
         if (onInputBlur !== undefined) {
-            onInputBlur({
-                id: name,
-                value: value,
-            });
+            onInputBlur(value);
         }
     }
     var _b = React.useState(),

--- a/lib/build/recipe/emailpassword/components/library/input.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/input.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="react" />
-import type { APIFormField } from "../../../../types";
 export declare type InputProps = {
     type: string;
     name: string;
@@ -9,8 +8,8 @@ export declare type InputProps = {
     hasError: boolean;
     placeholder: string;
     value: string;
-    onInputBlur?: (field: APIFormField) => void;
-    onInputFocus?: (field: APIFormField) => void;
+    onInputBlur?: (value: string) => void;
+    onInputFocus?: (value: string) => void;
     onChange?: (value: string) => void;
 };
 declare const Input: React.FC<InputProps>;

--- a/lib/build/recipe/emailpassword/components/library/input.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/input.d.ts
@@ -11,7 +11,7 @@ export declare type InputProps = {
     value: string;
     onInputBlur?: (field: APIFormField) => void;
     onInputFocus?: (field: APIFormField) => void;
-    onChange?: (value: string) => void;
+    onChange?: (field: APIFormField) => void;
 };
 declare const Input: React.FC<InputProps>;
 export default Input;

--- a/lib/build/recipe/emailpassword/components/library/input.d.ts
+++ b/lib/build/recipe/emailpassword/components/library/input.d.ts
@@ -11,7 +11,7 @@ export declare type InputProps = {
     value: string;
     onInputBlur?: (field: APIFormField) => void;
     onInputFocus?: (field: APIFormField) => void;
-    onChange?: (field: APIFormField) => void;
+    onChange?: (value: string) => void;
 };
 declare const Input: React.FC<InputProps>;
 export default Input;

--- a/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/resetPasswordEmail.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/resetPasswordEmail.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 export declare const ResetPasswordEmail: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: import("../../../types").FormFieldThemeProps[];
+        formFields: Omit<import("../../../types").FormFieldThemeProps, "inputComponent">[];
         error: string | undefined;
     } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;

--- a/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/submitNewPassword.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/submitNewPassword.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 export declare const SubmitNewPassword: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: import("../../../types").FormFieldThemeProps[];
+        formFields: Omit<import("../../../types").FormFieldThemeProps, "inputComponent">[];
         error: string | undefined;
     } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signIn.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signIn.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 export declare const SignIn: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: import("../../../types").FormFieldThemeProps[];
+        formFields: Omit<import("../../../types").FormFieldThemeProps, "inputComponent">[];
         error: string | undefined;
     } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signInForm.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signInForm.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 export declare const SignInForm: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: import("../../../types").FormFieldThemeProps[];
+        formFields: Omit<import("../../../types").FormFieldThemeProps, "inputComponent">[];
         error: string | undefined;
     } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUp.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUp.d.ts
@@ -1,14 +1,13 @@
 /// <reference types="react" />
 export declare const SignUp: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: import("../../../types").FormFieldThemeProps[];
-        error: string | undefined;
-    } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;
         clearError: () => void;
         onError: (error: string) => void;
         config: import("../../../types").NormalisedConfig;
         signInClicked?: (() => void) | undefined;
         onSuccess: (result: { user: import("supertokens-web-js/types").User }) => void;
+        formFields: import("../../../types").FormFieldThemeProps[];
+        error: string | undefined;
     }
 >;

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUpForm.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUpForm.d.ts
@@ -1,15 +1,14 @@
 /// <reference types="react" />
 export declare const SignUpForm: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: import("../../../types").FormFieldThemeProps[];
-        error: string | undefined;
-    } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;
         clearError: () => void;
         onError: (error: string) => void;
         config: import("../../../types").NormalisedConfig;
         signInClicked?: (() => void) | undefined;
         onSuccess: (result: { user: import("supertokens-web-js/types").User }) => void;
+        formFields: import("../../../types").FormFieldThemeProps[];
+        error: string | undefined;
     } & {
         header?: JSX.Element | undefined;
         footer?: JSX.Element | undefined;

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -94,7 +94,9 @@ export declare type NormalisedSignInFormFeatureConfig = NormalisedBaseConfig & {
     formFields: NormalisedFormField[];
 };
 export declare type FormFieldSignInConfig = FormFieldBaseConfig;
-export declare type FormFieldSignUpConfig = FormField;
+export declare type FormFieldSignUpConfig = FormField & {
+    inputComponent?: React.FC<InputProps>;
+};
 export declare type ResetPasswordUsingTokenUserInput = {
     disableDefaultUI?: boolean;
     submitNewPasswordForm?: FeatureBaseConfig;
@@ -131,6 +133,9 @@ export declare type SignUpThemeProps = FormThemeBaseProps & {
     config: NormalisedConfig;
     signInClicked?: () => void;
     onSuccess: (result: { user: User }) => void;
+    formFields: (FormFieldThemeProps & {
+        inputComponent?: React.FC<InputProps>;
+    })[];
 };
 export declare type SignInAndUpThemeProps = {
     signInForm: SignInThemeProps;
@@ -144,7 +149,6 @@ export declare type SignInAndUpThemeProps = {
 };
 export declare type FormFieldThemeProps = NormalisedFormField & {
     labelComponent?: JSX.Element;
-    inputComponent?: React.FC<InputProps>;
     showIsRequired?: boolean;
     clearOnSubmit?: boolean;
 };

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -83,7 +83,9 @@ export declare type SignUpFormFeatureUserInput = FeatureBaseConfig & {
     termsOfServiceLink?: string;
 };
 export declare type NormalisedSignUpFormFeatureConfig = NormalisedBaseConfig & {
-    formFields: NormalisedFormField[];
+    formFields: (NormalisedFormField & {
+        inputComponent?: React.FC<InputProps>;
+    })[];
     privacyPolicyLink?: string;
     termsOfServiceLink?: string;
 };
@@ -114,14 +116,10 @@ export declare type NormalisedEnterEmailForm = FeatureBaseConfig & {
     formFields: NormalisedFormField[];
 };
 declare type FormThemeBaseProps = ThemeBaseProps & {
-    formFields: FormFieldThemeProps[];
-    error: string | undefined;
-};
-declare type SignInFormThemeBaseProps = ThemeBaseProps & {
     formFields: Omit<FormFieldThemeProps, "inputComponent">[];
     error: string | undefined;
 };
-export declare type SignInThemeProps = SignInFormThemeBaseProps & {
+export declare type SignInThemeProps = FormThemeBaseProps & {
     recipeImplementation: RecipeInterface;
     clearError: () => void;
     onError: (error: string) => void;
@@ -130,13 +128,15 @@ export declare type SignInThemeProps = SignInFormThemeBaseProps & {
     forgotPasswordClick: () => void;
     onSuccess: (result: { user: User }) => void;
 };
-export declare type SignUpThemeProps = FormThemeBaseProps & {
+export declare type SignUpThemeProps = ThemeBaseProps & {
     recipeImplementation: RecipeInterface;
     clearError: () => void;
     onError: (error: string) => void;
     config: NormalisedConfig;
     signInClicked?: () => void;
     onSuccess: (result: { user: User }) => void;
+    formFields: FormFieldThemeProps[];
+    error: string | undefined;
 };
 export declare type SignInAndUpThemeProps = {
     signInForm: SignInThemeProps;

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -114,11 +114,11 @@ export declare type NormalisedSubmitNewPasswordForm = FeatureBaseConfig & {
 export declare type NormalisedEnterEmailForm = FeatureBaseConfig & {
     formFields: NormalisedFormField[];
 };
-declare type FormThemeBaseProps = ThemeBaseProps & {
+declare type NonSignUpFormThemeBaseProps = ThemeBaseProps & {
     formFields: Omit<FormFieldThemeProps, "inputComponent">[];
     error: string | undefined;
 };
-export declare type SignInThemeProps = FormThemeBaseProps & {
+export declare type SignInThemeProps = NonSignUpFormThemeBaseProps & {
     recipeImplementation: RecipeInterface;
     clearError: () => void;
     onError: (error: string) => void;
@@ -197,7 +197,7 @@ export declare type ResetPasswordUsingTokenThemeProps = {
     config: NormalisedConfig;
     userContext?: any;
 };
-export declare type EnterEmailProps = FormThemeBaseProps & {
+export declare type EnterEmailProps = NonSignUpFormThemeBaseProps & {
     recipeImplementation: RecipeInterface;
     error: string | undefined;
     clearError: () => void;
@@ -205,7 +205,7 @@ export declare type EnterEmailProps = FormThemeBaseProps & {
     config: NormalisedConfig;
     onBackButtonClicked: () => void;
 };
-export declare type SubmitNewPasswordProps = FormThemeBaseProps & {
+export declare type SubmitNewPasswordProps = NonSignUpFormThemeBaseProps & {
     recipeImplementation: RecipeInterface;
     error: string | undefined;
     clearError: () => void;

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -117,7 +117,11 @@ declare type FormThemeBaseProps = ThemeBaseProps & {
     formFields: FormFieldThemeProps[];
     error: string | undefined;
 };
-export declare type SignInThemeProps = FormThemeBaseProps & {
+declare type SignInFormThemeBaseProps = ThemeBaseProps & {
+    formFields: Omit<FormFieldThemeProps, "inputComponent">[];
+    error: string | undefined;
+};
+export declare type SignInThemeProps = SignInFormThemeBaseProps & {
     recipeImplementation: RecipeInterface;
     clearError: () => void;
     onError: (error: string) => void;
@@ -133,9 +137,6 @@ export declare type SignUpThemeProps = FormThemeBaseProps & {
     config: NormalisedConfig;
     signInClicked?: () => void;
     onSuccess: (result: { user: User }) => void;
-    formFields: (FormFieldThemeProps & {
-        inputComponent?: React.FC<InputProps>;
-    })[];
 };
 export declare type SignInAndUpThemeProps = {
     signInForm: SignInThemeProps;
@@ -151,6 +152,7 @@ export declare type FormFieldThemeProps = NormalisedFormField & {
     labelComponent?: JSX.Element;
     showIsRequired?: boolean;
     clearOnSubmit?: boolean;
+    inputComponent?: React.FC<InputProps>;
 };
 export declare type FormFieldError = {
     id: string;

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -78,7 +78,9 @@ export declare type NormalisedSignInAndUpFeatureConfig = {
     signInForm: NormalisedSignInFormFeatureConfig;
 };
 export declare type SignUpFormFeatureUserInput = FeatureBaseConfig & {
-    formFields?: FormFieldSignUpConfig[];
+    formFields?: (FormField & {
+        inputComponent?: React.FC<InputProps>;
+    })[];
     privacyPolicyLink?: string;
     termsOfServiceLink?: string;
 };
@@ -96,9 +98,6 @@ export declare type NormalisedSignInFormFeatureConfig = NormalisedBaseConfig & {
     formFields: NormalisedFormField[];
 };
 export declare type FormFieldSignInConfig = FormFieldBaseConfig;
-export declare type FormFieldSignUpConfig = FormField & {
-    inputComponent?: React.FC<InputProps>;
-};
 export declare type ResetPasswordUsingTokenUserInput = {
     disableDefaultUI?: boolean;
     submitNewPasswordForm?: FeatureBaseConfig;

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -79,6 +79,7 @@ export declare type NormalisedSignInAndUpFeatureConfig = {
 export declare type SignUpFormFeatureUserInput = FeatureBaseConfig & {
     formFields?: (FormField & {
         inputComponent?: (props: InputProps) => JSX.Element;
+        getDefaultValue?: () => string;
     })[];
     privacyPolicyLink?: string;
     termsOfServiceLink?: string;
@@ -86,6 +87,7 @@ export declare type SignUpFormFeatureUserInput = FeatureBaseConfig & {
 export declare type NormalisedSignUpFormFeatureConfig = NormalisedBaseConfig & {
     formFields: (NormalisedFormField & {
         inputComponent?: (props: InputProps) => JSX.Element;
+        getDefaultValue?: () => string;
     })[];
     privacyPolicyLink?: string;
     termsOfServiceLink?: string;
@@ -151,6 +153,7 @@ export declare type FormFieldThemeProps = NormalisedFormField & {
     showIsRequired?: boolean;
     clearOnSubmit?: boolean;
     inputComponent?: (props: InputProps) => JSX.Element;
+    getDefaultValue?: () => string;
 };
 export declare type FormFieldError = {
     id: string;

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -26,7 +26,6 @@ import type {
     NormalisedConfig as NormalisedAuthRecipeModuleConfig,
     UserInput as AuthRecipeModuleUserInput,
 } from "../authRecipe/types";
-import type React from "react";
 import type { Dispatch } from "react";
 import type { OverrideableBuilder } from "supertokens-js-override";
 import type { RecipeInterface } from "supertokens-web-js/recipe/emailpassword";
@@ -79,14 +78,14 @@ export declare type NormalisedSignInAndUpFeatureConfig = {
 };
 export declare type SignUpFormFeatureUserInput = FeatureBaseConfig & {
     formFields?: (FormField & {
-        inputComponent?: React.FC<InputProps>;
+        inputComponent?: (props: InputProps) => JSX.Element;
     })[];
     privacyPolicyLink?: string;
     termsOfServiceLink?: string;
 };
 export declare type NormalisedSignUpFormFeatureConfig = NormalisedBaseConfig & {
     formFields: (NormalisedFormField & {
-        inputComponent?: React.FC<InputProps>;
+        inputComponent?: (props: InputProps) => JSX.Element;
     })[];
     privacyPolicyLink?: string;
     termsOfServiceLink?: string;
@@ -151,7 +150,7 @@ export declare type FormFieldThemeProps = NormalisedFormField & {
     labelComponent?: JSX.Element;
     showIsRequired?: boolean;
     clearOnSubmit?: boolean;
-    inputComponent?: React.FC<InputProps>;
+    inputComponent?: (props: InputProps) => JSX.Element;
 };
 export declare type FormFieldError = {
     id: string;

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -79,7 +79,6 @@ export declare type NormalisedSignInAndUpFeatureConfig = {
 export declare type SignUpFormFeatureUserInput = FeatureBaseConfig & {
     formFields?: (FormField & {
         inputComponent?: (props: InputProps) => JSX.Element;
-        getDefaultValue?: () => string;
     })[];
     privacyPolicyLink?: string;
     termsOfServiceLink?: string;
@@ -87,7 +86,6 @@ export declare type SignUpFormFeatureUserInput = FeatureBaseConfig & {
 export declare type NormalisedSignUpFormFeatureConfig = NormalisedBaseConfig & {
     formFields: (NormalisedFormField & {
         inputComponent?: (props: InputProps) => JSX.Element;
-        getDefaultValue?: () => string;
     })[];
     privacyPolicyLink?: string;
     termsOfServiceLink?: string;
@@ -153,7 +151,6 @@ export declare type FormFieldThemeProps = NormalisedFormField & {
     showIsRequired?: boolean;
     clearOnSubmit?: boolean;
     inputComponent?: (props: InputProps) => JSX.Element;
-    getDefaultValue?: () => string;
 };
 export declare type FormFieldError = {
     id: string;

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -89,6 +89,7 @@ export declare type FormFieldBaseConfig = {
     id: string;
     label: string;
     placeholder?: string;
+    getDefaultValue?: () => string;
 };
 export declare type FormField = FormFieldBaseConfig & {
     validate?: (value: any) => Promise<string | undefined>;
@@ -106,6 +107,7 @@ export declare type NormalisedFormField = {
     optional: boolean;
     autoComplete?: string;
     autofocus?: boolean;
+    getDefaultValue?: () => string;
 };
 export declare type ReactComponentClass<P = any> = ComponentClass<P, any> | ((props: P) => JSX.Element);
 export declare type FeatureBaseConfig = {

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -108,6 +108,7 @@ export declare type NormalisedFormField = {
     optional: boolean;
     autoComplete?: string;
     autofocus?: boolean;
+    inputComponent?: React.FC<InputProps>;
 };
 export declare type ReactComponentClass<P = any> = ComponentClass<P, any> | ((props: P) => JSX.Element);
 export declare type FeatureBaseConfig = {

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -108,7 +108,6 @@ export declare type NormalisedFormField = {
     optional: boolean;
     autoComplete?: string;
     autofocus?: boolean;
-    inputComponent?: React.FC<InputProps>;
 };
 export declare type ReactComponentClass<P = any> = ComponentClass<P, any> | ((props: P) => JSX.Element);
 export declare type FeatureBaseConfig = {

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -1,3 +1,4 @@
+import type { InputProps } from "./recipe/emailpassword/components/library/input";
 import type { BaseRecipeModule } from "./recipe/recipeModule/baseRecipeModule";
 import type { NormalisedConfig as NormalisedRecipeModuleConfig } from "./recipe/recipeModule/types";
 import type { TranslationFunc, TranslationStore } from "./translation/translationHelpers";
@@ -93,6 +94,7 @@ export declare type FormFieldBaseConfig = {
 export declare type FormField = FormFieldBaseConfig & {
     validate?: (value: any) => Promise<string | undefined>;
     optional?: boolean;
+    inputComponent?: React.FC<InputProps>;
 };
 export declare type APIFormField = {
     id: string;
@@ -106,6 +108,7 @@ export declare type NormalisedFormField = {
     optional: boolean;
     autoComplete?: string;
     autofocus?: boolean;
+    inputComponent?: React.FC<InputProps>;
 };
 export declare type ReactComponentClass<P = any> = ComponentClass<P, any> | ((props: P) => JSX.Element);
 export declare type FeatureBaseConfig = {

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -94,7 +94,6 @@ export declare type FormFieldBaseConfig = {
 export declare type FormField = FormFieldBaseConfig & {
     validate?: (value: any) => Promise<string | undefined>;
     optional?: boolean;
-    inputComponent?: React.FC<InputProps>;
 };
 export declare type APIFormField = {
     id: string;

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -1,4 +1,3 @@
-import type { InputProps } from "./recipe/emailpassword/components/library/input";
 import type { BaseRecipeModule } from "./recipe/recipeModule/baseRecipeModule";
 import type { NormalisedConfig as NormalisedRecipeModuleConfig } from "./recipe/recipeModule/types";
 import type { TranslationFunc, TranslationStore } from "./translation/translationHelpers";
@@ -107,7 +106,6 @@ export declare type NormalisedFormField = {
     optional: boolean;
     autoComplete?: string;
     autofocus?: boolean;
-    inputComponent?: React.FC<InputProps>;
 };
 export declare type ReactComponentClass<P = any> = ComponentClass<P, any> | ((props: P) => JSX.Element);
 export declare type FeatureBaseConfig = {

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -25,7 +25,7 @@ import STGeneralError from "supertokens-web-js/utils/error";
 import { MANDATORY_FORM_FIELDS_ID_ARRAY } from "../../constants";
 
 import type { APIFormField } from "../../../../types";
-import type { FormBaseProps, FormFieldThemeProps } from "../../types";
+import type { FormBaseProps } from "../../types";
 import type { FormEvent } from "react";
 
 import { Button, FormRow, Input, InputError, Label } from ".";
@@ -37,24 +37,24 @@ type FieldState = {
     value: string;
 };
 
-const fetchDefaultValue = (field: FormFieldThemeProps): string => {
-    if (field && field.getDefaultValue) {
-        try {
-            if (typeof field.getDefaultValue !== "function") {
-                throw new Error(`getDefaultValue for ${field.id} must be a function`);
-            }
-            const defaultValue = field.getDefaultValue();
-            if (typeof defaultValue !== "string") {
-                throw new Error(`getDefaultValue for ${field.id} must return a string`);
-            } else {
-                return defaultValue;
-            }
-        } catch (error) {
-            console.error(error);
-        }
-    }
-    return "";
-};
+// const fetchDefaultValue = (field: FormFieldThemeProps): string => {
+//     if (field && field.getDefaultValue) {
+//         try {
+//             if (typeof field.getDefaultValue !== "function") {
+//                 throw new Error(`getDefaultValue for ${field.id} must be a function`);
+//             }
+//             const defaultValue = field.getDefaultValue();
+//             if (typeof defaultValue !== "string") {
+//                 throw new Error(`getDefaultValue for ${field.id} must return a string`);
+//             } else {
+//                 return defaultValue;
+//             }
+//         } catch (error) {
+//             console.error(error);
+//         }
+//     }
+//     return "";
+// };
 
 export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
     const { footer, buttonLabel, showLabels, validateOnBlur, formFields } = props;
@@ -73,13 +73,13 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
     );
     const [isLoading, setIsLoading] = useState(false);
 
-    useEffect(() => {
-        const initialValues = props.formFields.map((f) => ({
-            id: f.id,
-            value: fetchDefaultValue(f),
-        }));
-        setFieldStates(initialValues);
-    }, []);
+    // useEffect(() => {
+    //     const initialValues = props.formFields.map((f) => ({
+    //         id: f.id,
+    //         value: fetchDefaultValue(f),
+    //     }));
+    //     setFieldStates(initialValues);
+    // }, []);
 
     const updateFieldState = useCallback(
         (id: string, update: (os: FieldState) => FieldState) => {

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -37,6 +37,25 @@ type FieldState = {
     value: string;
 };
 
+const fetchDefaultValue = (field: FormFieldThemeProps): string => {
+    if (field && field.getDefaultValue) {
+        try {
+            if (typeof field.getDefaultValue !== "function") {
+                throw new Error(`getDefaultValue for ${field.id} must be a function`);
+            }
+            const defaultValue = field.getDefaultValue();
+            if (typeof defaultValue !== "string") {
+                throw new Error(`getDefaultValue for ${field.id} must return a string`);
+            } else {
+                return defaultValue;
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    return "";
+};
+
 export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
     const { footer, buttonLabel, showLabels, validateOnBlur, formFields } = props;
 
@@ -49,17 +68,16 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
         };
     }, [unmounting]);
 
-    const fetchDefaultValue = (field: FormFieldThemeProps) => {
-        if (field && field.getDefaultValue) {
-            return field.getDefaultValue();
-        }
-        return "";
-    };
-
-    const [fieldStates, setFieldStates] = useState<FieldState[]>(
-        props.formFields.map((f) => ({ id: f.id, value: fetchDefaultValue(f) }))
-    );
+    const [fieldStates, setFieldStates] = useState<FieldState[]>([]);
     const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        const initialValues = props.formFields.map((f) => ({
+            id: f.id,
+            value: fetchDefaultValue(f),
+        }));
+        setFieldStates(initialValues);
+    }, []);
 
     const updateFieldState = useCallback(
         (id: string, update: (os: FieldState) => FieldState) => {

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -68,7 +68,9 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
         };
     }, [unmounting]);
 
-    const [fieldStates, setFieldStates] = useState<FieldState[]>([]);
+    const [fieldStates, setFieldStates] = useState<FieldState[]>(
+        props.formFields.map((f) => ({ id: f.id, value: "" }))
+    );
     const [isLoading, setIsLoading] = useState(false);
 
     useEffect(() => {

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -25,7 +25,7 @@ import STGeneralError from "supertokens-web-js/utils/error";
 import { MANDATORY_FORM_FIELDS_ID_ARRAY } from "../../constants";
 
 import type { APIFormField } from "../../../../types";
-import type { FormBaseProps } from "../../types";
+import type { FormBaseProps, FormFieldThemeProps } from "../../types";
 import type { FormEvent } from "react";
 
 import { Button, FormRow, Input, InputError, Label } from ".";
@@ -49,8 +49,15 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
         };
     }, [unmounting]);
 
+    const fetchDefaultValue = (field: FormFieldThemeProps) => {
+        if (field && field.getDefaultValue) {
+            return field.getDefaultValue();
+        }
+        return "";
+    };
+
     const [fieldStates, setFieldStates] = useState<FieldState[]>(
-        props.formFields.map((f) => ({ id: f.id, value: "" }))
+        props.formFields.map((f) => ({ id: f.id, value: fetchDefaultValue(f) }))
     );
     const [isLoading, setIsLoading] = useState(false);
 

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -252,7 +252,7 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
                                     autofocus={field.autofocus}
                                     onInputFocus={onInputFocus}
                                     onInputBlur={onInputBlur}
-                                    onChange={(value) => onInputChange({ id: field.id, value: value })}
+                                    onChange={onInputChange}
                                     hasError={fstate.error !== undefined}
                                 />
                             ) : (
@@ -265,7 +265,7 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
                                     autoComplete={field.autoComplete}
                                     onInputFocus={onInputFocus}
                                     onInputBlur={onInputBlur}
-                                    onChange={(value) => onInputChange({ id: field.id, value: value })}
+                                    onChange={onInputChange}
                                     autofocus={field.autofocus}
                                     hasError={fstate.error !== undefined}
                                 />

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -38,23 +38,87 @@ type FieldState = {
 };
 
 const fetchDefaultValue = (field: FormFieldThemeProps): string => {
-    if (field && field.getDefaultValue) {
-        try {
-            if (typeof field.getDefaultValue !== "function") {
-                throw new Error(`getDefaultValue for ${field.id} must be a function`);
-            }
-            const defaultValue = field.getDefaultValue();
-            if (typeof defaultValue !== "string") {
-                throw new Error(`getDefaultValue for ${field.id} must return a string`);
-            } else {
-                return defaultValue;
-            }
-        } catch (error) {
-            console.error(error);
+    if (field.getDefaultValue !== undefined) {
+        const defaultValue = field.getDefaultValue();
+        if (typeof defaultValue !== "string") {
+            throw new Error(`getDefaultValue for ${field.id} must return a string`);
+        } else {
+            return defaultValue;
         }
     }
     return "";
 };
+
+function InputComponentWrapper(props: {
+    field: FormFieldThemeProps;
+    type: string;
+    fstate: FieldState;
+    onInputFocus: (field: APIFormField) => void;
+    onInputBlur: (field: APIFormField) => void;
+    onInputChange: (field: APIFormField) => void;
+}) {
+    const { field, type, fstate, onInputFocus, onInputBlur, onInputChange } = props;
+
+    const useCallbackOnInputFocus = useCallback<(value: string) => void>(
+        (value) => {
+            onInputFocus({
+                id: field.id,
+                value,
+            });
+        },
+        [onInputFocus, field]
+    );
+
+    const useCallbackOnInputBlur = useCallback<(value: string) => void>(
+        (value) => {
+            onInputBlur({
+                id: field.id,
+                value,
+            });
+        },
+        [onInputBlur, field]
+    );
+
+    const useCallbackOnInputChange = useCallback(
+        (value) => {
+            onInputChange({
+                id: field.id,
+                value,
+            });
+        },
+        [onInputChange, field]
+    );
+
+    return field.inputComponent !== undefined ? (
+        <field.inputComponent
+            type={type}
+            name={field.id}
+            validated={fstate.validated === true}
+            placeholder={field.placeholder}
+            value={fstate.value}
+            autoComplete={field.autoComplete}
+            autofocus={field.autofocus}
+            onInputFocus={useCallbackOnInputFocus}
+            onInputBlur={useCallbackOnInputBlur}
+            onChange={useCallbackOnInputChange}
+            hasError={fstate.error !== undefined}
+        />
+    ) : (
+        <Input
+            type={type}
+            name={field.id}
+            validated={fstate.validated === true}
+            placeholder={field.placeholder}
+            value={fstate.value}
+            autoComplete={field.autoComplete}
+            onInputFocus={useCallbackOnInputFocus}
+            onInputBlur={useCallbackOnInputBlur}
+            onChange={useCallbackOnInputChange}
+            autofocus={field.autofocus}
+            hasError={fstate.error !== undefined}
+        />
+    );
+}
 
 export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
     const { footer, buttonLabel, showLabels, validateOnBlur, formFields } = props;
@@ -114,13 +178,8 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
 
     const onInputChange = useCallback(
         (field: APIFormField) => {
-            try {
-                if (typeof field.value !== "string") {
-                    throw new Error(`${field.id} value must be a string`);
-                }
-            } catch (error) {
-                console.error(error);
-                return props.onError("SOMETHING_WENT_WRONG_ERROR");
+            if (typeof field.value !== "string") {
+                throw new Error(`${field.id} value must be a string`);
             }
             updateFieldState(field.id, (os) => ({ ...os, value: field.value, error: undefined }));
             props.clearError();
@@ -218,12 +277,11 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
                 if (field.id === "confirm-password") {
                     type = "password";
                 }
-                const fstate: FieldState = fieldStates.find((s) => s.id === field.id) || {
-                    id: field.id,
-                    validated: false,
-                    error: undefined,
-                    value: "",
-                };
+
+                const fstate: FieldState | undefined = fieldStates.find((s) => s.id === field.id);
+                if (fstate === undefined) {
+                    throw new Error("Should never come here");
+                }
 
                 return (
                     <FormRow key={field.id} hasError={fstate.error !== undefined}>
@@ -235,36 +293,14 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
                                     <Label value={field.label} showIsRequired={field.showIsRequired} />
                                 ))}
 
-                            {field.inputComponent !== undefined ? (
-                                <field.inputComponent
-                                    type={type}
-                                    name={field.id}
-                                    validated={fstate.validated === true}
-                                    placeholder={field.placeholder}
-                                    value={fstate.value}
-                                    autoComplete={field.autoComplete}
-                                    autofocus={field.autofocus}
-                                    onInputFocus={onInputFocus}
-                                    onInputBlur={onInputBlur}
-                                    onChange={(value) => onInputChange({ id: field.id, value: value })}
-                                    hasError={fstate.error !== undefined}
-                                />
-                            ) : (
-                                <Input
-                                    type={type}
-                                    name={field.id}
-                                    validated={fstate.validated === true}
-                                    placeholder={field.placeholder}
-                                    value={fstate.value}
-                                    autoComplete={field.autoComplete}
-                                    onInputFocus={onInputFocus}
-                                    onInputBlur={onInputBlur}
-                                    onChange={(value) => onInputChange({ id: field.id, value: value })}
-                                    autofocus={field.autofocus}
-                                    hasError={fstate.error !== undefined}
-                                />
-                            )}
-
+                            <InputComponentWrapper
+                                type={type}
+                                field={field}
+                                fstate={fstate}
+                                onInputFocus={onInputFocus}
+                                onInputBlur={onInputBlur}
+                                onInputChange={onInputChange}
+                            />
                             {fstate.error && <InputError error={fstate.error} />}
                         </Fragment>
                     </FormRow>

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -120,14 +120,14 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
 
     const onInputChange = useCallback(
         (field: APIFormField) => {
-            // try {
-            //     if (typeof field.value !== "string") {
-            //         throw new Error(`${field.id} value must be a string`);
-            //     }
-            // } catch (error) {
-            //     console.error(error);
-            //     return props.onError("SOMETHING_WENT_WRONG_ERROR");
-            // }
+            try {
+                if (typeof field.value !== "string") {
+                    throw new Error(`${field.id} value must be a string`);
+                }
+            } catch (error) {
+                console.error(error);
+                return props.onError("SOMETHING_WENT_WRONG_ERROR");
+            }
             updateFieldState(field.id, (os) => ({ ...os, value: field.value, error: undefined }));
             props.clearError();
         },
@@ -252,7 +252,7 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
                                     autofocus={field.autofocus}
                                     onInputFocus={onInputFocus}
                                     onInputBlur={onInputBlur}
-                                    onChange={onInputChange}
+                                    onChange={(value) => onInputChange({ id: field.id, value: value })}
                                     hasError={fstate.error !== undefined}
                                 />
                             ) : (
@@ -265,7 +265,7 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
                                     autoComplete={field.autoComplete}
                                     onInputFocus={onInputFocus}
                                     onInputBlur={onInputBlur}
-                                    onChange={onInputChange}
+                                    onChange={(value) => onInputChange({ id: field.id, value: value })}
                                     autofocus={field.autofocus}
                                     hasError={fstate.error !== undefined}
                                 />

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -25,7 +25,7 @@ import STGeneralError from "supertokens-web-js/utils/error";
 import { MANDATORY_FORM_FIELDS_ID_ARRAY } from "../../constants";
 
 import type { APIFormField } from "../../../../types";
-import type { FormBaseProps } from "../../types";
+import type { FormBaseProps, FormFieldThemeProps } from "../../types";
 import type { FormEvent } from "react";
 
 import { Button, FormRow, Input, InputError, Label } from ".";
@@ -37,24 +37,24 @@ type FieldState = {
     value: string;
 };
 
-// const fetchDefaultValue = (field: FormFieldThemeProps): string => {
-//     if (field && field.getDefaultValue) {
-//         try {
-//             if (typeof field.getDefaultValue !== "function") {
-//                 throw new Error(`getDefaultValue for ${field.id} must be a function`);
-//             }
-//             const defaultValue = field.getDefaultValue();
-//             if (typeof defaultValue !== "string") {
-//                 throw new Error(`getDefaultValue for ${field.id} must return a string`);
-//             } else {
-//                 return defaultValue;
-//             }
-//         } catch (error) {
-//             console.error(error);
-//         }
-//     }
-//     return "";
-// };
+const fetchDefaultValue = (field: FormFieldThemeProps): string => {
+    if (field && field.getDefaultValue) {
+        try {
+            if (typeof field.getDefaultValue !== "function") {
+                throw new Error(`getDefaultValue for ${field.id} must be a function`);
+            }
+            const defaultValue = field.getDefaultValue();
+            if (typeof defaultValue !== "string") {
+                throw new Error(`getDefaultValue for ${field.id} must return a string`);
+            } else {
+                return defaultValue;
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    return "";
+};
 
 export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
     const { footer, buttonLabel, showLabels, validateOnBlur, formFields } = props;
@@ -69,17 +69,9 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
     }, [unmounting]);
 
     const [fieldStates, setFieldStates] = useState<FieldState[]>(
-        props.formFields.map((f) => ({ id: f.id, value: "" }))
+        props.formFields.map((f) => ({ id: f.id, value: fetchDefaultValue(f) }))
     );
     const [isLoading, setIsLoading] = useState(false);
-
-    // useEffect(() => {
-    //     const initialValues = props.formFields.map((f) => ({
-    //         id: f.id,
-    //         value: fetchDefaultValue(f),
-    //     }));
-    //     setFieldStates(initialValues);
-    // }, []);
 
     const updateFieldState = useCallback(
         (id: string, update: (os: FieldState) => FieldState) => {

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -120,6 +120,19 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
                 };
             });
 
+            // field.value must be a string
+            try {
+                const fieldsWithIncorrectValues = apiFields.filter((field) => typeof field.value !== "string");
+                if (fieldsWithIncorrectValues.length > 0) {
+                    const errorFields = fieldsWithIncorrectValues.map(({ id }) => id).join(", ");
+                    throw new Error(`${errorFields} value must be a string`);
+                }
+            } catch (error) {
+                console.error(error);
+                setIsLoading(false);
+                return props.onError("SOMETHING_WENT_WRONG_ERROR");
+            }
+
             const fieldUpdates: FieldState[] = [];
             // Call API.
             try {
@@ -219,7 +232,7 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
                                     autofocus={field.autofocus}
                                     onInputFocus={onInputFocus}
                                     onInputBlur={onInputBlur}
-                                    onChange={onInputChange}
+                                    onChange={(value) => onInputChange({ id: field.id, value: value })}
                                     hasError={fstate.error !== undefined}
                                 />
                             ) : (
@@ -232,7 +245,7 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
                                     autoComplete={field.autoComplete}
                                     onInputFocus={onInputFocus}
                                     onInputBlur={onInputBlur}
-                                    onChange={onInputChange}
+                                    onChange={(value) => onInputChange({ id: field.id, value: value })}
                                     autofocus={field.autofocus}
                                     hasError={fstate.error !== undefined}
                                 />

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -120,6 +120,14 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
 
     const onInputChange = useCallback(
         (field: APIFormField) => {
+            try {
+                if (typeof field.value !== "string") {
+                    throw new Error(`${field.id} value must be a string`);
+                }
+            } catch (error) {
+                console.error(error);
+                return props.onError("SOMETHING_WENT_WRONG_ERROR");
+            }
             updateFieldState(field.id, (os) => ({ ...os, value: field.value, error: undefined }));
             props.clearError();
         },
@@ -144,19 +152,6 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
                     value: fieldState === undefined ? "" : fieldState.value,
                 };
             });
-
-            // field.value must be a string
-            try {
-                const fieldsWithIncorrectValues = apiFields.filter((field) => typeof field.value !== "string");
-                if (fieldsWithIncorrectValues.length > 0) {
-                    const errorFields = fieldsWithIncorrectValues.map(({ id }) => id).join(", ");
-                    throw new Error(`${errorFields} value must be a string`);
-                }
-            } catch (error) {
-                console.error(error);
-                setIsLoading(false);
-                return props.onError("SOMETHING_WENT_WRONG_ERROR");
-            }
 
             const fieldUpdates: FieldState[] = [];
             // Call API.

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -120,14 +120,14 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
 
     const onInputChange = useCallback(
         (field: APIFormField) => {
-            try {
-                if (typeof field.value !== "string") {
-                    throw new Error(`${field.id} value must be a string`);
-                }
-            } catch (error) {
-                console.error(error);
-                return props.onError("SOMETHING_WENT_WRONG_ERROR");
-            }
+            // try {
+            //     if (typeof field.value !== "string") {
+            //         throw new Error(`${field.id} value must be a string`);
+            //     }
+            // } catch (error) {
+            //     console.error(error);
+            //     return props.onError("SOMETHING_WENT_WRONG_ERROR");
+            // }
             updateFieldState(field.id, (os) => ({ ...os, value: field.value, error: undefined }));
             props.clearError();
         },

--- a/lib/ts/recipe/emailpassword/components/library/input.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/input.tsx
@@ -20,7 +20,6 @@ import CheckedIcon from "../../../../components/assets/checkedIcon";
 import ErrorIcon from "../../../../components/assets/errorIcon";
 import ShowPasswordIcon from "../../../../components/assets/showPasswordIcon";
 
-import type { APIFormField } from "../../../../types";
 import type { ChangeEvent } from "react";
 
 export type InputProps = {
@@ -32,8 +31,8 @@ export type InputProps = {
     hasError: boolean;
     placeholder: string;
     value: string;
-    onInputBlur?: (field: APIFormField) => void;
-    onInputFocus?: (field: APIFormField) => void;
+    onInputBlur?: (value: string) => void;
+    onInputFocus?: (value: string) => void;
     onChange?: (value: string) => void;
 };
 
@@ -59,19 +58,13 @@ const Input: React.FC<InputProps> = ({
 
     function handleFocus() {
         if (onInputFocus !== undefined) {
-            onInputFocus({
-                id: name,
-                value: value,
-            });
+            onInputFocus(value);
         }
     }
 
     function handleBlur() {
         if (onInputBlur !== undefined) {
-            onInputBlur({
-                id: name,
-                value,
-            });
+            onInputBlur(value);
         }
     }
 

--- a/lib/ts/recipe/emailpassword/components/library/input.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/input.tsx
@@ -34,7 +34,7 @@ export type InputProps = {
     value: string;
     onInputBlur?: (field: APIFormField) => void;
     onInputFocus?: (field: APIFormField) => void;
-    onChange?: (value: string) => void;
+    onChange?: (field: APIFormField) => void;
 };
 
 const Input: React.FC<InputProps> = ({
@@ -77,7 +77,10 @@ const Input: React.FC<InputProps> = ({
 
     function handleChange(event: ChangeEvent<HTMLInputElement>) {
         if (onChange) {
-            onChange(event.target.value);
+            onChange({
+                id: name,
+                value: event.target.value,
+            });
         }
     }
 

--- a/lib/ts/recipe/emailpassword/components/library/input.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/input.tsx
@@ -34,7 +34,7 @@ export type InputProps = {
     value: string;
     onInputBlur?: (field: APIFormField) => void;
     onInputFocus?: (field: APIFormField) => void;
-    onChange?: (field: APIFormField) => void;
+    onChange?: (value: string) => void;
 };
 
 const Input: React.FC<InputProps> = ({
@@ -77,10 +77,7 @@ const Input: React.FC<InputProps> = ({
 
     function handleChange(event: ChangeEvent<HTMLInputElement>) {
         if (onChange) {
-            onChange({
-                id: name,
-                value: event.target.value,
-            });
+            onChange(event.target.value);
         }
     }
 

--- a/lib/ts/recipe/emailpassword/components/themes/signInAndUp/signInHeader.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/signInAndUp/signInHeader.tsx
@@ -21,15 +21,13 @@ export const SignInHeader = withOverride(
     "EmailPasswordSignInHeader",
     function EmailPasswordSignInHeader({ onClick }: { onClick: (() => void) | undefined }): JSX.Element {
         const t = useTranslation();
-        const testing = "TESTING";
 
         return (
             <Fragment>
                 <div data-supertokens="headerTitle">{t("EMAIL_PASSWORD_SIGN_IN_HEADER_TITLE")}</div>
                 <div data-supertokens="headerSubtitle">
                     <div data-supertokens="secondaryText">
-                        {/* {t("EMAIL_PASSWORD_SIGN_IN_HEADER_SUBTITLE_START")} */}
-                        {testing}
+                        {t("EMAIL_PASSWORD_SIGN_IN_HEADER_SUBTITLE_START")}
                         <span data-supertokens="link" onClick={onClick}>
                             {t("EMAIL_PASSWORD_SIGN_IN_HEADER_SUBTITLE_SIGN_UP_LINK")}
                         </span>

--- a/lib/ts/recipe/emailpassword/components/themes/signInAndUp/signInHeader.tsx
+++ b/lib/ts/recipe/emailpassword/components/themes/signInAndUp/signInHeader.tsx
@@ -21,13 +21,15 @@ export const SignInHeader = withOverride(
     "EmailPasswordSignInHeader",
     function EmailPasswordSignInHeader({ onClick }: { onClick: (() => void) | undefined }): JSX.Element {
         const t = useTranslation();
+        const testing = "TESTING";
 
         return (
             <Fragment>
                 <div data-supertokens="headerTitle">{t("EMAIL_PASSWORD_SIGN_IN_HEADER_TITLE")}</div>
                 <div data-supertokens="headerSubtitle">
                     <div data-supertokens="secondaryText">
-                        {t("EMAIL_PASSWORD_SIGN_IN_HEADER_SUBTITLE_START")}
+                        {/* {t("EMAIL_PASSWORD_SIGN_IN_HEADER_SUBTITLE_START")} */}
+                        {testing}
                         <span data-supertokens="link" onClick={onClick}>
                             {t("EMAIL_PASSWORD_SIGN_IN_HEADER_SUBTITLE_SIGN_UP_LINK")}
                         </span>

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -236,14 +236,23 @@ export type NormalisedEnterEmailForm = FeatureBaseConfig & {
 
 type FormThemeBaseProps = ThemeBaseProps & {
     /*
-     * Form fields to use in the signin form.
+     * Form fields to use in the signup form.
      */
     formFields: FormFieldThemeProps[];
 
     error: string | undefined;
 };
 
-export type SignInThemeProps = FormThemeBaseProps & {
+type SignInFormThemeBaseProps = ThemeBaseProps & {
+    /*
+     * Form fields to use in the signin form. exclude custom component
+     */
+    formFields: Omit<FormFieldThemeProps, "inputComponent">[];
+
+    error: string | undefined;
+};
+
+export type SignInThemeProps = SignInFormThemeBaseProps & {
     recipeImplementation: RecipeInterface;
     clearError: () => void;
     onError: (error: string) => void;
@@ -260,7 +269,6 @@ export type SignUpThemeProps = FormThemeBaseProps & {
     config: NormalisedConfig;
     signInClicked?: () => void;
     onSuccess: (result: { user: User }) => void;
-    formFields: (FormFieldThemeProps & { inputComponent?: React.FC<InputProps> })[];
 };
 
 export type SignInAndUpThemeProps = {
@@ -289,6 +297,11 @@ export type FormFieldThemeProps = NormalisedFormField & {
      * Clears the field after calling the API.
      */
     clearOnSubmit?: boolean;
+
+    /*
+     * Ability to add custom components
+     */
+    inputComponent?: React.FC<InputProps>;
 };
 
 export type FormFieldError = {

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -223,16 +223,16 @@ export type NormalisedEnterEmailForm = FeatureBaseConfig & {
     formFields: NormalisedFormField[];
 };
 
-type FormThemeBaseProps = ThemeBaseProps & {
+type NonSignUpFormThemeBaseProps = ThemeBaseProps & {
     /*
-     * Form fields to use in the signup form.
+     * Omit since, custom inputComponent only part of signup
      */
     formFields: Omit<FormFieldThemeProps, "inputComponent">[];
 
     error: string | undefined;
 };
 
-export type SignInThemeProps = FormThemeBaseProps & {
+export type SignInThemeProps = NonSignUpFormThemeBaseProps & {
     recipeImplementation: RecipeInterface;
     clearError: () => void;
     onError: (error: string) => void;
@@ -363,7 +363,7 @@ export type ResetPasswordUsingTokenThemeProps = {
     userContext?: any;
 };
 
-export type EnterEmailProps = FormThemeBaseProps & {
+export type EnterEmailProps = NonSignUpFormThemeBaseProps & {
     recipeImplementation: RecipeInterface;
     error: string | undefined;
     clearError: () => void;
@@ -372,7 +372,7 @@ export type EnterEmailProps = FormThemeBaseProps & {
     onBackButtonClicked: () => void;
 };
 
-export type SubmitNewPasswordProps = FormThemeBaseProps & {
+export type SubmitNewPasswordProps = NonSignUpFormThemeBaseProps & {
     recipeImplementation: RecipeInterface;
     error: string | undefined;
     clearError: () => void;

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -181,7 +181,12 @@ export type NormalisedSignInFormFeatureConfig = NormalisedBaseConfig & {
 
 export type FormFieldSignInConfig = FormFieldBaseConfig;
 
-export type FormFieldSignUpConfig = FormField;
+export type FormFieldSignUpConfig = FormField & {
+    /*
+     * Ability to add custom components
+     */
+    inputComponent?: React.FC<InputProps>;
+};
 
 export type ResetPasswordUsingTokenUserInput = {
     /*
@@ -255,6 +260,7 @@ export type SignUpThemeProps = FormThemeBaseProps & {
     config: NormalisedConfig;
     signInClicked?: () => void;
     onSuccess: (result: { user: User }) => void;
+    formFields: (FormFieldThemeProps & { inputComponent?: React.FC<InputProps> })[];
 };
 
 export type SignInAndUpThemeProps = {
@@ -273,11 +279,6 @@ export type FormFieldThemeProps = NormalisedFormField & {
      * Custom component that replaces the label entirely
      */
     labelComponent?: JSX.Element;
-
-    /*
-     * Custom component that replaces the standard input component
-     */
-    inputComponent?: React.FC<InputProps>;
 
     /*
      * Show Is required (*) next to label

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -134,7 +134,10 @@ export type SignUpFormFeatureUserInput = FeatureBaseConfig & {
     /*
      * Form fields for SignUp.
      */
-    formFields?: (FormField & { inputComponent?: (props: InputProps) => JSX.Element })[];
+    formFields?: (FormField & {
+        inputComponent?: (props: InputProps) => JSX.Element;
+        getDefaultValue?: () => string;
+    })[];
 
     /*
      * Privacy policy link for sign up form.
@@ -151,7 +154,10 @@ export type NormalisedSignUpFormFeatureConfig = NormalisedBaseConfig & {
     /*
      * Normalised form fields for SignUp.
      */
-    formFields: (NormalisedFormField & { inputComponent?: (props: InputProps) => JSX.Element })[];
+    formFields: (NormalisedFormField & {
+        inputComponent?: (props: InputProps) => JSX.Element;
+        getDefaultValue?: () => string;
+    })[];
 
     /*
      * Privacy policy link for sign up form.
@@ -283,6 +289,11 @@ export type FormFieldThemeProps = NormalisedFormField & {
      * Ability to add custom components
      */
     inputComponent?: (props: InputProps) => JSX.Element;
+
+    /*
+     * Ability to add custom components
+     */
+    getDefaultValue?: () => string;
 };
 
 export type FormFieldError = {

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -41,7 +41,6 @@ import type {
     NormalisedConfig as NormalisedAuthRecipeModuleConfig,
     UserInput as AuthRecipeModuleUserInput,
 } from "../authRecipe/types";
-import type React from "react";
 import type { Dispatch } from "react";
 import type { OverrideableBuilder } from "supertokens-js-override";
 import type { RecipeInterface } from "supertokens-web-js/recipe/emailpassword";
@@ -135,7 +134,7 @@ export type SignUpFormFeatureUserInput = FeatureBaseConfig & {
     /*
      * Form fields for SignUp.
      */
-    formFields?: (FormField & { inputComponent?: React.FC<InputProps> })[];
+    formFields?: (FormField & { inputComponent?: (props: InputProps) => JSX.Element })[];
 
     /*
      * Privacy policy link for sign up form.
@@ -152,7 +151,7 @@ export type NormalisedSignUpFormFeatureConfig = NormalisedBaseConfig & {
     /*
      * Normalised form fields for SignUp.
      */
-    formFields: (NormalisedFormField & { inputComponent?: React.FC<InputProps> })[];
+    formFields: (NormalisedFormField & { inputComponent?: (props: InputProps) => JSX.Element })[];
 
     /*
      * Privacy policy link for sign up form.
@@ -283,7 +282,7 @@ export type FormFieldThemeProps = NormalisedFormField & {
     /*
      * Ability to add custom components
      */
-    inputComponent?: React.FC<InputProps>;
+    inputComponent?: (props: InputProps) => JSX.Element;
 };
 
 export type FormFieldError = {

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -152,7 +152,7 @@ export type NormalisedSignUpFormFeatureConfig = NormalisedBaseConfig & {
     /*
      * Normalised form fields for SignUp.
      */
-    formFields: NormalisedFormField[];
+    formFields: (NormalisedFormField & { inputComponent?: React.FC<InputProps> })[];
 
     /*
      * Privacy policy link for sign up form.
@@ -230,29 +230,16 @@ export type NormalisedEnterEmailForm = FeatureBaseConfig & {
     formFields: NormalisedFormField[];
 };
 
-/*
- * Props Types.
- */
-
 type FormThemeBaseProps = ThemeBaseProps & {
     /*
      * Form fields to use in the signup form.
-     */
-    formFields: FormFieldThemeProps[];
-
-    error: string | undefined;
-};
-
-type SignInFormThemeBaseProps = ThemeBaseProps & {
-    /*
-     * Form fields to use in the signin form. exclude custom component
      */
     formFields: Omit<FormFieldThemeProps, "inputComponent">[];
 
     error: string | undefined;
 };
 
-export type SignInThemeProps = SignInFormThemeBaseProps & {
+export type SignInThemeProps = FormThemeBaseProps & {
     recipeImplementation: RecipeInterface;
     clearError: () => void;
     onError: (error: string) => void;
@@ -262,13 +249,15 @@ export type SignInThemeProps = SignInFormThemeBaseProps & {
     onSuccess: (result: { user: User }) => void;
 };
 
-export type SignUpThemeProps = FormThemeBaseProps & {
+export type SignUpThemeProps = ThemeBaseProps & {
     recipeImplementation: RecipeInterface;
     clearError: () => void;
     onError: (error: string) => void;
     config: NormalisedConfig;
     signInClicked?: () => void;
     onSuccess: (result: { user: User }) => void;
+    formFields: FormFieldThemeProps[];
+    error: string | undefined;
 };
 
 export type SignInAndUpThemeProps = {

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -135,7 +135,7 @@ export type SignUpFormFeatureUserInput = FeatureBaseConfig & {
     /*
      * Form fields for SignUp.
      */
-    formFields?: FormFieldSignUpConfig[];
+    formFields?: (FormField & { inputComponent?: React.FC<InputProps> })[];
 
     /*
      * Privacy policy link for sign up form.
@@ -180,13 +180,6 @@ export type NormalisedSignInFormFeatureConfig = NormalisedBaseConfig & {
 };
 
 export type FormFieldSignInConfig = FormFieldBaseConfig;
-
-export type FormFieldSignUpConfig = FormField & {
-    /*
-     * Ability to add custom components
-     */
-    inputComponent?: React.FC<InputProps>;
-};
 
 export type ResetPasswordUsingTokenUserInput = {
     /*

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -136,7 +136,6 @@ export type SignUpFormFeatureUserInput = FeatureBaseConfig & {
      */
     formFields?: (FormField & {
         inputComponent?: (props: InputProps) => JSX.Element;
-        getDefaultValue?: () => string;
     })[];
 
     /*
@@ -156,7 +155,6 @@ export type NormalisedSignUpFormFeatureConfig = NormalisedBaseConfig & {
      */
     formFields: (NormalisedFormField & {
         inputComponent?: (props: InputProps) => JSX.Element;
-        getDefaultValue?: () => string;
     })[];
 
     /*
@@ -289,11 +287,6 @@ export type FormFieldThemeProps = NormalisedFormField & {
      * Ability to add custom components
      */
     inputComponent?: (props: InputProps) => JSX.Element;
-
-    /*
-     * Ability to add custom components
-     */
-    getDefaultValue?: () => string;
 };
 
 export type FormFieldError = {

--- a/lib/ts/recipe/passwordless/components/themes/signInUp/phoneNumberInput.tsx
+++ b/lib/ts/recipe/passwordless/components/themes/signInUp/phoneNumberInput.tsx
@@ -45,19 +45,13 @@ function PhoneNumberInput({
 }: InputProps & PhoneNumberInputProps): JSX.Element {
     function handleFocus() {
         if (onInputFocus !== undefined) {
-            onInputFocus({
-                id: name,
-                value: value,
-            });
+            onInputFocus(value);
         }
     }
 
     function handleBlur() {
         if (onInputBlur !== undefined) {
-            onInputBlur({
-                id: name,
-                value: value,
-            });
+            onInputBlur(value);
         }
     }
 

--- a/lib/ts/recipe/passwordless/components/themes/signInUp/phoneNumberInput.tsx
+++ b/lib/ts/recipe/passwordless/components/themes/signInUp/phoneNumberInput.tsx
@@ -71,10 +71,7 @@ function PhoneNumberInput({
     const handleChange = useCallback(
         (newValue: string) => {
             if (onChangeRef.current !== undefined) {
-                onChangeRef.current({
-                    id: name,
-                    value: newValue,
-                });
+                onChangeRef.current(newValue);
             }
         },
         [onChangeRef]
@@ -83,10 +80,7 @@ function PhoneNumberInput({
     const handleCountryChange = useCallback(
         (ev) => {
             if (onChangeRef.current !== undefined && phoneInputInstance !== undefined) {
-                onChangeRef.current({
-                    id: name,
-                    value: ev.target.value,
-                });
+                onChangeRef.current(ev.target.value);
             }
         },
         [onChangeRef]

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -13,7 +13,6 @@
  * under the License.
  */
 
-import type { InputProps } from "./recipe/emailpassword/components/library/input";
 import type { BaseRecipeModule } from "./recipe/recipeModule/baseRecipeModule";
 import type { NormalisedConfig as NormalisedRecipeModuleConfig } from "./recipe/recipeModule/types";
 import type { TranslationFunc, TranslationStore } from "./translation/translationHelpers";
@@ -284,11 +283,6 @@ export type NormalisedFormField = {
      * Moves focus to the input element when it mounts
      */
     autofocus?: boolean;
-
-    /*
-     * Ability to add custom components
-     */
-    inputComponent?: React.FC<InputProps>;
 };
 
 export type ReactComponentClass<P = any> = ComponentClass<P, any> | ((props: P) => JSX.Element);

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -289,11 +289,6 @@ export type NormalisedFormField = {
      * Moves focus to the input element when it mounts
      */
     autofocus?: boolean;
-
-    /*
-     * Ability to add custom components
-     */
-    inputComponent?: React.FC<InputProps>;
 };
 
 export type ReactComponentClass<P = any> = ComponentClass<P, any> | ((props: P) => JSX.Element);

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -13,6 +13,7 @@
  * under the License.
  */
 
+import type { InputProps } from "./recipe/emailpassword/components/library/input";
 import type { BaseRecipeModule } from "./recipe/recipeModule/baseRecipeModule";
 import type { NormalisedConfig as NormalisedRecipeModuleConfig } from "./recipe/recipeModule/types";
 import type { TranslationFunc, TranslationStore } from "./translation/translationHelpers";
@@ -234,6 +235,11 @@ export type FormField = FormFieldBaseConfig & {
      * Whether the field is optional or not.
      */
     optional?: boolean;
+
+    /*
+     * Ability to add custom components
+     */
+    inputComponent?: React.FC<InputProps>;
 };
 
 export type APIFormField = {

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -235,11 +235,6 @@ export type FormField = FormFieldBaseConfig & {
      * Whether the field is optional or not.
      */
     optional?: boolean;
-
-    /*
-     * Ability to add custom components
-     */
-    inputComponent?: React.FC<InputProps>;
 };
 
 export type APIFormField = {

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -239,7 +239,7 @@ export type FormField = FormFieldBaseConfig & {
     /*
      * Ability to add custom components
      */
-    inputComponent?: (props: InputProps) => JSX.Element;
+    inputComponent?: React.FC<InputProps>;
 };
 
 export type APIFormField = {
@@ -289,6 +289,11 @@ export type NormalisedFormField = {
      * Moves focus to the input element when it mounts
      */
     autofocus?: boolean;
+
+    /*
+     * Ability to add custom components
+     */
+    inputComponent?: React.FC<InputProps>;
 };
 
 export type ReactComponentClass<P = any> = ComponentClass<P, any> | ((props: P) => JSX.Element);

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -289,6 +289,11 @@ export type NormalisedFormField = {
      * Moves focus to the input element when it mounts
      */
     autofocus?: boolean;
+
+    /*
+     * Ability to add custom components
+     */
+    inputComponent?: React.FC<InputProps>;
 };
 
 export type ReactComponentClass<P = any> = ComponentClass<P, any> | ((props: P) => JSX.Element);

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -222,6 +222,11 @@ export type FormFieldBaseConfig = {
      * placeholder of the input field.
      */
     placeholder?: string;
+
+    /*
+     *Ability to provide default value to input field.
+     */
+    getDefaultValue?: () => string;
 };
 
 export type FormField = FormFieldBaseConfig & {
@@ -283,6 +288,11 @@ export type NormalisedFormField = {
      * Moves focus to the input element when it mounts
      */
     autofocus?: boolean;
+
+    /*
+     *Ability to provide default value to input field.
+     */
+    getDefaultValue?: () => string;
 };
 
 export type ReactComponentClass<P = any> = ComponentClass<P, any> | ((props: P) => JSX.Element);

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -239,7 +239,7 @@ export type FormField = FormFieldBaseConfig & {
     /*
      * Ability to add custom components
      */
-    inputComponent?: React.FC<InputProps>;
+    inputComponent?: (props: InputProps) => JSX.Element;
 };
 
 export type APIFormField = {

--- a/test/end-to-end/signin.test.js
+++ b/test/end-to-end/signin.test.js
@@ -669,6 +669,94 @@ describe("SuperTokens SignIn", function () {
             });
         });
     });
+
+    describe("SignIn default field tests", function () {
+        it("Should contain email and password fields prefilled", async function () {
+            await page.evaluate(() => window.localStorage.setItem("SHOW_SIGNIN_DEFAULT_FIELDS", "YES"));
+
+            await page.reload({
+                waitUntil: "domcontentloaded",
+            });
+
+            const expectedDefaultValues = {
+                email: "abc@xyz.com",
+                password: "fakepassword123",
+            };
+
+            const emailInput = await getInputField(page, "email");
+            const defaultEmail = await emailInput.evaluate((f) => f.value);
+            assert.strictEqual(defaultEmail, expectedDefaultValues["email"]);
+
+            const passwordInput = await getInputField(page, "password");
+            const defaultPassword = await passwordInput.evaluate((f) => f.value);
+            assert.strictEqual(defaultPassword, expectedDefaultValues["password"]);
+        });
+
+        it("Should have default values in the signin request payload", async function () {
+            await page.evaluate(() => window.localStorage.setItem("SHOW_SIGNIN_DEFAULT_FIELDS", "YES"));
+
+            await page.reload({
+                waitUntil: "domcontentloaded",
+            });
+
+            const expectedDefautlValues = [
+                { id: "email", value: "abc@xyz.com" },
+                { id: "password", value: "fakepassword123" },
+            ];
+
+            let assertionError = null;
+            let interceptionPassed = false;
+
+            const requestHandler = async (request) => {
+                if (request.url().includes(SIGN_IN_API) && request.method() === "POST") {
+                    try {
+                        const postData = JSON.parse(request.postData());
+                        expectedDefautlValues.forEach(({ id, value }) => {
+                            let findFormData = postData.formFields.find((inputData) => inputData.id === id);
+                            if (findFormData) {
+                                assert.strictEqual(findFormData["value"], value, `Mismatch in payload for key: ${id}`);
+                            } else {
+                                throw new Error("Field not found in req.data");
+                            }
+                        });
+                        interceptionPassed = true;
+                        return request.respond({
+                            status: 200,
+                            headers: {
+                                "access-control-allow-origin": TEST_CLIENT_BASE_URL,
+                                "access-control-allow-credentials": "true",
+                            },
+                            body: JSON.stringify({
+                                status: "OK",
+                            }),
+                        });
+                    } catch (error) {
+                        assertionError = error; // Store the error
+                    }
+                }
+                return request.continue();
+            };
+
+            await page.setRequestInterception(true);
+            page.on("request", requestHandler);
+
+            try {
+                // Perform the button click and wait for all network activity to finish
+                await Promise.all([page.waitForNetworkIdle(), submitForm(page)]);
+            } finally {
+                page.off("request", requestHandler);
+                await page.setRequestInterception(false);
+            }
+
+            if (assertionError) {
+                throw assertionError;
+            }
+
+            if (!interceptionPassed) {
+                throw new Error("test failed");
+            }
+        });
+    });
 });
 
 describe("SuperTokens SignIn => Server Error", function () {

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -347,7 +347,7 @@ describe("SuperTokens SignUp", function () {
 
     // CUSTOM FIELDS TEST
 
-    describe("Signup custom fields test", function () {
+    describe.only("Signup custom fields test", function () {
         beforeEach(async function () {
             // set cookie and reload which loads the form with custom field
             await page.evaluate(() => window.localStorage.setItem("SHOW_CUSTOM_FIELDS", "YES"));
@@ -412,7 +412,7 @@ describe("SuperTokens SignUp", function () {
             const requestHandler = (request) => {
                 if (request.url().includes(SIGN_UP_API) && request.method() === "POST") {
                     Object.keys(customFields).every((key) => {
-                        assert.equal(data[key], customFields[key]);
+                        assert.strictEqual(data[key], customFields[key]);
                     });
                 }
                 return request.continue();

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -347,7 +347,7 @@ describe("SuperTokens SignUp", function () {
 
     // CUSTOM FIELDS TEST
 
-    describe.only("Signup custom fields test", function () {
+    describe("Signup custom fields test", function () {
         beforeEach(async function () {
             // set cookie and reload which loads the form with custom field
             await page.evaluate(() => window.localStorage.setItem("SHOW_CUSTOM_FIELDS", "YES"));
@@ -414,6 +414,8 @@ describe("SuperTokens SignUp", function () {
                     Object.keys(customFields).every((key) => {
                         assert.strictEqual(data[key], customFields[key]);
                     });
+                    // remove it after updating backend to handle the custom fields
+                    return request.abort();
                 }
                 return request.continue();
             };

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -651,27 +651,6 @@ describe("SuperTokens SignUp", function () {
                 `Expected "${expectedErrorMessage}" to be included in page-error`
             );
         });
-
-        // TODO
-        // it("Check if default values are getting sent in signup-payload", async function () {
-        //     const updatedFields = {
-        //         country: "USA",
-        //         ratings: "good",
-        //     };
-
-        //     await setInputValues(page, [{ name: "country", value: updatedFields["country"] }]);
-        //     await setSelectDropdownValue(page, 'select[name="ratings"]', updatedFields["ratings"]);
-
-        //     // input field default value
-        //     const countryInput = await getInputField(page, "country");
-        //     const updatedCountry = await countryInput.evaluate((f) => f.value);
-        //     assert.strictEqual(updatedCountry, updatedFields["country"]);
-
-        //     // dropdown default value is also getting set correctly
-        //     const ratingsDropdown = await waitForSTElement(page, "select");
-        //     const updatedRating = await ratingsDropdown.evaluate((f) => f.value);
-        //     assert.strictEqual(updatedRating, updatedFields["ratings"]);
-        // });
     });
 });
 

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -39,7 +39,6 @@ import {
     getGeneralError,
     waitForSTElement,
     backendBeforeEach,
-    getCustomComponents,
     setSelectDropdownValue,
 } from "../helpers";
 
@@ -363,11 +362,11 @@ describe("SuperTokens SignUp", function () {
             assert.deepStrictEqual(text, "Sign Up");
 
             // check if select dropdown is loaded
-            const selectDropdownExists = await getCustomComponents(page, "select");
+            const selectDropdownExists = await waitForSTElement(page, "select");
             assert.ok(selectDropdownExists, "Select dropdown exists");
 
             // check if checbox is loaded
-            const checkboxExists = await getCustomComponents(page, 'input[type="checkbox"]');
+            const checkboxExists = await waitForSTElement(page, 'input[type="checkbox"]');
             assert.ok(checkboxExists, "Checkbox exists");
         });
 
@@ -397,7 +396,7 @@ describe("SuperTokens SignUp", function () {
             assert.deepStrictEqual(formFieldErrors, ["Field is not optional"]);
 
             // check terms and condition checkbox
-            let termsCheckbox = await getCustomComponents(page, '[name="terms"]');
+            let termsCheckbox = await waitForSTElement(page, '[name="terms"]');
             await page.evaluate((e) => e.click(), termsCheckbox);
             await submitForm(page);
             formFieldErrors = await getFieldErrors(page);
@@ -434,7 +433,7 @@ describe("SuperTokens SignUp", function () {
                 await setSelectDropdownValue(page, 'select[name="ratings"]', customFields["ratings"]);
 
                 // Check terms and condition checkbox
-                let termsCheckbox = await getCustomComponents(page, '[name="terms"]');
+                let termsCheckbox = await waitForSTElement(page, '[name="terms"]');
                 await page.evaluate((e) => e.click(), termsCheckbox);
 
                 await submitForm(page);

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -394,9 +394,13 @@ describe("SuperTokens SignUp", function () {
             // check terms and condition checkbox
             let termsCheckbox = await waitForSTElement(page, '[name="terms"]');
             await page.evaluate((e) => e.click(), termsCheckbox);
+
+            //un-checking the required checkbox should throw custom error message
+            await page.evaluate((e) => e.click(), termsCheckbox);
+
             await submitForm(page);
             formFieldErrors = await getFieldErrors(page);
-            assert.deepStrictEqual(formFieldErrors, []);
+            assert.deepStrictEqual(formFieldErrors, ["Please check Terms and conditions"]);
         });
 
         it("Check if custom values are part of the signup payload", async function () {

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -343,6 +343,133 @@ describe("SuperTokens SignUp", function () {
             assert.deepStrictEqual(emailError, "This email already exists. Please sign in instead.");
         });
     });
+
+    // CUSTOM FIELDS TEST
+
+    describe("Signup custom fields test", function () {
+        before(async function () {
+            await backendBeforeEach();
+
+            await fetch(`${TEST_SERVER_BASE_URL}/startst`, {
+                method: "POST",
+            }).catch(console.error);
+
+            browser = await puppeteer.launch({
+                args: ["--no-sandbox", "--disable-setuid-sandbox"],
+                headless: false,
+            });
+            page = await browser.newPage();
+        });
+
+        // after(async function () {
+        //     await browser.close();
+        // });
+
+        afterEach(function () {
+            return screenshotOnFailure(this, browser);
+        });
+
+        beforeEach(async function () {
+            consoleLogs = [];
+            consoleLogs = await clearBrowserCookiesWithoutAffectingConsole(page, consoleLogs);
+            await Promise.all([
+                page.goto(`${TEST_CLIENT_BASE_URL}`),
+                page.waitForNavigation({ waitUntil: "networkidle0" }),
+            ]);
+
+            await page.evaluate(() => window.localStorage.setItem("SHOW_CUSTOM_FIELDS", "YES"));
+
+            let elem = await getLoginWithRedirectToSignUp(page);
+            await page.evaluate((e) => e.click(), elem);
+            await page.waitForNavigation({ waitUntil: "networkidle0" });
+        });
+
+        it.only("Check if the custom fields are loaded", async function () {
+            let text = await getAuthPageHeaderText(page);
+            assert.deepStrictEqual(text, "Sign Up");
+
+            // check if select dropdown is loaded
+            const selectDropdownExists = await getCustomComponents(page, "select");
+            assert.ok(selectDropdownExists, "Select dropdown exists");
+
+            // check if checbox is loaded
+            const checkboxExists = await getCustomComponents(page, 'input[type="checkbox"]');
+            assert.ok(checkboxExists, "Checkbox exists");
+        });
+
+        it.only("Should show error messages, based on the validation", async function () {
+            await submitForm(page);
+            let formFieldErrors = await getFieldErrors(page);
+
+            // 4 regular form field errors +
+            // 1 required custom field => terms checkbox
+            assert.deepStrictEqual(formFieldErrors, [
+                "Field is not optional",
+                "Field is not optional",
+                "Field is not optional",
+                "Field is not optional",
+                "Field is not optional",
+            ]);
+
+            // supply values for regular-required fields only
+            await setInputValues(page, [
+                { name: "email", value: "jack.doe@supertokens.io" },
+                { name: "password", value: "Str0ngP@ssw0rd" },
+                { name: "name", value: "John Doe" },
+                { name: "age", value: "20" },
+            ]);
+            await submitForm(page);
+            formFieldErrors = await getFieldErrors(page);
+            assert.deepStrictEqual(formFieldErrors, ["Field is not optional"]);
+
+            // check terms and condition checkbox
+            let termsCheckbox = await getCustomComponents(page, '[name="terms"]');
+            await page.evaluate((e) => e.click(), termsCheckbox);
+            await submitForm(page);
+            formFieldErrors = await getFieldErrors(page);
+            assert.deepStrictEqual(formFieldErrors, []);
+        });
+
+        it.only("Check if custom values are part of the signup payload", async function () {
+            const customFieldNames = ["terms", "ratings"];
+            const requestHandler = (request) => {
+                if (request.url().includes(SIGN_UP_API) && request.method() === "POST") {
+                    assert.ok(
+                        customFieldNames.every((key) => request.data.hasOwnProperty(key)),
+                        "Custom field are part of the payload"
+                    );
+                }
+                return request.continue();
+            };
+
+            try {
+                await page.setRequestInterception(true);
+                page.on("request", requestHandler);
+
+                // Fill the entire form
+                await setInputValues(page, [
+                    { name: "email", value: "john.doe@supertokens.io" },
+                    { name: "password", value: "Str0ngP@assw0rd" },
+                    { name: "name", value: "Supertokens" },
+                    { name: "age", value: "20" },
+                ]);
+
+                // Select value from dropdown (ratings)
+                let dropdownEle = await getCustomComponents(page, '[name="ratings"]');
+                const dropdownValue = 3;
+                await page.select(dropdownEle, dropdownValue);
+
+                // Check terms and condition checkbox
+                let termsCheckbox = await getCustomComponents(page, '[name="terms"]');
+                await page.evaluate((e) => e.click(), termsCheckbox);
+
+                await submitForm(page);
+            } finally {
+                page.off("request", requestHandler);
+                await page.setRequestInterception(false);
+            }
+        });
+    });
 });
 
 describe("SuperTokens SignUp => Server Error", function () {
@@ -413,136 +540,5 @@ describe("SuperTokens SignUp => Server Error", function () {
         assert.strictEqual(generalError, SOMETHING_WENT_WRONG_ERROR);
         await toggleSignInSignUp(page);
         await waitForSTElement(page, "[data-supertokens~=generalError]", true);
-    });
-});
-
-// CUSTOM FIELDS TEST
-
-describe("Signup custom fields test", function () {
-    let browser;
-    let page;
-    let consoleLogs;
-
-    before(async function () {
-        await backendBeforeEach();
-
-        await fetch(`${TEST_SERVER_BASE_URL}/startst`, {
-            method: "POST",
-        }).catch(console.error);
-
-        browser = await puppeteer.launch({
-            args: ["--no-sandbox", "--disable-setuid-sandbox"],
-            headless: false,
-        });
-        page = await browser.newPage();
-    });
-
-    // after(async function () {
-    //     await browser.close();
-    // });
-
-    afterEach(function () {
-        return screenshotOnFailure(this, browser);
-    });
-
-    beforeEach(async function () {
-        consoleLogs = [];
-        consoleLogs = await clearBrowserCookiesWithoutAffectingConsole(page, consoleLogs);
-        await Promise.all([
-            page.goto(`${TEST_CLIENT_BASE_URL}`),
-            page.waitForNavigation({ waitUntil: "networkidle0" }),
-        ]);
-
-        await page.evaluate(() => window.localStorage.setItem("SHOW_CUSTOM_FIELDS", "YES"));
-
-        let elem = await getLoginWithRedirectToSignUp(page);
-        await page.evaluate((e) => e.click(), elem);
-        await page.waitForNavigation({ waitUntil: "networkidle0" });
-    });
-
-    it("Check if the custom fields are loaded", async function () {
-        let text = await getAuthPageHeaderText(page);
-        assert.deepStrictEqual(text, "Sign Up");
-
-        // check if select dropdown is loaded
-        const selectDropdownExists = await getCustomComponents(page, "select");
-        assert.ok(selectDropdownExists, "Select dropdown exists");
-
-        // check if checbox is loaded
-        const checkboxExists = await getCustomComponents(page, 'input[type="checkbox"]');
-        assert.ok(checkboxExists, "Checkbox exists");
-    });
-
-    it("Should show error messages, based on the validation", async function () {
-        await submitForm(page);
-        let formFieldErrors = await getFieldErrors(page);
-
-        // 4 regular form field errors +
-        // 1 required custom field => terms checkbox
-        assert.deepStrictEqual(formFieldErrors, [
-            "Field is not optional",
-            "Field is not optional",
-            "Field is not optional",
-            "Field is not optional",
-            "Field is not optional",
-        ]);
-
-        // supply values for regular-required fields only
-        await setInputValues(page, [
-            { name: "email", value: "jack.doe@supertokens.io" },
-            { name: "password", value: "Str0ngP@ssw0rd" },
-            { name: "name", value: "John Doe" },
-            { name: "age", value: "20" },
-        ]);
-        await submitForm(page);
-        formFieldErrors = await getFieldErrors(page);
-        assert.deepStrictEqual(formFieldErrors, ["Field is not optional"]);
-
-        // check terms and condition checkbox
-        let termsCheckbox = await getCustomComponents(page, '[name="terms"]');
-        await page.evaluate((e) => e.click(), termsCheckbox);
-        await submitForm(page);
-        formFieldErrors = await getFieldErrors(page);
-        assert.deepStrictEqual(formFieldErrors, []);
-    });
-
-    it.only("Check if custom values are part of the signup payload", async function () {
-        const customFieldNames = ["terms", "ratings"];
-        const requestHandler = (request) => {
-            if (request.url().includes(SIGN_UP_API) && request.method() === "POST") {
-                assert.ok(
-                    customFieldNames.every((key) => request.data.hasOwnProperty(key)),
-                    "Custom field are part of the payload"
-                );
-            }
-            return request.continue();
-        };
-
-        try {
-            await page.setRequestInterception(true);
-            page.on("request", requestHandler);
-
-            // Fill the entire form
-            await setInputValues(page, [
-                { name: "email", value: "john.doe@supertokens.io" },
-                { name: "password", value: "Str0ngP@assw0rd" },
-                { name: "name", value: "Supertokens" },
-                { name: "age", value: "20" },
-            ]);
-
-            // Select value from dropdown (ratings)
-            let dropdownEle = await getCustomComponents(page, '[name="ratings"]');
-            const dropdownValue = 3;
-            await page.select(dropdownEle, dropdownValue);
-
-            // Check terms and condition checkbox
-            let termsCheckbox = await getCustomComponents(page, '[name="terms"]');
-            await page.evaluate((e) => e.click(), termsCheckbox);
-
-            await submitForm(page);
-        } finally {
-            page.off("request", requestHandler);
-            await page.setRequestInterception(false);
-        }
     });
 });

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -489,64 +489,6 @@ describe("SuperTokens SignUp", function () {
             assert.strictEqual(defaultRating, updatedFields["ratings"]);
         });
     });
-
-    describe("Signup with Incorrect fields config", function () {
-        beforeEach(async function () {
-            // set cookie and reload which loads the form fields with incorrect field values
-            await page.evaluate(() => window.localStorage.setItem("SHOW_INCORRECT_FIELDS", "YES"));
-
-            await page.reload({
-                waitUntil: "domcontentloaded",
-            });
-            await toggleSignInSignUp(page);
-        });
-
-        it("Check if throws an error in console log", async function () {
-            // based on incorrect fields config, should get following console.error
-            const expectedErrors = [
-                "getDefaultValue for ratings must be a function",
-                "getDefaultValue for country must return a string",
-            ];
-            let consoleErrorMessages = [];
-
-            page.on("console", async (msg) => {
-                // serialize the args, returns error text
-                const args = await Promise.all(
-                    msg.args().map((arg) =>
-                        arg.executionContext().evaluate((arg) => {
-                            if (arg instanceof Error) {
-                                return arg.message;
-                            }
-                            return null;
-                        }, arg)
-                    )
-                );
-                consoleErrorMessages.push(...args.filter(Boolean));
-            });
-
-            await page.reload({
-                waitUntil: "domcontentloaded",
-            });
-            await toggleSignInSignUp(page);
-
-            // Some delay  so that console messages have been processed
-            await new Promise((resolve) => setTimeout(resolve, 1000));
-            let isSubset = expectedErrors.every((err) => consoleErrorMessages.includes(err));
-            assert(isSubset, "Throwing errors for incorrect field config - getDefaultValue prop");
-
-            // Supply NON-STRING value to onChange function should throw error
-            const expectedOnChangeError = ["terms value must be a string"];
-            // check terms and condition checkbox
-
-            let termsCheckbox = await waitForSTElement(page, '[name="terms"]');
-            await page.evaluate((e) => e.click(), termsCheckbox);
-            isSubset = false;
-
-            await new Promise((resolve) => setTimeout(resolve, 1000));
-            isSubset = expectedOnChangeError.every((err) => consoleErrorMessages.includes(err));
-            assert(isSubset, "Throwing errors for incorrect field config - onChange func.");
-        });
-    });
 });
 
 describe("SuperTokens SignUp => Server Error", function () {

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -662,7 +662,7 @@ describe("SuperTokens SignUp => Server Error", function () {
     before(async function () {
         browser = await puppeteer.launch({
             args: ["--no-sandbox", "--disable-setuid-sandbox"],
-            headless: false,
+            headless: true,
         });
     });
 

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -409,8 +409,6 @@ describe("SuperTokens SignUp", function () {
                     Object.keys(customFields).every((key) => {
                         assert.strictEqual(data[key], customFields[key]);
                     });
-                    // remove it after updating backend to handle the custom fields
-                    return request.abort();
                 }
                 return request.continue();
             };

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -444,7 +444,7 @@ describe("SuperTokens SignUp", function () {
     describe("Signup default value for fields test", function () {
         beforeEach(async function () {
             // set cookie and reload which loads the form fields with default values
-            await page.evaluate(() => window.localStorage.setItem("SHOW_DEFAULT_FIELDS", "YES"));
+            await page.evaluate(() => window.localStorage.setItem("SHOW_CUSTOM_FIELDS_WITH_DEFAULT_VALUES", "YES"));
 
             await page.reload({
                 waitUntil: "domcontentloaded",
@@ -480,14 +480,35 @@ describe("SuperTokens SignUp", function () {
 
             // input field default value
             const countryInput = await getInputField(page, "country");
-            const defaultCountry = await countryInput.evaluate((f) => f.value);
-            assert.strictEqual(defaultCountry, updatedFields["country"]);
+            const updatedCountry = await countryInput.evaluate((f) => f.value);
+            assert.strictEqual(updatedCountry, updatedFields["country"]);
 
             // dropdown default value is also getting set correctly
             const ratingsDropdown = await waitForSTElement(page, "select");
-            const defaultRating = await ratingsDropdown.evaluate((f) => f.value);
-            assert.strictEqual(defaultRating, updatedFields["ratings"]);
+            const updatedRating = await ratingsDropdown.evaluate((f) => f.value);
+            assert.strictEqual(updatedRating, updatedFields["ratings"]);
         });
+
+        // TODO
+        // it("Check if default values are getting sent in signup-payload", async function () {
+        //     const updatedFields = {
+        //         country: "USA",
+        //         ratings: "good",
+        //     };
+
+        //     await setInputValues(page, [{ name: "country", value: updatedFields["country"] }]);
+        //     await setSelectDropdownValue(page, 'select[name="ratings"]', updatedFields["ratings"]);
+
+        //     // input field default value
+        //     const countryInput = await getInputField(page, "country");
+        //     const updatedCountry = await countryInput.evaluate((f) => f.value);
+        //     assert.strictEqual(updatedCountry, updatedFields["country"]);
+
+        //     // dropdown default value is also getting set correctly
+        //     const ratingsDropdown = await waitForSTElement(page, "select");
+        //     const updatedRating = await ratingsDropdown.evaluate((f) => f.value);
+        //     assert.strictEqual(updatedRating, updatedFields["ratings"]);
+        // });
     });
 });
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -418,17 +418,16 @@ export async function setInputValues(page, fields) {
 }
 
 export async function setSelectDropdownValue(page, selector, optionValue) {
+    const shadowRootHandle = await getShadowRootHandle(page);
     return await page.evaluate(
-        (selector, optionValue, ST_ROOT_SELECTOR) => {
-            const dropdownElement = document.querySelector(ST_ROOT_SELECTOR).shadowRoot.querySelector(selector);
-            if (dropdownElement) {
-                dropdownElement.value = optionValue;
-                dropdownElement.dispatchEvent(new Event("change", { bubbles: false }));
-            }
+        (root, selector, optionValue) => {
+            const select = root.querySelector(selector);
+            select.value = optionValue;
+            select.dispatchEvent(new Event("change", { bubbles: true }));
         },
+        shadowRootHandle,
         selector,
-        optionValue,
-        ST_ROOT_SELECTOR
+        optionValue
     );
 }
 
@@ -1020,4 +1019,9 @@ export async function backendBeforeEach() {
             method: "POST",
         }).catch(console.error);
     }
+}
+
+export async function getShadowRootHandle(page) {
+    const hostElement = await page.$(ST_ROOT_SELECTOR);
+    return await page.evaluateHandle((el) => el.shadowRoot, hostElement);
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -234,10 +234,6 @@ export async function getInputNames(page) {
     );
 }
 
-export async function getCustomComponents(page, element) {
-    return waitForSTElement(page, element);
-}
-
 export async function getInputAdornmentsSuccess(page) {
     await waitForSTElement(page);
     return await page.evaluate(

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -422,6 +422,21 @@ export async function setInputValues(page, fields) {
     return await new Promise((r) => setTimeout(r, 300));
 }
 
+export async function setSelectDropdownValue(page, selector, optionValue) {
+    return await page.evaluate(
+        (selector, optionValue, ST_ROOT_SELECTOR) => {
+            const dropdownElement = document.querySelector(ST_ROOT_SELECTOR).shadowRoot.querySelector(selector);
+            if (dropdownElement) {
+                dropdownElement.value = optionValue;
+                dropdownElement.dispatchEvent(new Event("change", { bubbles: false }));
+            }
+        },
+        selector,
+        optionValue,
+        ST_ROOT_SELECTOR
+    );
+}
+
 export async function clearBrowserCookiesWithoutAffectingConsole(page, console) {
     let toReturn = [...console];
     const client = await page.target().createCDPSession();

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -28,7 +28,6 @@ import {
 import path from "path";
 import assert from "assert";
 import mkdirp from "mkdirp";
-import { async } from "regenerator-runtime";
 
 const SESSION_STORAGE_STATE_KEY = "supertokens-oauth-state";
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -28,6 +28,7 @@ import {
 import path from "path";
 import assert from "assert";
 import mkdirp from "mkdirp";
+import { async } from "regenerator-runtime";
 
 const SESSION_STORAGE_STATE_KEY = "supertokens-oauth-state";
 
@@ -231,6 +232,10 @@ export async function getInputNames(page) {
             ),
         { ST_ROOT_SELECTOR }
     );
+}
+
+export async function getCustomComponents(page, element) {
+    return waitForSTElement(page, element);
 }
 
 export async function getInputAdornmentsSuccess(page) {

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -326,97 +326,6 @@ function getRecipeList() {
     ];
 }
 
-const formFieldsForSignUp = [
-    {
-        id: "email",
-        label: "Your Email",
-        placeholder: "Your work email",
-    },
-    {
-        id: "name",
-        label: "Full name",
-        placeholder: "First name and last name",
-    },
-    {
-        id: "age",
-        label: "Your age",
-        placeholder: "How old are you?",
-        validate: async (value) => {
-            if (parseInt(value) > 18) {
-                return undefined;
-            }
-
-            return "You must be over 18 to register";
-        },
-    },
-    {
-        id: "country",
-        label: "Your Country",
-        placeholder: "Where do you live?",
-        optional: true,
-    },
-];
-
-const customFormFieldsWithDefault = [
-    {
-        id: "terms",
-        label: "",
-        optional: false,
-        inputComponent: (inputProps) => (
-            <div
-                style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "left",
-                }}>
-                <input
-                    name={inputProps.name}
-                    type="checkbox"
-                    onChange={(e) => {
-                        if (inputProps.onChange) {
-                            inputProps.onChange(e.target.checked.toString());
-                        }
-                    }}></input>
-                <span style={{ marginLeft: 5 }}>I agree to the terms and conditions</span>
-            </div>
-        ),
-        validate: async (value) => {
-            if (value === "true") {
-                return undefined;
-            }
-            return "Please check Terms and conditions";
-        },
-    },
-    {
-        id: "ratings",
-        label: "Ratings",
-        getDefaultValue: () => "best",
-        inputComponent: (inputProps) => (
-            <select
-                value={inputProps.value}
-                name={inputProps.name}
-                onChange={(e) => {
-                    if (inputProps.onChange) {
-                        inputProps.onChange(e.target.value.toString());
-                    }
-                }}
-                placeholder="Add Ratings">
-                <option value="" disabled hidden>
-                    Select an option
-                </option>
-                <option value="good">Good</option>
-                <option value="better">Better</option>
-                <option value="best">Best</option>
-            </select>
-        ),
-        optional: true,
-    },
-];
-
-const getFormFieldsForSignUp = () => {
-    return localStorage.getItem("SHOW_CUSTOM_FIELDS") === "YES" ? customFormFieldsWithDefault : formFieldsForSignUp;
-};
-
 function getEmailPasswordConfigs() {
     return EmailPassword.init({
         resetPasswordUsingTokenFeature: {
@@ -435,7 +344,99 @@ function getEmailPasswordConfigs() {
                 style: theme.style,
                 privacyPolicyLink: "https://supertokens.io/legal/privacy-policy",
                 termsOfServiceLink: "https://supertokens.io/legal/terms-and-conditions",
-                formFields: getFormFieldsForSignUp(),
+                formFields: [
+                    {
+                        id: "email",
+                        label: "Your Email",
+                        placeholder: "Your work email",
+                    },
+                    {
+                        id: "name",
+                        label: "Full name",
+                        placeholder: "First name and last name",
+                    },
+                    {
+                        id: "age",
+                        label: "Your age",
+                        placeholder: "How old are you?",
+                        validate: async (value) => {
+                            if (parseInt(value) > 18) {
+                                return undefined;
+                            }
+
+                            return "You must be over 18 to register";
+                        },
+                    },
+                    {
+                        id: "country",
+                        label: "Your Country",
+                        placeholder: "Where do you live?",
+                        optional: true,
+                    },
+                    {
+                        id: "terms",
+                        label: "",
+                        optional: false,
+                        inputComponent: (inputProps) => (
+                            <div
+                                style={{
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "left",
+                                }}>
+                                <input
+                                    name={inputProps.name}
+                                    type="checkbox"
+                                    onChange={(e) => {
+                                        if (inputProps.onChange) {
+                                            inputProps.onChange(e.target.checked.toString());
+                                        }
+                                    }}></input>
+                                <span style={{ marginLeft: 5 }}>I agree to the terms and conditions</span>
+                            </div>
+                        ),
+                        validate: async (value) => {
+                            if (value === "true") {
+                                return undefined;
+                            }
+                            return "Please check Terms and conditions";
+                        },
+                    },
+                    {
+                        id: "select",
+                        label: "Select",
+                        getDefaultValue: () => "option 2",
+                        inputComponent: (inputProps) => (
+                            <select
+                                onBlur={(e) => {
+                                    if (inputProps.onInputBlur) {
+                                        inputProps.onInputBlur(e.target.value);
+                                    }
+                                }}
+                                onFocus={(e) => {
+                                    if (inputProps.onInputFocus) {
+                                        inputProps.onInputFocus(e.target.value);
+                                    }
+                                }}
+                                value={inputProps.value}
+                                name={inputProps.name}
+                                onChange={(e) => {
+                                    if (inputProps.onChange) {
+                                        inputProps.onChange(e.target.value);
+                                    }
+                                }}
+                                placeholder="Select option">
+                                <option value="" disabled hidden>
+                                    Select an option
+                                </option>
+                                <option value="option 1">Option 1</option>
+                                <option value="option 2">Option 2</option>
+                                <option value="option 3">Option 3</option>
+                            </select>
+                        ),
+                        optional: true,
+                    },
+                ],
             },
         },
 

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -326,6 +326,97 @@ function getRecipeList() {
     ];
 }
 
+const formFieldsForSignUp = [
+    {
+        id: "email",
+        label: "Your Email",
+        placeholder: "Your work email",
+    },
+    {
+        id: "name",
+        label: "Full name",
+        placeholder: "First name and last name",
+    },
+    {
+        id: "age",
+        label: "Your age",
+        placeholder: "How old are you?",
+        validate: async (value) => {
+            if (parseInt(value) > 18) {
+                return undefined;
+            }
+
+            return "You must be over 18 to register";
+        },
+    },
+    {
+        id: "country",
+        label: "Your Country",
+        placeholder: "Where do you live?",
+        optional: true,
+    },
+];
+
+const customFormFieldsWithDefault = [
+    {
+        id: "terms",
+        label: "",
+        optional: false,
+        inputComponent: (inputProps) => (
+            <div
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "left",
+                }}>
+                <input
+                    name={inputProps.name}
+                    type="checkbox"
+                    onChange={(e) => {
+                        if (inputProps.onChange) {
+                            inputProps.onChange(e.target.checked.toString());
+                        }
+                    }}></input>
+                <span style={{ marginLeft: 5 }}>I agree to the terms and conditions</span>
+            </div>
+        ),
+        validate: async (value) => {
+            if (value === "true") {
+                return undefined;
+            }
+            return "Please check Terms and conditions";
+        },
+    },
+    {
+        id: "ratings",
+        label: "Ratings",
+        getDefaultValue: () => "best",
+        inputComponent: (inputProps) => (
+            <select
+                value={inputProps.value}
+                name={inputProps.name}
+                onChange={(e) => {
+                    if (inputProps.onChange) {
+                        inputProps.onChange(e.target.value.toString());
+                    }
+                }}
+                placeholder="Add Ratings">
+                <option value="" disabled hidden>
+                    Select an option
+                </option>
+                <option value="good">Good</option>
+                <option value="better">Better</option>
+                <option value="best">Best</option>
+            </select>
+        ),
+        optional: true,
+    },
+];
+
+const getFormFieldsForSignUp = () => {
+    return localStorage.getItem("SHOW_CUSTOM_FIELDS") === "YES" ? customFormFieldsWithDefault : formFieldsForSignUp;
+};
+
 function getEmailPasswordConfigs() {
     return EmailPassword.init({
         resetPasswordUsingTokenFeature: {
@@ -344,36 +435,7 @@ function getEmailPasswordConfigs() {
                 style: theme.style,
                 privacyPolicyLink: "https://supertokens.io/legal/privacy-policy",
                 termsOfServiceLink: "https://supertokens.io/legal/terms-and-conditions",
-                formFields: [
-                    {
-                        id: "email",
-                        label: "Your Email",
-                        placeholder: "Your work email",
-                    },
-                    {
-                        id: "name",
-                        label: "Full name",
-                        placeholder: "First name and last name",
-                    },
-                    {
-                        id: "age",
-                        label: "Your age",
-                        placeholder: "How old are you?",
-                        validate: async (value) => {
-                            if (parseInt(value) > 18) {
-                                return undefined;
-                            }
-
-                            return "You must be over 18 to register";
-                        },
-                    },
-                    {
-                        id: "country",
-                        label: "Your Country",
-                        placeholder: "Where do you live?",
-                        optional: true,
-                    },
-                ],
+                formFields: getFormFieldsForSignUp(),
             },
         },
 

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -377,6 +377,7 @@ function getEmailPasswordConfigs() {
                         id: "terms",
                         label: "",
                         optional: false,
+                        getDefaultValue: () => "true",
                         inputComponent: (inputProps) => (
                             <div
                                 style={{
@@ -387,6 +388,8 @@ function getEmailPasswordConfigs() {
                                 <input
                                     name={inputProps.name}
                                     type="checkbox"
+                                    value={inputProps.value}
+                                    checked={inputProps.value === "true"}
                                     onChange={(e) => {
                                         if (inputProps.onChange) {
                                             inputProps.onChange(e.target.checked.toString());
@@ -424,8 +427,7 @@ function getEmailPasswordConfigs() {
                                     if (inputProps.onChange) {
                                         inputProps.onChange(e.target.value);
                                     }
-                                }}
-                                placeholder="Select option">
+                                }}>
                                 <option value="" disabled hidden>
                                     Select an option
                                 </option>


### PR DESCRIPTION
…clude that

## Summary of change

Now sign in & sign up fields for email-password recipe can provide default value

## Related issues

-   [Field decorators #36](https://github.com/supertokens/supertokens-auth-react/issues/36)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
