### PR TITLE
feat: add nonOptionalErrorMsg props 

### DIFF
--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -285,6 +285,7 @@ const customFields = [
     {
         id: "select-dropdown",
         label: "Select Dropdown",
+        nonOptionalErrorMsg: "Select dropdown is not an optional",
         inputComponent: ({ value, name, onChange }) => (
             <select value={value} name={name} onChange={(e) => onChange(e.target.value)}>
                 <option value="" disabled hidden>
@@ -301,6 +302,7 @@ const customFields = [
         id: "terms",
         label: "",
         optional: false,
+        nonOptionalErrorMsg: "You must accept the terms and conditions",
         inputComponent: ({ name, onChange }) => (
             <div
                 style={{
@@ -723,6 +725,7 @@ function getFormFields() {
 
 function getSignInFormFields() {
     let showDefaultFields = localStorage.getItem("SHOW_SIGNIN_DEFAULT_FIELDS");
+    let showFieldsWithNonOptionalErrMsg = localStorage.getItem("SHOW_SIGNIN_WITH_NON_OPTIONAL_ERROR_MESSAGE");
     if (showDefaultFields === "YES") {
         return {
             formFields: [
@@ -733,6 +736,15 @@ function getSignInFormFields() {
                 {
                     id: "password",
                     getDefaultValue: () => "fakepassword123",
+                },
+            ],
+        };
+    } else if (showFieldsWithNonOptionalErrMsg === "YES") {
+        return {
+            formFields: [
+                {
+                    id: "email",
+                    nonOptionalErrorMsg: "Please add email",
                 },
             ],
         };

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -279,6 +279,12 @@ const incorrectFormFields = [
             return "Please check Terms and conditions";
         },
     },
+    {
+        id: "city",
+        label: "Your city",
+        optional: false,
+        nonOptionalErrorMsg: "", // empty string should throw error
+    },
 ];
 
 const customFields = [
@@ -713,6 +719,10 @@ function getFormFields() {
             // since page-error blocks all the other errors
             // use this filter to test specific error
             return incorrectFormFields.filter(({ id }) => id === "terms");
+        } else if (localStorage.getItem("INCORRECT_NON_OPTIONAL_ERROR_MSG") === "YES") {
+            return incorrectFormFields.filter(({ id }) => id === "city");
+        } else if (localStorage.getItem("INCORRECT_GETDEFAULT") === "YES") {
+            return incorrectFormFields.filter(({ id }) => id === "country");
         }
         return incorrectFormFields;
     } else if (localStorage.getItem("SHOW_CUSTOM_FIELDS_WITH_DEFAULT_VALUES") === "YES") {

--- a/lib/build/emailpassword-shared4.js
+++ b/lib/build/emailpassword-shared4.js
@@ -378,7 +378,7 @@ function getFormattedFormField(field) {
     var _this = this;
     // Fields with the 'nonOptionalErrorMsg' property must have a valid message defined
     if (field.optional === false && field.nonOptionalErrorMsg === "") {
-        throw new Error("nonOptionalErrorMsg for field ".concat(field.id, " cannot be empty"));
+        throw new Error("nonOptionalErrorMsg for field ".concat(field.id, " cannot be an empty string"));
     }
     return genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, field), {
         validate: function (value) {

--- a/lib/build/emailpassword-shared4.js
+++ b/lib/build/emailpassword-shared4.js
@@ -364,8 +364,11 @@ function mergeFormFields(defaultFormFields, userFormFields) {
         if (isNewField) {
             mergedFormFields.push(
                 genericComponentOverrideContext.__assign(
-                    { optional: false, placeholder: userField.label, validate: validators.defaultValidate },
-                    userField
+                    genericComponentOverrideContext.__assign(
+                        { placeholder: userField.label, validate: validators.defaultValidate },
+                        userField
+                    ),
+                    { optional: Boolean(userField.optional) }
                 )
             );
         }

--- a/lib/build/emailpassword-shared4.js
+++ b/lib/build/emailpassword-shared4.js
@@ -384,6 +384,9 @@ function getFormattedFormField(field) {
                         case 0:
                             // Absent or not optional empty field
                             if (value === "" && field.optional === false) {
+                                if (field.nonOptionalErrorMsg !== undefined && field.nonOptionalErrorMsg !== "") {
+                                    return [2 /*return*/, field.nonOptionalErrorMsg];
+                                }
                                 return [2 /*return*/, "ERROR_NON_OPTIONAL"];
                             }
                             return [4 /*yield*/, field.validate(value)];

--- a/lib/build/emailpassword-shared4.js
+++ b/lib/build/emailpassword-shared4.js
@@ -376,6 +376,10 @@ function mergeFormFields(defaultFormFields, userFormFields) {
 }
 function getFormattedFormField(field) {
     var _this = this;
+    // Fields with the 'nonOptionalErrorMsg' property must have a valid message defined
+    if (field.optional === false && field.nonOptionalErrorMsg === "") {
+        throw new Error("nonOptionalErrorMsg for field ".concat(field.id, " cannot be empty"));
+    }
     return genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, field), {
         validate: function (value) {
             return genericComponentOverrideContext.__awaiter(_this, void 0, void 0, function () {
@@ -384,7 +388,7 @@ function getFormattedFormField(field) {
                         case 0:
                             // Absent or not optional empty field
                             if (value === "" && field.optional === false) {
-                                if (field.nonOptionalErrorMsg !== undefined && field.nonOptionalErrorMsg !== "") {
+                                if (field.nonOptionalErrorMsg !== undefined) {
                                     return [2 /*return*/, field.nonOptionalErrorMsg];
                                 }
                                 return [2 /*return*/, "ERROR_NON_OPTIONAL"];

--- a/lib/build/emailpassword-shared4.js
+++ b/lib/build/emailpassword-shared4.js
@@ -364,11 +364,8 @@ function mergeFormFields(defaultFormFields, userFormFields) {
         if (isNewField) {
             mergedFormFields.push(
                 genericComponentOverrideContext.__assign(
-                    genericComponentOverrideContext.__assign(
-                        { placeholder: userField.label, validate: validators.defaultValidate },
-                        userField
-                    ),
-                    { optional: Boolean(userField.optional) }
+                    { optional: false, placeholder: userField.label, validate: validators.defaultValidate },
+                    userField
                 )
             );
         }

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -732,10 +732,7 @@ var FormBase = function (props) {
                                             if (
                                                 (fieldConfigData === null || fieldConfigData === void 0
                                                     ? void 0
-                                                    : fieldConfigData.nonOptionalErrorMsg) !== undefined &&
-                                                (fieldConfigData === null || fieldConfigData === void 0
-                                                    ? void 0
-                                                    : fieldConfigData.nonOptionalErrorMsg) !== ""
+                                                    : fieldConfigData.nonOptionalErrorMsg) !== undefined
                                             ) {
                                                 return fieldConfigData === null || fieldConfigData === void 0
                                                     ? void 0

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -616,7 +616,17 @@ var FormBase = function (props) {
     var onFormSubmit = React.useCallback(
         function (e) {
             return genericComponentOverrideContext.__awaiter(void 0, void 0, void 0, function () {
-                var apiFields, fieldUpdates, result, generalError, e_1, _loop_1, _i, formFields_1, field, errorFields_1;
+                var apiFields,
+                    fieldUpdates,
+                    result,
+                    generalError,
+                    e_1,
+                    _loop_1,
+                    _i,
+                    formFields_1,
+                    field,
+                    errorFields_1,
+                    getErrorMessage_1;
                 return genericComponentOverrideContext.__generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
@@ -706,19 +716,39 @@ var FormBase = function (props) {
                                 // If field error.
                                 if (result.status === "FIELD_ERROR") {
                                     errorFields_1 = result.formFields;
+                                    getErrorMessage_1 = function (fs) {
+                                        var _a;
+                                        var errorMessage =
+                                            (_a = errorFields_1.find(function (ef) {
+                                                return ef.id === fs.id;
+                                            })) === null || _a === void 0
+                                                ? void 0
+                                                : _a.error;
+                                        if (errorMessage === "Field is not optional") {
+                                            var fieldConfigData = props.formFields.find(function (f) {
+                                                return f.id === fs.id;
+                                            });
+                                            // replace non-optional server error message from nonOptionalErrorMsg
+                                            if (
+                                                (fieldConfigData === null || fieldConfigData === void 0
+                                                    ? void 0
+                                                    : fieldConfigData.nonOptionalErrorMsg) !== undefined &&
+                                                (fieldConfigData === null || fieldConfigData === void 0
+                                                    ? void 0
+                                                    : fieldConfigData.nonOptionalErrorMsg) !== ""
+                                            ) {
+                                                return fieldConfigData === null || fieldConfigData === void 0
+                                                    ? void 0
+                                                    : fieldConfigData.nonOptionalErrorMsg;
+                                            }
+                                        }
+                                        return errorMessage;
+                                    };
                                     setFieldStates(function (os) {
                                         return os.map(function (fs) {
-                                            var _a;
                                             return genericComponentOverrideContext.__assign(
                                                 genericComponentOverrideContext.__assign({}, fs),
-                                                {
-                                                    error:
-                                                        (_a = errorFields_1.find(function (ef) {
-                                                            return ef.id === fs.id;
-                                                        })) === null || _a === void 0
-                                                            ? void 0
-                                                            : _a.error,
-                                                }
+                                                { error: getErrorMessage_1(fs) }
                                             );
                                         });
                                     });

--- a/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/submitNewPassword.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/submitNewPassword.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 export declare const SubmitNewPassword: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: Omit<import("../../../types").FormFieldThemeProps, "inputComponent">[];
+        formFields: import("../../../types").FormFieldThemeProps[];
         error: string | undefined;
     } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signIn.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signIn.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 export declare const SignIn: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: Omit<import("../../../types").FormFieldThemeProps, "inputComponent">[];
+        formFields: import("../../../types").FormFieldThemeProps[];
         error: string | undefined;
     } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;
@@ -10,6 +10,6 @@ export declare const SignIn: import("react").ComponentType<
         config: import("../../../types").NormalisedConfig;
         signUpClicked?: (() => void) | undefined;
         forgotPasswordClick: () => void;
-        onSuccess: (result: { user: import("supertokens-web-js/types").User }) => void;
+        onSuccess: () => void;
     }
 >;

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUp.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUp.d.ts
@@ -1,13 +1,14 @@
 /// <reference types="react" />
 export declare const SignUp: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
+        formFields: import("../../../types").FormFieldThemeProps[];
+        error: string | undefined;
+    } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;
         clearError: () => void;
         onError: (error: string) => void;
         config: import("../../../types").NormalisedConfig;
         signInClicked?: (() => void) | undefined;
-        onSuccess: (result: { user: import("supertokens-web-js/types").User }) => void;
-        formFields: import("../../../types").FormFieldThemeProps[];
-        error: string | undefined;
+        onSuccess: () => void;
     }
 >;

--- a/lib/build/recipe/thirdpartyemailpassword/components/themes/translations.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/components/themes/translations.d.ts
@@ -58,9 +58,6 @@ export declare const defaultTranslationsThirdPartyEmailPassword: {
         "Password must contain at least one alphabet": undefined;
         "Password must contain at least one number": undefined;
         "Email is invalid": undefined;
-        "Reset password link was not created because of account take over risk. Please contact support. (ERR_CODE_001)": undefined;
-        "Cannot sign up due to security reasons. Please try logging in, use a different login method or contact support. (ERR_CODE_007)": undefined;
-        "Cannot sign in due to security reasons. Please try resetting your password, use a different login method or contact support. (ERR_CODE_008)": undefined;
         EMAIL_VERIFICATION_RESEND_SUCCESS: string;
         EMAIL_VERIFICATION_SEND_TITLE: string;
         EMAIL_VERIFICATION_SEND_DESC_START: string;
@@ -89,8 +86,5 @@ export declare const defaultTranslationsThirdPartyEmailPassword: {
         THIRD_PARTY_PROVIDER_DEFAULT_BTN_START: string;
         THIRD_PARTY_PROVIDER_DEFAULT_BTN_END: string;
         THIRD_PARTY_ERROR_NO_EMAIL: string;
-        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_004)": undefined;
-        "Cannot sign in / up because new email cannot be applied to existing account. Please contact support. (ERR_CODE_005)": undefined;
-        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_006)": undefined;
     };
 };

--- a/lib/build/recipe/thirdpartypasswordless/components/themes/translations.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/components/themes/translations.d.ts
@@ -57,8 +57,6 @@ export declare const defaultTranslationsThirdPartyPasswordless: {
         "Failed to generate a one time code. Please try again": undefined;
         "Phone number is invalid": undefined;
         "Email is invalid": undefined;
-        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_002)": undefined;
-        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_003)": undefined;
         BRANDING_POWERED_BY_START: string;
         BRANDING_POWERED_BY_END: string;
         SOMETHING_WENT_WRONG_ERROR: string;
@@ -71,8 +69,5 @@ export declare const defaultTranslationsThirdPartyPasswordless: {
         THIRD_PARTY_PROVIDER_DEFAULT_BTN_START: string;
         THIRD_PARTY_PROVIDER_DEFAULT_BTN_END: string;
         THIRD_PARTY_ERROR_NO_EMAIL: string;
-        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_004)": undefined;
-        "Cannot sign in / up because new email cannot be applied to existing account. Please contact support. (ERR_CODE_005)": undefined;
-        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_006)": undefined;
     };
 };

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -94,6 +94,7 @@ export declare type FormFieldBaseConfig = {
 export declare type FormField = FormFieldBaseConfig & {
     validate?: (value: any) => Promise<string | undefined>;
     optional?: boolean;
+    nonOptionalErrorMsg?: string;
 };
 export declare type APIFormField = {
     id: string;
@@ -105,6 +106,7 @@ export declare type NormalisedFormField = {
     placeholder: string;
     validate: (value: any) => Promise<string | undefined> | string | undefined;
     optional: boolean;
+    nonOptionalErrorMsg?: string;
     autoComplete?: string;
     autofocus?: boolean;
     getDefaultValue?: () => string;

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -90,11 +90,11 @@ export declare type FormFieldBaseConfig = {
     label: string;
     placeholder?: string;
     getDefaultValue?: () => string;
+    nonOptionalErrorMsg?: string;
 };
 export declare type FormField = FormFieldBaseConfig & {
     validate?: (value: any) => Promise<string | undefined>;
     optional?: boolean;
-    nonOptionalErrorMsg?: string;
 };
 export declare type APIFormField = {
     id: string;

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -251,10 +251,21 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
                     // If field error.
                     if (result.status === "FIELD_ERROR") {
                         const errorFields = result.formFields;
-
-                        setFieldStates((os) =>
-                            os.map((fs) => ({ ...fs, error: errorFields.find((ef: any) => ef.id === fs.id)?.error }))
-                        );
+                        const getErrorMessage = (fs: FieldState) => {
+                            const errorMessage = errorFields.find((ef: any) => ef.id === fs.id)?.error;
+                            if (errorMessage === "Field is not optional") {
+                                const fieldConfigData = props.formFields.find((f) => f.id === fs.id);
+                                // replace non-optional server error message from nonOptionalErrorMsg
+                                if (
+                                    fieldConfigData?.nonOptionalErrorMsg !== undefined &&
+                                    fieldConfigData?.nonOptionalErrorMsg !== ""
+                                ) {
+                                    return fieldConfigData?.nonOptionalErrorMsg;
+                                }
+                            }
+                            return errorMessage;
+                        };
+                        setFieldStates((os) => os.map((fs) => ({ ...fs, error: getErrorMessage(fs) })));
                     }
                 }
             } catch (e) {

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -256,10 +256,7 @@ export const FormBase: React.FC<FormBaseProps<any>> = (props) => {
                             if (errorMessage === "Field is not optional") {
                                 const fieldConfigData = props.formFields.find((f) => f.id === fs.id);
                                 // replace non-optional server error message from nonOptionalErrorMsg
-                                if (
-                                    fieldConfigData?.nonOptionalErrorMsg !== undefined &&
-                                    fieldConfigData?.nonOptionalErrorMsg !== ""
-                                ) {
+                                if (fieldConfigData?.nonOptionalErrorMsg !== undefined) {
                                     return fieldConfigData?.nonOptionalErrorMsg;
                                 }
                             }

--- a/lib/ts/recipe/emailpassword/utils.ts
+++ b/lib/ts/recipe/emailpassword/utils.ts
@@ -340,7 +340,7 @@ export function mergeFormFields(
 export function getFormattedFormField(field: NormalisedFormField): NormalisedFormField {
     // Fields with the 'nonOptionalErrorMsg' property must have a valid message defined
     if (field.optional === false && field.nonOptionalErrorMsg === "") {
-        throw new Error(`nonOptionalErrorMsg for field ${field.id} cannot be empty`);
+        throw new Error(`nonOptionalErrorMsg for field ${field.id} cannot be an empty string`);
     }
     return {
         ...field,

--- a/lib/ts/recipe/emailpassword/utils.ts
+++ b/lib/ts/recipe/emailpassword/utils.ts
@@ -326,10 +326,10 @@ export function mergeFormFields(
         // If new field, push to mergeFormFields.
         if (isNewField) {
             mergedFormFields.push({
-                optional: false,
                 placeholder: userField.label,
                 validate: defaultValidate,
                 ...userField,
+                optional: Boolean(userField.optional),
             });
         }
     }

--- a/lib/ts/recipe/emailpassword/utils.ts
+++ b/lib/ts/recipe/emailpassword/utils.ts
@@ -343,6 +343,9 @@ export function getFormattedFormField(field: NormalisedFormField): NormalisedFor
         validate: async (value: any): Promise<string | undefined> => {
             // Absent or not optional empty field
             if (value === "" && field.optional === false) {
+                if (field.nonOptionalErrorMsg !== undefined && field.nonOptionalErrorMsg !== "") {
+                    return field.nonOptionalErrorMsg;
+                }
                 return "ERROR_NON_OPTIONAL";
             }
 

--- a/lib/ts/recipe/emailpassword/utils.ts
+++ b/lib/ts/recipe/emailpassword/utils.ts
@@ -326,10 +326,10 @@ export function mergeFormFields(
         // If new field, push to mergeFormFields.
         if (isNewField) {
             mergedFormFields.push({
+                optional: false,
                 placeholder: userField.label,
                 validate: defaultValidate,
                 ...userField,
-                optional: Boolean(userField.optional),
             });
         }
     }

--- a/lib/ts/recipe/emailpassword/utils.ts
+++ b/lib/ts/recipe/emailpassword/utils.ts
@@ -338,12 +338,16 @@ export function mergeFormFields(
 }
 
 export function getFormattedFormField(field: NormalisedFormField): NormalisedFormField {
+    // Fields with the 'nonOptionalErrorMsg' property must have a valid message defined
+    if (field.optional === false && field.nonOptionalErrorMsg === "") {
+        throw new Error(`nonOptionalErrorMsg for field ${field.id} cannot be empty`);
+    }
     return {
         ...field,
         validate: async (value: any): Promise<string | undefined> => {
             // Absent or not optional empty field
             if (value === "" && field.optional === false) {
-                if (field.nonOptionalErrorMsg !== undefined && field.nonOptionalErrorMsg !== "") {
+                if (field.nonOptionalErrorMsg !== undefined) {
                     return field.nonOptionalErrorMsg;
                 }
                 return "ERROR_NON_OPTIONAL";

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -227,6 +227,11 @@ export type FormFieldBaseConfig = {
      *Ability to provide default value to input field.
      */
     getDefaultValue?: () => string;
+
+    /*
+     * Error message for non optional field.
+     */
+    nonOptionalErrorMsg?: string;
 };
 
 export type FormField = FormFieldBaseConfig & {
@@ -239,11 +244,6 @@ export type FormField = FormFieldBaseConfig & {
      * Whether the field is optional or not.
      */
     optional?: boolean;
-
-    /*
-     * Error message for non optional field.
-     */
-    nonOptionalErrorMsg?: string;
 };
 
 export type APIFormField = {

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -239,6 +239,11 @@ export type FormField = FormFieldBaseConfig & {
      * Whether the field is optional or not.
      */
     optional?: boolean;
+
+    /*
+     * Error message for non optional field.
+     */
+    nonOptionalErrorMsg?: string;
 };
 
 export type APIFormField = {
@@ -278,6 +283,11 @@ export type NormalisedFormField = {
      * Whether the field is optional or not.
      */
     optional: boolean;
+
+    /*
+     * Error message for non optional field.
+     */
+    nonOptionalErrorMsg?: string;
 
     /*
      * Autocomplete input.

--- a/test/end-to-end/signin.test.js
+++ b/test/end-to-end/signin.test.js
@@ -761,6 +761,8 @@ describe("SuperTokens SignIn", function () {
 
     describe("Check if nonOptionalErrorMsg works as expected", function () {
         it("Check on blank form submit nonOptionalErrorMsg gets displayed as expected", async function () {
+            await page.evaluate(() => localStorage.removeItem("SHOW_SIGNIN_DEFAULT_FIELDS"));
+
             // set cookie and reload which loads the form with custom field
             await page.evaluate(() =>
                 window.localStorage.setItem("SHOW_SIGNIN_WITH_NON_OPTIONAL_ERROR_MESSAGE", "YES")
@@ -771,7 +773,6 @@ describe("SuperTokens SignIn", function () {
 
             await submitForm(page);
             let formFieldErrors = await getFieldErrors(page);
-
             // Also standard non-optional-error is displayed if nonOptionalErrorMsg is not provided
             assert.deepStrictEqual(formFieldErrors, ["Please add email", "Field is not optional"]);
         });

--- a/test/end-to-end/signin.test.js
+++ b/test/end-to-end/signin.test.js
@@ -771,10 +771,35 @@ describe("SuperTokens SignIn", function () {
                 waitUntil: "domcontentloaded",
             });
 
-            await submitForm(page);
-            let formFieldErrors = await getFieldErrors(page);
-            // Also standard non-optional-error is displayed if nonOptionalErrorMsg is not provided
-            assert.deepStrictEqual(formFieldErrors, ["Please add email", "Field is not optional"]);
+            let apiCallMade = false;
+
+            const requestHandler = (request) => {
+                const url = request.url();
+                if (url === SIGN_IN_API) {
+                    apiCallMade = true;
+                    request.continue();
+                } else {
+                    request.continue();
+                }
+            };
+
+            await page.setRequestInterception(true);
+            page.on("request", requestHandler);
+
+            try {
+                await submitForm(page);
+                let formFieldErrors = await getFieldErrors(page);
+
+                // Also standard non-optional-error is displayed if nonOptionalErrorMsg is not provided
+                assert.deepStrictEqual(formFieldErrors, ["Please add email", "Field is not optional"]);
+            } finally {
+                page.off("request", requestHandler);
+                await page.setRequestInterception(false);
+            }
+
+            if (apiCallMade) {
+                throw new Error("Empty form making API request to signin");
+            }
         });
     });
 });

--- a/test/end-to-end/signin.test.js
+++ b/test/end-to-end/signin.test.js
@@ -758,6 +758,24 @@ describe("SuperTokens SignIn", function () {
             }
         });
     });
+
+    describe("Check if nonOptionalErrorMsg works as expected", function () {
+        it("Check on blank form submit nonOptionalErrorMsg gets displayed as expected", async function () {
+            // set cookie and reload which loads the form with custom field
+            await page.evaluate(() =>
+                window.localStorage.setItem("SHOW_SIGNIN_WITH_NON_OPTIONAL_ERROR_MESSAGE", "YES")
+            );
+            await page.reload({
+                waitUntil: "domcontentloaded",
+            });
+
+            await submitForm(page);
+            let formFieldErrors = await getFieldErrors(page);
+
+            // Also standard non-optional-error is displayed if nonOptionalErrorMsg is not provided
+            assert.deepStrictEqual(formFieldErrors, ["Please add email", "Field is not optional"]);
+        });
+    });
 });
 
 describe("SuperTokens SignIn => Server Error", function () {

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -378,7 +378,7 @@ describe("SuperTokens SignUp", function () {
             assert.deepStrictEqual(formFieldErrors, [
                 "Field is not optional",
                 "Field is not optional",
-                "Field is not optional",
+                "You must accept the terms and conditions",
             ]);
 
             // supply values for regular-required fields only
@@ -389,7 +389,7 @@ describe("SuperTokens SignUp", function () {
 
             await submitForm(page);
             formFieldErrors = await getFieldErrors(page);
-            assert.deepStrictEqual(formFieldErrors, ["Field is not optional"]);
+            assert.deepStrictEqual(formFieldErrors, ["You must accept the terms and conditions"]);
 
             // check terms and condition checkbox
             let termsCheckbox = await waitForSTElement(page, '[name="terms"]');
@@ -474,6 +474,75 @@ describe("SuperTokens SignUp", function () {
 
             if (!interceptionPassed) {
                 throw new Error("test failed");
+            }
+        });
+
+        it("Check on blank form submit nonOptionalErrorMsg gets displayed as expected", async function () {
+            await submitForm(page);
+            let formFieldErrors = await getFieldErrors(page);
+            // Also standard non-optional-error is displayed if nonOptionalErrorMsg is not provided
+            assert.deepStrictEqual(formFieldErrors, [
+                "Field is not optional",
+                "Field is not optional",
+                "You must accept the terms and conditions",
+            ]);
+        });
+
+        it("Check if nonOptionalErrorMsg overwrites server error message for non-optional fields", async function () {
+            const requestHandler = (request) => {
+                if (request.method() === "POST" && request.url() === SIGN_UP_API) {
+                    request.respond({
+                        status: 200,
+                        contentType: "application/json",
+                        headers: {
+                            "access-control-allow-origin": TEST_CLIENT_BASE_URL,
+                            "access-control-allow-credentials": "true",
+                        },
+                        body: JSON.stringify({
+                            status: "FIELD_ERROR",
+                            formFields: [
+                                {
+                                    id: "select-dropdown",
+                                    error: "Field is not optional",
+                                },
+                                {
+                                    id: "email",
+                                    error: "Field is not optional",
+                                },
+                            ],
+                        }),
+                    });
+                } else {
+                    request.continue();
+                }
+            };
+
+            try {
+                await page.setRequestInterception(true);
+                page.on("request", requestHandler);
+
+                // Fill and submit the form with custom fields
+                await setInputValues(page, [
+                    { name: "email", value: "john.doe@supertokens.io" },
+                    { name: "password", value: "Str0ngP@assw0rd" },
+                ]);
+                // Check terms and condition checkbox
+                let termsCheckbox = await waitForSTElement(page, '[name="terms"]');
+                await page.evaluate((e) => e.click(), termsCheckbox);
+
+                // Perform the button click and wait for all network activity to finish
+                await Promise.all([page.waitForNetworkIdle(), submitForm(page)]);
+
+                await waitForSTElement(page, "[data-supertokens~='inputErrorMessage']");
+                // should also show the server error message if nonOptionalErrorMsg is not provided
+                let formFieldsErrors = await getFieldErrors(page);
+                assert.deepStrictEqual(formFieldsErrors, [
+                    "Field is not optional",
+                    "Select dropdown is not an optional",
+                ]);
+            } finally {
+                page.off("request", requestHandler);
+                await page.setRequestInterception(false);
             }
         });
     });

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -493,9 +493,6 @@ describe("SuperTokens SignUp", function () {
             await page.setRequestInterception(true);
             page.on("request", requestHandler);
 
-            // Listen for all network requests
-            page.on("request", (request) => {});
-
             try {
                 // Fill and submit the form with custom fields
                 await submitForm(page);

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -749,7 +749,7 @@ describe("SuperTokens SignUp", function () {
         });
 
         it("Check if empty string for nonOptionalErrorMsg throws error", async function () {
-            const expectedErrorMessage = "nonOptionalErrorMsg for field city cannot be empty";
+            const expectedErrorMessage = "nonOptionalErrorMsg for field city cannot be an empty string";
             let pageErrorMessage = "";
             page.on("pageerror", (err) => {
                 pageErrorMessage = err.message;

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -706,6 +706,7 @@ describe("SuperTokens SignUp", function () {
         });
 
         it("Check if incorrect getDefaultValue throws error", async function () {
+            await page.evaluate(() => window.localStorage.setItem("INCORRECT_GETDEFAULT", "YES"));
             let pageErrorMessage = "";
             page.on("pageerror", (err) => {
                 pageErrorMessage = err.message;
@@ -724,6 +725,7 @@ describe("SuperTokens SignUp", function () {
         });
 
         it("Check if non-string params to onChange throws error", async function () {
+            await page.evaluate(() => window.localStorage.removeItem("INCORRECT_GETDEFAULT"));
             await page.evaluate(() => window.localStorage.setItem("INCORRECT_ONCHANGE", "YES"));
             await page.reload({
                 waitUntil: "domcontentloaded",
@@ -744,6 +746,30 @@ describe("SuperTokens SignUp", function () {
                 pageErrorMessage.includes(expectedErrorMessage),
                 `Expected "${expectedErrorMessage}" to be included in page-error`
             );
+        });
+
+        it("Check if empty string for nonOptionalErrorMsg throws error", async function () {
+            const expectedErrorMessage = "nonOptionalErrorMsg for field city cannot be empty";
+            let pageErrorMessage = "";
+            page.on("pageerror", (err) => {
+                pageErrorMessage = err.message;
+            });
+
+            await page.evaluate(() => window.localStorage.removeItem("INCORRECT_GETDEFAULT"));
+            await page.evaluate(() => window.localStorage.removeItem("INCORRECT_ONCHANGE"));
+            await page.evaluate(() => window.localStorage.setItem("INCORRECT_NON_OPTIONAL_ERROR_MSG", "YES"));
+            await page.reload({
+                waitUntil: "domcontentloaded",
+            });
+
+            if (pageErrorMessage !== "") {
+                assert(
+                    pageErrorMessage.includes(expectedErrorMessage),
+                    `Expected "${expectedErrorMessage}" to be included in page-error`
+                );
+            } else {
+                throw "Empty nonOptionalErrorMsg should throw error";
+            }
         });
     });
 });

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -343,6 +343,7 @@ function getEmailPasswordConfigs() {
                     {
                         id: "email",
                         label: "Email",
+                        nonOptionalErrorMsg: "Please add your email",
                         getDefaultValue: () => "abc@xyz.com",
                     },
                 ],

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -384,6 +384,7 @@ function getEmailPasswordConfigs() {
                         id: "terms",
                         label: "",
                         optional: false,
+                        nonOptionalErrorMsg: "Please check Terms and conditions",
                         getDefaultValue: () => "true",
                         inputComponent: (inputProps) => (
                             <div


### PR DESCRIPTION
## Summary of change

Modified the sign-in and sign-up form fields to accept a new property: `nonOptionalErrorMsg`. 
This allows for the display of a custom error message specified by the user, instead of the default `Field is not Optional` message, for fields that are mandatory.

## Related issues

-   [Field decorators #36](https://github.com/supertokens/supertokens-auth-react/issues/36)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [x] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`

## Remaining TODOs for this PR

- [ ] Check in all backend SDKs that "Field is not optional" is the right message that's returned from the backend.