### PR TITLE
fix: display required indicator only for non-empty labels and Improve test structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ ThirdPartyEmailPassword.init({
                     label: "",
                     optional: false,
                     getDefaultValue: () => "true",
-                    optional: false,
                     nonOptionalErrorMsg: "You must accept the terms and conditions",
                     inputComponent: ({ name, onChange, value }) => (
                         <div

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   Email-Password and Third-Party Email Password Recipes Enhancements:
-    -   Introduced the capability to utilize custom components in the Email-Password by exposing inputComponent types.
+-   Email-Password and Third-Party Email Password Recipes Enhancements as follows:
+    -   Introduced the capability to utilize custom components by exposing inputComponent types.
     -   Allow setting default values in signup/signin form fields.
     -   Made onChange prop in inputComponent simpler by removing the need for an id attribute.
     -   Added a feature to customize the "Field is not optional" error message for each form field with the nonOptionalErrorMsg prop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## [0.35.7] - 2023-10-30
+## [0.35.7] - 2023-11-16
 
 ### Added
 
--   Introduced the capability to utilize custom components in the Email-Password based recipes' signup form fields by exposing inputComponent types.
--   Implemented the functionality to assign default values to the form fields in the Email-Password based recipes.
--   Simplified onChange prop usage in inputComponent - id attribute removed.
+-   Email-Password and Third-Party Email Password Recipes Enhancements:
+    -   Introduced the capability to utilize custom components in the Email-Password by exposing inputComponent types.
+    -   Allow setting default values in signup/signin form fields.
+    -   Made onChange prop in inputComponent simpler by removing the need for an id attribute.
+    -   Added a feature to customize the "Field is not optional" error message for each form field with the nonOptionalErrorMsg prop.
 
 Following is an example of how to use above features.
 
@@ -24,6 +26,7 @@ EmailPassword.init({
                     id: "select-dropdown",
                     label: "Select Option",
                     getDefaultValue: () => "option 2",
+                    nonOptionalErrorMsg: "Select dropdown is required",
                     inputComponent: ({ value, name, onChange }) => (
                         <select
                             value={value}
@@ -37,6 +40,39 @@ EmailPassword.init({
                             <option value="option 2">Option 2</option>
                             <option value="option 3">Option 3</option>
                         </select>
+                    ),
+                },
+            ],
+        },
+    },
+});
+
+ThirdPartyEmailPassword.init({
+    signInAndUpFeature: {
+        signUpForm: {
+            formFields: [
+                {
+                    id: "terms",
+                    label: "",
+                    optional: false,
+                    getDefaultValue: () => "true",
+                    optional: false,
+                    nonOptionalErrorMsg: "You must accept the terms and conditions",
+                    inputComponent: ({ name, onChange, value }) => (
+                        <div
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "left",
+                            }}>
+                            <input
+                                value={value}
+                                checked={value === "true"}
+                                name={name}
+                                type="checkbox"
+                                onChange={(e) => onChange(e.target.checked.toString())}></input>
+                            <span style={{ marginLeft: 5 }}>I agree to the terms and conditions</span>
+                        </div>
                     ),
                 },
             ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   Email-Password and Third-Party Email Password Recipes Enhancements as follows:
-    -   Introduced the capability to utilize custom components by exposing inputComponent types.
+-   EmailPassword and ThirdPartyEmailPassword recipe enhancements:
+    -   Introduced the capability to utilize custom components by exposing `inputComponent` types.
     -   Allow setting default values in signup/signin form fields.
-    -   Made onChange prop in inputComponent simpler by removing the need for an id attribute.
-    -   Added a feature to customize the "Field is not optional" error message for each form field with the nonOptionalErrorMsg prop.
+    -   Made the `onChange` prop in `inputComponent` simpler by removing the need for an `id` attribute.
+    -   Added a feature to customize the "Field is not optional" error message for each form field with the `nonOptionalErrorMsg` prop.
 
 Following is an example of how to use above features.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## [0.36.0] - 2023-10-30
+## [0.35.7] - 2023-10-30
 
 ### Added
 

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -753,7 +753,7 @@ function getSignInFormFields(formType) {
                 },
             ];
         default:
-            return [];
+            return;
     }
 }
 

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -713,29 +713,36 @@ function getEmailVerificationConfigs({ disableDefaultUI }) {
     });
 }
 
-function getSignUpFormFields() {
-    if (localStorage.getItem("SHOW_INCORRECT_FIELDS") === "YES") {
-        if (localStorage.getItem("INCORRECT_ONCHANGE") === "YES") {
+function getSignUpFormFields(formFieldConfig) {
+    const {
+        showIncorrectFields,
+        incorrectOnChange,
+        incorrectNonOptionalErrorMsg,
+        incorrectGetDefault,
+        customFieldsWithDefault,
+        showCustomFields,
+    } = formFieldConfig;
+    if (showIncorrectFields === "YES") {
+        if (incorrectOnChange === "YES") {
             // since page-error blocks all the other errors
             // use this filter to test specific error
             return incorrectFormFields.filter(({ id }) => id === "terms");
-        } else if (localStorage.getItem("INCORRECT_NON_OPTIONAL_ERROR_MSG") === "YES") {
+        } else if (incorrectNonOptionalErrorMsg === "YES") {
             return incorrectFormFields.filter(({ id }) => id === "city");
-        } else if (localStorage.getItem("INCORRECT_GETDEFAULT") === "YES") {
+        } else if (incorrectGetDefault === "YES") {
             return incorrectFormFields.filter(({ id }) => id === "country");
         }
         return incorrectFormFields;
-    } else if (localStorage.getItem("SHOW_CUSTOM_FIELDS_WITH_DEFAULT_VALUES") === "YES") {
+    } else if (customFieldsWithDefault === "YES") {
         return formFieldsWithDefault;
-    } else if (localStorage.getItem("SHOW_CUSTOM_FIELDS") === "YES") {
+    } else if (showCustomFields === "YES") {
         return customFields;
     }
     return formFields;
 }
 
-function getSignInFormFields() {
-    let showDefaultFields = localStorage.getItem("SHOW_SIGNIN_DEFAULT_FIELDS");
-    let showFieldsWithNonOptionalErrMsg = localStorage.getItem("SHOW_SIGNIN_WITH_NON_OPTIONAL_ERROR_MESSAGE");
+function getSignInFormFields(signInFormFieldConfig) {
+    const { showDefaultFields, showFieldsWithNonOptionalErrMsg } = signInFormFieldConfig;
     if (showDefaultFields === "YES") {
         return [
             {
@@ -758,7 +765,7 @@ function getSignInFormFields() {
     return [];
 }
 
-function getEmailPasswordConfigs({ disableDefaultUI }) {
+function getEmailPasswordConfigs({ disableDefaultUI, signUpFormFieldConfig, signInFormFieldConfig }) {
     return EmailPassword.init({
         style: `          
             [data-supertokens~=container] {
@@ -838,13 +845,13 @@ function getEmailPasswordConfigs({ disableDefaultUI }) {
             defaultToSignUp,
             signInForm: {
                 style: theme,
-                formFields: getSignInFormFields(),
+                formFields: getSignInFormFields(signInFormFieldConfig),
             },
             signUpForm: {
                 style: theme,
                 privacyPolicyLink: "https://supertokens.com/legal/privacy-policy",
                 termsOfServiceLink: "https://supertokens.com/legal/terms-and-conditions",
-                formFields: getSignUpFormFields(),
+                formFields: getSignUpFormFields(signUpFormFieldConfig),
             },
         },
     });
@@ -1188,7 +1195,13 @@ function getThirdPartyConfigs({ staticProviderList, disableDefaultUI, thirdParty
     });
 }
 
-function getThirdPartyEmailPasswordConfigs({ staticProviderList, disableDefaultUI, thirdPartyRedirectURL }) {
+function getThirdPartyEmailPasswordConfigs({
+    staticProviderList,
+    disableDefaultUI,
+    thirdPartyRedirectURL,
+    signUpFormFieldConfig,
+    signInFormFieldConfig,
+}) {
     let providers = [
         ThirdParty.Github.init(),
         ThirdParty.Google.init(),
@@ -1368,10 +1381,10 @@ function getThirdPartyEmailPasswordConfigs({ staticProviderList, disableDefaultU
         signInAndUpFeature: {
             disableDefaultUI,
             signInForm: {
-                formFields: getSignInFormFields(),
+                formFields: getSignInFormFields(signInFormFieldConfig),
             },
             signUpForm: {
-                formFields: getSignUpFormFields(),
+                formFields: getSignUpFormFields(signUpFormFieldConfig),
                 privacyPolicyLink: "https://supertokens.com/legal/privacy-policy",
                 termsOfServiceLink: "https://supertokens.com/legal/terms-and-conditions",
             },

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -713,59 +713,51 @@ function getEmailVerificationConfigs({ disableDefaultUI }) {
     });
 }
 
-function getSignUpFormFields(formFieldConfig) {
-    const {
-        showIncorrectFields,
-        incorrectOnChange,
-        incorrectNonOptionalErrorMsg,
-        incorrectGetDefault,
-        customFieldsWithDefault,
-        showCustomFields,
-    } = formFieldConfig;
-    if (showIncorrectFields === "YES") {
-        if (incorrectOnChange === "YES") {
-            // since page-error blocks all the other errors
-            // use this filter to test specific error
+function getSignUpFormFields(formType) {
+    switch (formType) {
+        case "INCORRECT_FIELDS":
+            return incorrectFormFields;
+        case "INCORRECT_ONCHANGE":
             return incorrectFormFields.filter(({ id }) => id === "terms");
-        } else if (incorrectNonOptionalErrorMsg === "YES") {
+        case "INCORRECT_NON_OPTIONAL_ERROR_MSG":
             return incorrectFormFields.filter(({ id }) => id === "city");
-        } else if (incorrectGetDefault === "YES") {
+        case "INCORRECT_GETDEFAULT":
             return incorrectFormFields.filter(({ id }) => id === "country");
-        }
-        return incorrectFormFields;
-    } else if (customFieldsWithDefault === "YES") {
-        return formFieldsWithDefault;
-    } else if (showCustomFields === "YES") {
-        return customFields;
+        case "CUSTOM_FIELDS_WITH_DEFAULT_VALUES":
+            return formFieldsWithDefault;
+        case "CUSTOM_FIELDS":
+            return customFields;
+        default:
+            return formFields;
     }
-    return formFields;
 }
 
-function getSignInFormFields(signInFormFieldConfig) {
-    const { showDefaultFields, showFieldsWithNonOptionalErrMsg } = signInFormFieldConfig;
-    if (showDefaultFields === "YES") {
-        return [
-            {
-                id: "email",
-                getDefaultValue: () => "abc@xyz.com",
-            },
-            {
-                id: "password",
-                getDefaultValue: () => "fakepassword123",
-            },
-        ];
-    } else if (showFieldsWithNonOptionalErrMsg === "YES") {
-        return [
-            {
-                id: "email",
-                nonOptionalErrorMsg: "Please add email",
-            },
-        ];
+function getSignInFormFields(formType) {
+    switch (formType) {
+        case "DEFAULT_FIELDS":
+            return [
+                {
+                    id: "email",
+                    getDefaultValue: () => "abc@xyz.com",
+                },
+                {
+                    id: "password",
+                    getDefaultValue: () => "fakepassword123",
+                },
+            ];
+        case "FIELDS_WITH_NON_OPTIONAL_ERROR_MESSAGE":
+            return [
+                {
+                    id: "email",
+                    nonOptionalErrorMsg: "Please add email",
+                },
+            ];
+        default:
+            return [];
     }
-    return [];
 }
 
-function getEmailPasswordConfigs({ disableDefaultUI, signUpFormFieldConfig, signInFormFieldConfig }) {
+function getEmailPasswordConfigs({ disableDefaultUI, formFieldType }) {
     return EmailPassword.init({
         style: `          
             [data-supertokens~=container] {
@@ -845,13 +837,13 @@ function getEmailPasswordConfigs({ disableDefaultUI, signUpFormFieldConfig, sign
             defaultToSignUp,
             signInForm: {
                 style: theme,
-                formFields: getSignInFormFields(signInFormFieldConfig),
+                formFields: getSignInFormFields(formFieldType.signIn),
             },
             signUpForm: {
                 style: theme,
                 privacyPolicyLink: "https://supertokens.com/legal/privacy-policy",
                 termsOfServiceLink: "https://supertokens.com/legal/terms-and-conditions",
-                formFields: getSignUpFormFields(signUpFormFieldConfig),
+                formFields: getSignUpFormFields(formFieldType.signUp),
             },
         },
     });
@@ -1199,8 +1191,7 @@ function getThirdPartyEmailPasswordConfigs({
     staticProviderList,
     disableDefaultUI,
     thirdPartyRedirectURL,
-    signUpFormFieldConfig,
-    signInFormFieldConfig,
+    formFieldType,
 }) {
     let providers = [
         ThirdParty.Github.init(),
@@ -1381,10 +1372,10 @@ function getThirdPartyEmailPasswordConfigs({
         signInAndUpFeature: {
             disableDefaultUI,
             signInForm: {
-                formFields: getSignInFormFields(signInFormFieldConfig),
+                formFields: getSignInFormFields(formFieldType.signIn),
             },
             signUpForm: {
-                formFields: getSignUpFormFields(signUpFormFieldConfig),
+                formFields: getSignUpFormFields(formFieldType.signUp),
                 privacyPolicyLink: "https://supertokens.com/legal/privacy-policy",
                 termsOfServiceLink: "https://supertokens.com/legal/terms-and-conditions",
             },

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -713,7 +713,7 @@ function getEmailVerificationConfigs({ disableDefaultUI }) {
     });
 }
 
-function getFormFields() {
+function getSignUpFormFields() {
     if (localStorage.getItem("SHOW_INCORRECT_FIELDS") === "YES") {
         if (localStorage.getItem("INCORRECT_ONCHANGE") === "YES") {
             // since page-error blocks all the other errors
@@ -737,29 +737,25 @@ function getSignInFormFields() {
     let showDefaultFields = localStorage.getItem("SHOW_SIGNIN_DEFAULT_FIELDS");
     let showFieldsWithNonOptionalErrMsg = localStorage.getItem("SHOW_SIGNIN_WITH_NON_OPTIONAL_ERROR_MESSAGE");
     if (showDefaultFields === "YES") {
-        return {
-            formFields: [
-                {
-                    id: "email",
-                    getDefaultValue: () => "abc@xyz.com",
-                },
-                {
-                    id: "password",
-                    getDefaultValue: () => "fakepassword123",
-                },
-            ],
-        };
+        return [
+            {
+                id: "email",
+                getDefaultValue: () => "abc@xyz.com",
+            },
+            {
+                id: "password",
+                getDefaultValue: () => "fakepassword123",
+            },
+        ];
     } else if (showFieldsWithNonOptionalErrMsg === "YES") {
-        return {
-            formFields: [
-                {
-                    id: "email",
-                    nonOptionalErrorMsg: "Please add email",
-                },
-            ],
-        };
+        return [
+            {
+                id: "email",
+                nonOptionalErrorMsg: "Please add email",
+            },
+        ];
     }
-    return {};
+    return [];
 }
 
 function getEmailPasswordConfigs({ disableDefaultUI }) {
@@ -842,13 +838,13 @@ function getEmailPasswordConfigs({ disableDefaultUI }) {
             defaultToSignUp,
             signInForm: {
                 style: theme,
-                ...getSignInFormFields(),
+                formFields: getSignInFormFields(),
             },
             signUpForm: {
                 style: theme,
                 privacyPolicyLink: "https://supertokens.com/legal/privacy-policy",
                 termsOfServiceLink: "https://supertokens.com/legal/terms-and-conditions",
-                formFields: getFormFields(),
+                formFields: getSignUpFormFields(),
             },
         },
     });
@@ -1372,10 +1368,10 @@ function getThirdPartyEmailPasswordConfigs({ staticProviderList, disableDefaultU
         signInAndUpFeature: {
             disableDefaultUI,
             signInForm: {
-                ...getSignInFormFields(),
+                formFields: getSignInFormFields(),
             },
             signUpForm: {
-                formFields: getFormFields(),
+                formFields: getSignUpFormFields(),
                 privacyPolicyLink: "https://supertokens.com/legal/privacy-policy",
                 termsOfServiceLink: "https://supertokens.com/legal/terms-and-conditions",
             },

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -306,7 +306,7 @@ const customFields = [
     },
     {
         id: "terms",
-        label: "",
+        label: "   ",
         optional: false,
         nonOptionalErrorMsg: "You must accept the terms and conditions",
         inputComponent: ({ name, onChange }) => (

--- a/examples/for-tests/src/testContext.js
+++ b/examples/for-tests/src/testContext.js
@@ -14,17 +14,9 @@ export function getTestContext() {
         staticProviderList: localStorage.getItem("staticProviderList"),
         mockTenantId: localStorage.getItem("mockTenantId"),
         clientType: localStorage.getItem("clientType") || undefined,
-        signUpFormFieldConfig: {
-            showIncorrectFields: localStorage.getItem("SHOW_INCORRECT_FIELDS"),
-            incorrectOnChange: localStorage.getItem("INCORRECT_ONCHANGE"),
-            incorrectNonOptionalErrorMsg: localStorage.getItem("INCORRECT_NON_OPTIONAL_ERROR_MSG"),
-            incorrectGetDefault: localStorage.getItem("INCORRECT_GETDEFAULT"),
-            customFieldsWithDefault: localStorage.getItem("SHOW_CUSTOM_FIELDS_WITH_DEFAULT_VALUES"),
-            showCustomFields: localStorage.getItem("SHOW_CUSTOM_FIELDS"),
-        },
-        signInFormFieldConfig: {
-            showDefaultFields: localStorage.getItem("SHOW_SIGNIN_DEFAULT_FIELDS"),
-            showFieldsWithNonOptionalErrMsg: localStorage.getItem("SHOW_SIGNIN_WITH_NON_OPTIONAL_ERROR_MESSAGE"),
+        formFieldType: {
+            signIn: localStorage.getItem("SIGNIN_SETTING_TYPE"),
+            signUp: localStorage.getItem("SIGNUP_SETTING_TYPE"),
         },
     };
     return ret;

--- a/examples/for-tests/src/testContext.js
+++ b/examples/for-tests/src/testContext.js
@@ -14,6 +14,18 @@ export function getTestContext() {
         staticProviderList: localStorage.getItem("staticProviderList"),
         mockTenantId: localStorage.getItem("mockTenantId"),
         clientType: localStorage.getItem("clientType") || undefined,
+        signUpFormFieldConfig: {
+            showIncorrectFields: localStorage.getItem("SHOW_INCORRECT_FIELDS"),
+            incorrectOnChange: localStorage.getItem("INCORRECT_ONCHANGE"),
+            incorrectNonOptionalErrorMsg: localStorage.getItem("INCORRECT_NON_OPTIONAL_ERROR_MSG"),
+            incorrectGetDefault: localStorage.getItem("INCORRECT_GETDEFAULT"),
+            customFieldsWithDefault: localStorage.getItem("SHOW_CUSTOM_FIELDS_WITH_DEFAULT_VALUES"),
+            showCustomFields: localStorage.getItem("SHOW_CUSTOM_FIELDS"),
+        },
+        signInFormFieldConfig: {
+            showDefaultFields: localStorage.getItem("SHOW_SIGNIN_DEFAULT_FIELDS"),
+            showFieldsWithNonOptionalErrMsg: localStorage.getItem("SHOW_SIGNIN_WITH_NON_OPTIONAL_ERROR_MESSAGE"),
+        },
     };
     return ret;
 }

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -425,7 +425,7 @@ function Label(_a) {
         "div",
         genericComponentOverrideContext.__assign(
             { "data-supertokens": "label" },
-            { children: [t(value), showIsRequired && value.trim() !== "" && " *"] }
+            { children: [t(value), showIsRequired && value && value.trim() !== "" && " *"] }
         )
     );
 }

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -425,7 +425,7 @@ function Label(_a) {
         "div",
         genericComponentOverrideContext.__assign(
             { "data-supertokens": "label" },
-            { children: [t(value), showIsRequired && " *"] }
+            { children: [t(value), showIsRequired && value !== "" && " *"] }
         )
     );
 }

--- a/lib/build/emailpassword-shared7.js
+++ b/lib/build/emailpassword-shared7.js
@@ -425,7 +425,7 @@ function Label(_a) {
         "div",
         genericComponentOverrideContext.__assign(
             { "data-supertokens": "label" },
-            { children: [t(value), showIsRequired && value !== "" && " *"] }
+            { children: [t(value), showIsRequired && value.trim() !== "" && " *"] }
         )
     );
 }

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.36.0";
+export declare const package_version = "0.35.7";

--- a/lib/ts/recipe/emailpassword/components/library/label.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/label.tsx
@@ -26,7 +26,7 @@ export default function Label({ value, showIsRequired }: LabelProps): JSX.Elemen
     return (
         <div data-supertokens="label">
             {t(value)}
-            {showIsRequired && " *"}
+            {showIsRequired && value !== "" && " *"}
         </div>
     );
 }

--- a/lib/ts/recipe/emailpassword/components/library/label.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/label.tsx
@@ -26,7 +26,7 @@ export default function Label({ value, showIsRequired }: LabelProps): JSX.Elemen
     return (
         <div data-supertokens="label">
             {t(value)}
-            {showIsRequired && value.trim() !== "" && " *"}
+            {showIsRequired && value && value.trim() !== "" && " *"}
         </div>
     );
 }

--- a/lib/ts/recipe/emailpassword/components/library/label.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/label.tsx
@@ -26,7 +26,7 @@ export default function Label({ value, showIsRequired }: LabelProps): JSX.Elemen
     return (
         <div data-supertokens="label">
             {t(value)}
-            {showIsRequired && value !== "" && " *"}
+            {showIsRequired && value.trim() !== "" && " *"}
         </div>
     );
 }

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.36.0";
+export const package_version = "0.35.7";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.36.0",
+    "version": "0.35.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.36.0",
+            "version": "0.35.7",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.36.0",
+    "version": "0.35.7",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {

--- a/test/end-to-end/signin.test.js
+++ b/test/end-to-end/signin.test.js
@@ -773,8 +773,6 @@ describe("SuperTokens SignIn", function () {
                     request.continue();
                 }
             };
-
-            await page.setRequestInterception(true);
             page.on("request", requestHandler);
 
             try {
@@ -785,7 +783,6 @@ describe("SuperTokens SignIn", function () {
                 assert.deepStrictEqual(formFieldErrors, ["Please add email", "Field is not optional"]);
             } finally {
                 page.off("request", requestHandler);
-                await page.setRequestInterception(false);
             }
 
             assert.ok(!apiCallMade, "Empty form making API request to signin");

--- a/test/end-to-end/signin.test.js
+++ b/test/end-to-end/signin.test.js
@@ -671,7 +671,7 @@ describe("SuperTokens SignIn", function () {
         });
     });
 
-    describe("SignIn default field tests", function () {
+    describe("Default fields", function () {
         it("Should contain email and password fields prefilled", async function () {
             await page.evaluate(() => window.localStorage.setItem("SHOW_SIGNIN_DEFAULT_FIELDS", "YES"));
 
@@ -750,8 +750,8 @@ describe("SuperTokens SignIn", function () {
         });
     });
 
-    describe("Check if nonOptionalErrorMsg works as expected", function () {
-        it("Check on blank form submit nonOptionalErrorMsg gets displayed as expected", async function () {
+    describe("nonOptionalErrorMsg", function () {
+        it("Should be displayed on a blank form submit", async function () {
             await page.evaluate(() => localStorage.removeItem("SHOW_SIGNIN_DEFAULT_FIELDS"));
 
             // set cookie and reload which loads the form with custom field

--- a/test/end-to-end/signin.test.js
+++ b/test/end-to-end/signin.test.js
@@ -673,7 +673,7 @@ describe("SuperTokens SignIn", function () {
 
     describe("Default fields", function () {
         it("Should contain email and password fields prefilled", async function () {
-            await page.evaluate(() => window.localStorage.setItem("SHOW_SIGNIN_DEFAULT_FIELDS", "YES"));
+            await page.evaluate(() => window.localStorage.setItem("SIGNIN_SETTING_TYPE", "DEFAULT_FIELDS"));
 
             await page.reload({
                 waitUntil: "domcontentloaded",
@@ -694,7 +694,7 @@ describe("SuperTokens SignIn", function () {
         });
 
         it("Should have default values in the signin request payload", async function () {
-            await page.evaluate(() => window.localStorage.setItem("SHOW_SIGNIN_DEFAULT_FIELDS", "YES"));
+            await page.evaluate(() => window.localStorage.setItem("SIGNIN_SETTING_TYPE", "DEFAULT_FIELDS"));
 
             await page.reload({
                 waitUntil: "domcontentloaded",
@@ -752,11 +752,11 @@ describe("SuperTokens SignIn", function () {
 
     describe("nonOptionalErrorMsg", function () {
         it("Should be displayed on a blank form submit", async function () {
-            await page.evaluate(() => localStorage.removeItem("SHOW_SIGNIN_DEFAULT_FIELDS"));
+            // await page.evaluate(() => localStorage.removeItem("SHOW_SIGNIN_DEFAULT_FIELDS"));
 
             // set cookie and reload which loads the form with custom field
             await page.evaluate(() =>
-                window.localStorage.setItem("SHOW_SIGNIN_WITH_NON_OPTIONAL_ERROR_MESSAGE", "YES")
+                window.localStorage.setItem("SIGNIN_SETTING_TYPE", "FIELDS_WITH_NON_OPTIONAL_ERROR_MESSAGE")
             );
             await page.reload({
                 waitUntil: "domcontentloaded",

--- a/test/end-to-end/signin.test.js
+++ b/test/end-to-end/signin.test.js
@@ -752,8 +752,6 @@ describe("SuperTokens SignIn", function () {
 
     describe("nonOptionalErrorMsg", function () {
         it("Should be displayed on a blank form submit", async function () {
-            // await page.evaluate(() => localStorage.removeItem("SHOW_SIGNIN_DEFAULT_FIELDS"));
-
             // set cookie and reload which loads the form with custom field
             await page.evaluate(() =>
                 window.localStorage.setItem("SIGNIN_SETTING_TYPE", "FIELDS_WITH_NON_OPTIONAL_ERROR_MESSAGE")

--- a/test/end-to-end/signin.test.js
+++ b/test/end-to-end/signin.test.js
@@ -714,11 +714,8 @@ describe("SuperTokens SignIn", function () {
                         const postData = JSON.parse(request.postData());
                         expectedDefautlValues.forEach(({ id, value }) => {
                             let findFormData = postData.formFields.find((inputData) => inputData.id === id);
-                            if (findFormData) {
-                                assert.strictEqual(findFormData["value"], value, `Mismatch in payload for key: ${id}`);
-                            } else {
-                                throw new Error("Field not found in req.data");
-                            }
+                            assert.ok(findFormData, "Field not found in req.data");
+                            assert.strictEqual(findFormData["value"], value, `Mismatch in payload for key: ${id}`);
                         });
                         interceptionPassed = true;
                         return request.respond({
@@ -748,14 +745,8 @@ describe("SuperTokens SignIn", function () {
                 page.off("request", requestHandler);
                 await page.setRequestInterception(false);
             }
-
-            if (assertionError) {
-                throw assertionError;
-            }
-
-            if (!interceptionPassed) {
-                throw new Error("test failed");
-            }
+            assert.ok(!assertionError, assertionError?.message);
+            assert.ok(interceptionPassed, "Test Failed");
         });
     });
 
@@ -797,9 +788,7 @@ describe("SuperTokens SignIn", function () {
                 await page.setRequestInterception(false);
             }
 
-            if (apiCallMade) {
-                throw new Error("Empty form making API request to signin");
-            }
+            assert.ok(!apiCallMade, "Empty form making API request to signin");
         });
     });
 });

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -348,7 +348,7 @@ describe("SuperTokens SignUp", function () {
     describe("Custom fields tests", function () {
         beforeEach(async function () {
             // set cookie and reload which loads the form with custom field
-            await page.evaluate(() => window.localStorage.setItem("SHOW_CUSTOM_FIELDS", "YES"));
+            await page.evaluate(() => window.localStorage.setItem("SIGNUP_SETTING_TYPE", "CUSTOM_FIELDS"));
 
             await page.reload({
                 waitUntil: "domcontentloaded",
@@ -570,7 +570,9 @@ describe("SuperTokens SignUp", function () {
     describe("Default fields tests", function () {
         beforeEach(async function () {
             // set cookie and reload which loads the form fields with default values
-            await page.evaluate(() => window.localStorage.setItem("SHOW_CUSTOM_FIELDS_WITH_DEFAULT_VALUES", "YES"));
+            await page.evaluate(() =>
+                window.localStorage.setItem("SIGNUP_SETTING_TYPE", "CUSTOM_FIELDS_WITH_DEFAULT_VALUES")
+            );
 
             await page.reload({
                 waitUntil: "domcontentloaded",
@@ -684,7 +686,7 @@ describe("SuperTokens SignUp", function () {
     describe("Incorrect field config test", function () {
         beforeEach(async function () {
             // set cookie and reload which loads the form fields with default values
-            await page.evaluate(() => window.localStorage.setItem("SHOW_INCORRECT_FIELDS", "YES"));
+            await page.evaluate(() => window.localStorage.setItem("SIGNUP_SETTING_TYPE", "INCORRECT_FIELDS"));
 
             await page.reload({
                 waitUntil: "domcontentloaded",
@@ -692,7 +694,7 @@ describe("SuperTokens SignUp", function () {
         });
 
         it("Should throw error for incorrect getDefaultValue func call", async function () {
-            await page.evaluate(() => window.localStorage.setItem("INCORRECT_GETDEFAULT", "YES"));
+            await page.evaluate(() => window.localStorage.setItem("SIGNUP_SETTING_TYPE", "INCORRECT_GETDEFAULT"));
             let pageErrorMessage = "";
             page.on("pageerror", (err) => {
                 pageErrorMessage = err.message;
@@ -711,8 +713,7 @@ describe("SuperTokens SignUp", function () {
         });
 
         it("Should throw error for non-string params to onChange", async function () {
-            await page.evaluate(() => window.localStorage.removeItem("INCORRECT_GETDEFAULT"));
-            await page.evaluate(() => window.localStorage.setItem("INCORRECT_ONCHANGE", "YES"));
+            await page.evaluate(() => window.localStorage.setItem("SIGNUP_SETTING_TYPE", "INCORRECT_ONCHANGE"));
             await page.reload({
                 waitUntil: "domcontentloaded",
             });
@@ -741,9 +742,11 @@ describe("SuperTokens SignUp", function () {
                 pageErrorMessage = err.message;
             });
 
-            await page.evaluate(() => window.localStorage.removeItem("INCORRECT_GETDEFAULT"));
-            await page.evaluate(() => window.localStorage.removeItem("INCORRECT_ONCHANGE"));
-            await page.evaluate(() => window.localStorage.setItem("INCORRECT_NON_OPTIONAL_ERROR_MSG", "YES"));
+            // await page.evaluate(() => window.localStorage.removeItem("INCORRECT_GETDEFAULT"));
+            // await page.evaluate(() => window.localStorage.removeItem("INCORRECT_ONCHANGE"));
+            await page.evaluate(() =>
+                window.localStorage.setItem("SIGNUP_SETTING_TYPE", "INCORRECT_NON_OPTIONAL_ERROR_MSG")
+            );
             await page.reload({
                 waitUntil: "domcontentloaded",
             });

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -488,7 +488,6 @@ describe("SuperTokens SignUp", function () {
                 }
             };
 
-            await page.setRequestInterception(true);
             page.on("request", requestHandler);
 
             try {
@@ -503,7 +502,6 @@ describe("SuperTokens SignUp", function () {
                 ]);
             } finally {
                 page.off("request", requestHandler);
-                await page.setRequestInterception(false);
             }
 
             assert.ok(!apiCallMade, "Empty form making signup API request");

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -367,6 +367,12 @@ describe("SuperTokens SignUp", function () {
             // check if checbox is loaded
             const checkboxExists = await waitForSTElement(page, 'input[type="checkbox"]');
             assert.ok(checkboxExists, "Checkbox exists");
+
+            // check if labels are loaded correctly
+            // non-optional field with empty labels should'nt show * sign
+            const expectedLabels = ["Email *", "Password *", "Select Dropdown", ""];
+            const labelNames = await getLabelsText(page);
+            assert.deepStrictEqual(labelNames, expectedLabels);
         });
 
         it("Should show error messages, based on optional flag", async function () {

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -742,8 +742,6 @@ describe("SuperTokens SignUp", function () {
                 pageErrorMessage = err.message;
             });
 
-            // await page.evaluate(() => window.localStorage.removeItem("INCORRECT_GETDEFAULT"));
-            // await page.evaluate(() => window.localStorage.removeItem("INCORRECT_ONCHANGE"));
             await page.evaluate(() =>
                 window.localStorage.setItem("SIGNUP_SETTING_TYPE", "INCORRECT_NON_OPTIONAL_ERROR_MSG")
             );

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -345,7 +345,7 @@ describe("SuperTokens SignUp", function () {
         });
     });
 
-    describe("Signup custom fields test", function () {
+    describe("Custom fields tests", function () {
         beforeEach(async function () {
             // set cookie and reload which loads the form with custom field
             await page.evaluate(() => window.localStorage.setItem("SHOW_CUSTOM_FIELDS", "YES"));
@@ -356,7 +356,7 @@ describe("SuperTokens SignUp", function () {
             await toggleSignInSignUp(page);
         });
 
-        it("Check if the custom fields are loaded", async function () {
+        it("Should load the custom fields", async function () {
             let text = await getAuthPageHeaderText(page);
             assert.deepStrictEqual(text, "Sign Up");
 
@@ -409,7 +409,7 @@ describe("SuperTokens SignUp", function () {
             assert.deepStrictEqual(formFieldErrors, ["Please check Terms and conditions"]);
         });
 
-        it("Check if custom values are part of the signup payload", async function () {
+        it("Should be part of the signup payload", async function () {
             const customFields = {
                 terms: "true",
                 "select-dropdown": "option 3",
@@ -475,7 +475,7 @@ describe("SuperTokens SignUp", function () {
             assert.ok(interceptionPassed, "Test Failed");
         });
 
-        it("Check on blank form submit nonOptionalErrorMsg gets displayed as expected", async function () {
+        it("Should display nonOptionalErrorMsg on blank form submit", async function () {
             let apiCallMade = false;
 
             const requestHandler = (request) => {
@@ -509,7 +509,7 @@ describe("SuperTokens SignUp", function () {
             assert.ok(!apiCallMade, "Empty form making signup API request");
         });
 
-        it("Check if nonOptionalErrorMsg overwrites server error message for non-optional fields", async function () {
+        it("Should overwrite server error message for non-optional fields with nonOptionalErrorMsg", async function () {
             const requestHandler = (request) => {
                 if (request.method() === "POST" && request.url() === SIGN_UP_API) {
                     request.respond({
@@ -569,7 +569,7 @@ describe("SuperTokens SignUp", function () {
     });
 
     // Default values test
-    describe("Signup default value for fields test", function () {
+    describe("Default fields tests", function () {
         beforeEach(async function () {
             // set cookie and reload which loads the form fields with default values
             await page.evaluate(() => window.localStorage.setItem("SHOW_CUSTOM_FIELDS_WITH_DEFAULT_VALUES", "YES"));
@@ -580,7 +580,7 @@ describe("SuperTokens SignUp", function () {
             await toggleSignInSignUp(page);
         });
 
-        it("Check if default values are set already", async function () {
+        it("Should prefill the fields with default values", async function () {
             const fieldsWithDefault = {
                 country: "India",
                 "select-dropdown": "option 2",
@@ -607,7 +607,7 @@ describe("SuperTokens SignUp", function () {
             assert.strictEqual(defaultValue, fieldsWithDefault["terms"].toString());
         });
 
-        it("Check if changing the field value actually overwrites the default value", async function () {
+        it("Should be able to overwrite the default values", async function () {
             const updatedFields = {
                 country: "USA",
                 "select-dropdown": "option 3",
@@ -627,7 +627,7 @@ describe("SuperTokens SignUp", function () {
             assert.strictEqual(updatedOption, updatedFields["select-dropdown"]);
         });
 
-        it("Check if default values are getting sent in signup-payload", async function () {
+        it("Should ensure signup-payload contains default values", async function () {
             // directly submit the form and test the payload
             const expectedDefautlValues = [
                 { id: "email", value: "test@one.com" },
@@ -693,7 +693,7 @@ describe("SuperTokens SignUp", function () {
             });
         });
 
-        it("Check if incorrect getDefaultValue throws error", async function () {
+        it("Should throw error for incorrect getDefaultValue func call", async function () {
             await page.evaluate(() => window.localStorage.setItem("INCORRECT_GETDEFAULT", "YES"));
             let pageErrorMessage = "";
             page.on("pageerror", (err) => {
@@ -712,7 +712,7 @@ describe("SuperTokens SignUp", function () {
             );
         });
 
-        it("Check if non-string params to onChange throws error", async function () {
+        it("Should throw error for non-string params to onChange", async function () {
             await page.evaluate(() => window.localStorage.removeItem("INCORRECT_GETDEFAULT"));
             await page.evaluate(() => window.localStorage.setItem("INCORRECT_ONCHANGE", "YES"));
             await page.reload({
@@ -736,7 +736,7 @@ describe("SuperTokens SignUp", function () {
             );
         });
 
-        it("Check if empty string for nonOptionalErrorMsg throws error", async function () {
+        it("Should throw error for empty string for nonOptionalErrorMsg", async function () {
             const expectedErrorMessage = "nonOptionalErrorMsg for field city cannot be an empty string";
             let pageErrorMessage = "";
             page.on("pageerror", (err) => {

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -423,15 +423,12 @@ describe("SuperTokens SignUp", function () {
                         const postData = JSON.parse(request.postData());
                         Object.keys(customFields).forEach((key) => {
                             let findFormData = postData.formFields.find((inputData) => inputData.id === key);
-                            if (findFormData) {
-                                assert.strictEqual(
-                                    findFormData["value"],
-                                    customFields[key],
-                                    `Mismatch in payload for key: ${key}`
-                                );
-                            } else {
-                                throw new Error("Field not found in req.data");
-                            }
+                            assert.ok(findFormData, "Field not found in req.data");
+                            assert.strictEqual(
+                                findFormData["value"],
+                                customFields[key],
+                                `Mismatch in payload for key: ${key}`
+                            );
                         });
                         interceptionPassed = true;
                         return request.respond({
@@ -474,13 +471,8 @@ describe("SuperTokens SignUp", function () {
                 await page.setRequestInterception(false);
             }
 
-            if (assertionError) {
-                throw assertionError;
-            }
-
-            if (!interceptionPassed) {
-                throw new Error("test failed");
-            }
+            assert.ok(!assertionError, assertionError?.message);
+            assert.ok(interceptionPassed, "Test Failed");
         });
 
         it("Check on blank form submit nonOptionalErrorMsg gets displayed as expected", async function () {
@@ -514,9 +506,7 @@ describe("SuperTokens SignUp", function () {
                 await page.setRequestInterception(false);
             }
 
-            if (apiCallMade) {
-                throw new Error("Empty form making API request to sign-up");
-            }
+            assert.ok(!apiCallMade, "Empty form making signup API request");
         });
 
         it("Check if nonOptionalErrorMsg overwrites server error message for non-optional fields", async function () {
@@ -656,11 +646,8 @@ describe("SuperTokens SignUp", function () {
                         const postData = JSON.parse(request.postData());
                         expectedDefautlValues.forEach(({ id, value }) => {
                             let findFormData = postData.formFields.find((inputData) => inputData.id === id);
-                            if (findFormData) {
-                                assert.strictEqual(findFormData["value"], value, `Mismatch in payload for key: ${id}`);
-                            } else {
-                                throw new Error("Field not found in req.data");
-                            }
+                            assert.ok(findFormData, "Field not found in req.data");
+                            assert.strictEqual(findFormData["value"], value, `Mismatch in payload for key: ${id}`);
                         });
                         interceptionPassed = true;
                         return request.respond({
@@ -691,13 +678,8 @@ describe("SuperTokens SignUp", function () {
                 await page.setRequestInterception(false);
             }
 
-            if (assertionError) {
-                throw assertionError;
-            }
-
-            if (!interceptionPassed) {
-                throw new Error("test failed");
-            }
+            assert.ok(!assertionError, assertionError?.message);
+            assert.ok(interceptionPassed, "Test Failed");
         });
     });
 
@@ -768,14 +750,11 @@ describe("SuperTokens SignUp", function () {
                 waitUntil: "domcontentloaded",
             });
 
-            if (pageErrorMessage !== "") {
-                assert(
-                    pageErrorMessage.includes(expectedErrorMessage),
-                    `Expected "${expectedErrorMessage}" to be included in page-error`
-                );
-            } else {
-                throw "Empty nonOptionalErrorMsg should throw error";
-            }
+            assert.ok(pageErrorMessage !== "", "Empty nonOptionalErrorMsg should throw error");
+            assert(
+                pageErrorMessage.includes(expectedErrorMessage),
+                `Expected "${expectedErrorMessage}" to be included in page-error`
+            );
         });
     });
 });

--- a/test/end-to-end/thirdpartyemailpassword.test.js
+++ b/test/end-to-end/thirdpartyemailpassword.test.js
@@ -46,6 +46,7 @@ import {
     backendBeforeEach,
     setSelectDropdownValue,
     getInputField,
+    getLabelsText,
 } from "../helpers";
 import {
     TEST_CLIENT_BASE_URL,
@@ -531,6 +532,12 @@ describe("SuperTokens Third Party Email Password", function () {
             // check if checbox is loaded
             const checkboxExists = await waitForSTElement(page, 'input[type="checkbox"]');
             assert.ok(checkboxExists, "Checkbox exists");
+
+            // check if labels are loaded correctly
+            // non-optional field with empty labels should'nt show * sign
+            const expectedLabels = ["Email *", "Password *", "Select Dropdown", ""];
+            const labelNames = await getLabelsText(page);
+            assert.deepStrictEqual(labelNames, expectedLabels);
         });
 
         it("Should show error messages, based on optional flag", async function () {

--- a/test/end-to-end/thirdpartyemailpassword.test.js
+++ b/test/end-to-end/thirdpartyemailpassword.test.js
@@ -446,7 +446,7 @@ describe("SuperTokens Third Party Email Password", function () {
 
     describe("SignIn default field tests", function () {
         it("Should contain email and password fields prefilled", async function () {
-            await page.evaluate(() => window.localStorage.setItem("SHOW_SIGNIN_DEFAULT_FIELDS", "YES"));
+            await page.evaluate(() => window.localStorage.setItem("SIGNIN_SETTING_TYPE", "DEFAULT_FIELDS"));
 
             await page.reload({
                 waitUntil: "domcontentloaded",
@@ -467,11 +467,11 @@ describe("SuperTokens Third Party Email Password", function () {
         });
 
         it("Check on blank form submit nonOptionalErrorMsg gets displayed as expected", async function () {
-            await page.evaluate(() => window.localStorage.removeItem("SHOW_SIGNIN_DEFAULT_FIELDS"));
+            // await page.evaluate(() => window.localStorage.removeItem("SHOW_SIGNIN_DEFAULT_FIELDS"));
 
             // set cookie and reload which loads the form with custom field
             await page.evaluate(() =>
-                window.localStorage.setItem("SHOW_SIGNIN_WITH_NON_OPTIONAL_ERROR_MESSAGE", "YES")
+                window.localStorage.setItem("SIGNIN_SETTING_TYPE", "FIELDS_WITH_NON_OPTIONAL_ERROR_MESSAGE")
             );
             await page.reload({
                 waitUntil: "domcontentloaded",
@@ -513,7 +513,7 @@ describe("SuperTokens Third Party Email Password", function () {
 
     describe("Third Party signup config supports custom fields tests", function () {
         beforeEach(async function () {
-            await page.evaluate(() => window.localStorage.setItem("SHOW_CUSTOM_FIELDS", "YES"));
+            await page.evaluate(() => window.localStorage.setItem("SIGNUP_SETTING_TYPE", "CUSTOM_FIELDS"));
 
             await page.reload({
                 waitUntil: "domcontentloaded",
@@ -747,7 +747,9 @@ describe("SuperTokens Third Party Email Password", function () {
     describe("Third Party signup default value for fields test", function () {
         beforeEach(async function () {
             // set cookie and reload which loads the form fields with default values
-            await page.evaluate(() => window.localStorage.setItem("SHOW_CUSTOM_FIELDS_WITH_DEFAULT_VALUES", "YES"));
+            await page.evaluate(() =>
+                window.localStorage.setItem("SIGNUP_SETTING_TYPE", "CUSTOM_FIELDS_WITH_DEFAULT_VALUES")
+            );
 
             await page.reload({
                 waitUntil: "domcontentloaded",
@@ -869,7 +871,7 @@ describe("SuperTokens Third Party Email Password", function () {
     describe("Third Party signup config Incorrect field message test", function () {
         beforeEach(async function () {
             // set cookie and reload which loads the form fields with default values
-            await page.evaluate(() => window.localStorage.setItem("SHOW_INCORRECT_FIELDS", "YES"));
+            await page.evaluate(() => window.localStorage.setItem("SIGNUP_SETTING_TYPE", "INCORRECT_FIELDS"));
 
             await page.reload({
                 waitUntil: "domcontentloaded",
@@ -877,7 +879,7 @@ describe("SuperTokens Third Party Email Password", function () {
         });
 
         it("Check if incorrect getDefaultValue throws error", async function () {
-            await page.evaluate(() => window.localStorage.setItem("INCORRECT_GETDEFAULT", "YES"));
+            await page.evaluate(() => window.localStorage.setItem("SIGNUP_SETTING_TYPE", "INCORRECT_GETDEFAULT"));
             let pageErrorMessage = "";
             page.on("pageerror", (err) => {
                 pageErrorMessage = err.message;
@@ -896,8 +898,8 @@ describe("SuperTokens Third Party Email Password", function () {
         });
 
         it("Check if non-string params to onChange throws error", async function () {
-            await page.evaluate(() => window.localStorage.removeItem("INCORRECT_GETDEFAULT"));
-            await page.evaluate(() => window.localStorage.setItem("INCORRECT_ONCHANGE", "YES"));
+            // await page.evaluate(() => window.localStorage.removeItem("INCORRECT_GETDEFAULT"));
+            await page.evaluate(() => window.localStorage.setItem("SIGNUP_SETTING_TYPE", "INCORRECT_ONCHANGE"));
             await page.reload({
                 waitUntil: "domcontentloaded",
             });
@@ -926,9 +928,11 @@ describe("SuperTokens Third Party Email Password", function () {
                 pageErrorMessage = err.message;
             });
 
-            await page.evaluate(() => window.localStorage.removeItem("INCORRECT_GETDEFAULT"));
-            await page.evaluate(() => window.localStorage.removeItem("INCORRECT_ONCHANGE"));
-            await page.evaluate(() => window.localStorage.setItem("INCORRECT_NON_OPTIONAL_ERROR_MSG", "YES"));
+            // await page.evaluate(() => window.localStorage.removeItem("INCORRECT_GETDEFAULT"));
+            // await page.evaluate(() => window.localStorage.removeItem("INCORRECT_ONCHANGE"));
+            await page.evaluate(() =>
+                window.localStorage.setItem("SIGNUP_SETTING_TYPE", "INCORRECT_NON_OPTIONAL_ERROR_MSG")
+            );
             await page.reload({
                 waitUntil: "domcontentloaded",
             });

--- a/test/end-to-end/thirdpartyemailpassword.test.js
+++ b/test/end-to-end/thirdpartyemailpassword.test.js
@@ -467,8 +467,6 @@ describe("SuperTokens Third Party Email Password", function () {
         });
 
         it("Check on blank form submit nonOptionalErrorMsg gets displayed as expected", async function () {
-            // await page.evaluate(() => window.localStorage.removeItem("SHOW_SIGNIN_DEFAULT_FIELDS"));
-
             // set cookie and reload which loads the form with custom field
             await page.evaluate(() =>
                 window.localStorage.setItem("SIGNIN_SETTING_TYPE", "FIELDS_WITH_NON_OPTIONAL_ERROR_MESSAGE")
@@ -898,7 +896,6 @@ describe("SuperTokens Third Party Email Password", function () {
         });
 
         it("Check if non-string params to onChange throws error", async function () {
-            // await page.evaluate(() => window.localStorage.removeItem("INCORRECT_GETDEFAULT"));
             await page.evaluate(() => window.localStorage.setItem("SIGNUP_SETTING_TYPE", "INCORRECT_ONCHANGE"));
             await page.reload({
                 waitUntil: "domcontentloaded",
@@ -928,8 +925,6 @@ describe("SuperTokens Third Party Email Password", function () {
                 pageErrorMessage = err.message;
             });
 
-            // await page.evaluate(() => window.localStorage.removeItem("INCORRECT_GETDEFAULT"));
-            // await page.evaluate(() => window.localStorage.removeItem("INCORRECT_ONCHANGE"));
             await page.evaluate(() =>
                 window.localStorage.setItem("SIGNUP_SETTING_TYPE", "INCORRECT_NON_OPTIONAL_ERROR_MSG")
             );


### PR DESCRIPTION
## Summary of change

Fixes and feedbacks from [this PR](https://github.com/supertokens/supertokens-auth-react/pull/760)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
