### PR TITLE
fix: tpep header with disabled emailpassword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.35.9] - 2023-12-06
+
+-   Fixes ThirdPartyEmailPassword rendering sign in/up switcher even with disabled email password. Instead it'll now render `SignInAndUpHeader` in this case (overrideable as `ThirdPartySignInAndUpHeader`)
+
 ## [0.35.8] - 2023-11-26
 
 -   Fixes `inputComponent` props to make them non optional. This is in the context of customizing the sign up form to add custom react components.

--- a/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/submitNewPassword.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/submitNewPassword.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 export declare const SubmitNewPassword: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: import("../../../types").FormFieldThemeProps[];
+        formFields: Omit<import("../../../types").FormFieldThemeProps, "inputComponent">[];
         error: string | undefined;
     } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signIn.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signIn.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 export declare const SignIn: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: import("../../../types").FormFieldThemeProps[];
+        formFields: Omit<import("../../../types").FormFieldThemeProps, "inputComponent">[];
         error: string | undefined;
     } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;
@@ -10,6 +10,6 @@ export declare const SignIn: import("react").ComponentType<
         config: import("../../../types").NormalisedConfig;
         signUpClicked?: (() => void) | undefined;
         forgotPasswordClick: () => void;
-        onSuccess: () => void;
+        onSuccess: (result: { user: import("supertokens-web-js/types").User }) => void;
     }
 >;

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUp.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUp.d.ts
@@ -1,14 +1,13 @@
 /// <reference types="react" />
 export declare const SignUp: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: import("../../../types").FormFieldThemeProps[];
-        error: string | undefined;
-    } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;
         clearError: () => void;
         onError: (error: string) => void;
         config: import("../../../types").NormalisedConfig;
         signInClicked?: (() => void) | undefined;
-        onSuccess: () => void;
+        onSuccess: (result: { user: import("supertokens-web-js/types").User }) => void;
+        formFields: import("../../../types").FormFieldThemeProps[];
+        error: string | undefined;
     }
 >;

--- a/lib/build/recipe/thirdpartyemailpassword/components/themes/translations.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/components/themes/translations.d.ts
@@ -58,6 +58,9 @@ export declare const defaultTranslationsThirdPartyEmailPassword: {
         "Password must contain at least one alphabet": undefined;
         "Password must contain at least one number": undefined;
         "Email is invalid": undefined;
+        "Reset password link was not created because of account take over risk. Please contact support. (ERR_CODE_001)": undefined;
+        "Cannot sign up due to security reasons. Please try logging in, use a different login method or contact support. (ERR_CODE_007)": undefined;
+        "Cannot sign in due to security reasons. Please try resetting your password, use a different login method or contact support. (ERR_CODE_008)": undefined;
         EMAIL_VERIFICATION_RESEND_SUCCESS: string;
         EMAIL_VERIFICATION_SEND_TITLE: string;
         EMAIL_VERIFICATION_SEND_DESC_START: string;
@@ -86,5 +89,8 @@ export declare const defaultTranslationsThirdPartyEmailPassword: {
         THIRD_PARTY_PROVIDER_DEFAULT_BTN_START: string;
         THIRD_PARTY_PROVIDER_DEFAULT_BTN_END: string;
         THIRD_PARTY_ERROR_NO_EMAIL: string;
+        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_004)": undefined;
+        "Cannot sign in / up because new email cannot be applied to existing account. Please contact support. (ERR_CODE_005)": undefined;
+        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_006)": undefined;
     };
 };

--- a/lib/build/recipe/thirdpartypasswordless/components/themes/translations.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/components/themes/translations.d.ts
@@ -57,6 +57,8 @@ export declare const defaultTranslationsThirdPartyPasswordless: {
         "Failed to generate a one time code. Please try again": undefined;
         "Phone number is invalid": undefined;
         "Email is invalid": undefined;
+        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_002)": undefined;
+        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_003)": undefined;
         BRANDING_POWERED_BY_START: string;
         BRANDING_POWERED_BY_END: string;
         SOMETHING_WENT_WRONG_ERROR: string;
@@ -69,5 +71,8 @@ export declare const defaultTranslationsThirdPartyPasswordless: {
         THIRD_PARTY_PROVIDER_DEFAULT_BTN_START: string;
         THIRD_PARTY_PROVIDER_DEFAULT_BTN_END: string;
         THIRD_PARTY_ERROR_NO_EMAIL: string;
+        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_004)": undefined;
+        "Cannot sign in / up because new email cannot be applied to existing account. Please contact support. (ERR_CODE_005)": undefined;
+        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_006)": undefined;
     };
 };

--- a/lib/build/thirdparty-shared2.js
+++ b/lib/build/thirdparty-shared2.js
@@ -767,6 +767,7 @@ exports.ProvidersForm = ProvidersForm;
 exports.SignInAndUp = SignInAndUp;
 exports.SignInAndUpCallback = SignInAndUpCallback;
 exports.SignInAndUpCallbackTheme = SignInAndUpCallbackTheme;
+exports.SignInAndUpHeader = SignInAndUpHeader;
 exports.SignInAndUpThemeWrapper = SignInAndUpThemeWrapper;
 exports.ThirdPartyPreBuiltUI = ThirdPartyPreBuiltUI;
 exports.defaultTranslationsThirdParty = defaultTranslationsThirdParty;

--- a/lib/build/thirdpartyemailpasswordprebuiltui.js
+++ b/lib/build/thirdpartyemailpasswordprebuiltui.js
@@ -157,12 +157,16 @@ var SignInAndUpTheme = function (props) {
                             { "data-supertokens": "row" },
                             {
                                 children: [
-                                    jsxRuntime.jsx(Header, {
-                                        isSignUp: props.epState.isSignUp,
-                                        setIsSignUp: function (isSignUp) {
-                                            return props.epDispatch({ type: isSignUp ? "setSignUp" : "setSignIn" });
-                                        },
-                                    }),
+                                    emailPasswordEnabled
+                                        ? jsxRuntime.jsx(Header, {
+                                              isSignUp: props.epState.isSignUp,
+                                              setIsSignUp: function (isSignUp) {
+                                                  return props.epDispatch({
+                                                      type: isSignUp ? "setSignUp" : "setSignIn",
+                                                  });
+                                              },
+                                          })
+                                        : jsxRuntime.jsx(thirdpartyprebuiltui.SignInAndUpHeader, {}),
                                     props.commonState.error &&
                                         jsxRuntime.jsx(generalError.GeneralError, { error: props.commonState.error }),
                                     props.tpChildProps !== undefined &&

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.35.8";
+export declare const package_version = "0.35.9";

--- a/lib/ts/recipe/thirdpartyemailpassword/components/themes/signInAndUp/index.tsx
+++ b/lib/ts/recipe/thirdpartyemailpassword/components/themes/signInAndUp/index.tsx
@@ -30,6 +30,7 @@ import { SignUpFooter } from "../../../../emailpassword/components/themes/signIn
 import { SignUpForm } from "../../../../emailpassword/components/themes/signInAndUp/signUpForm";
 import { useDynamicLoginMethods } from "../../../../multitenancy/dynamicLoginMethodsContext";
 import { ProvidersForm } from "../../../../thirdparty/components/themes/signInAndUp/providersForm";
+import { SignInAndUpHeader } from "../../../../thirdparty/components/themes/signInAndUp/signInAndUpHeader";
 import { ThemeBase } from "../themeBase";
 
 import { Header } from "./header";
@@ -62,10 +63,14 @@ const SignInAndUpTheme: React.FC<ThirdPartyEmailPasswordSignInAndUpThemeProps> =
     return (
         <div data-supertokens="container">
             <div data-supertokens="row">
-                <Header
-                    isSignUp={props.epState.isSignUp}
-                    setIsSignUp={(isSignUp) => props.epDispatch({ type: isSignUp ? "setSignUp" : "setSignIn" })}
-                />
+                {emailPasswordEnabled ? (
+                    <Header
+                        isSignUp={props.epState.isSignUp}
+                        setIsSignUp={(isSignUp) => props.epDispatch({ type: isSignUp ? "setSignUp" : "setSignIn" })}
+                    />
+                ) : (
+                    <SignInAndUpHeader />
+                )}
                 {props.commonState.error && <GeneralError error={props.commonState.error} />}
                 {props.tpChildProps !== undefined && thirdPartyEnabled && (
                     <ProvidersForm {...props.tpChildProps} featureState={props.tpState} dispatch={props.tpDispatch} />

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.35.8";
+export const package_version = "0.35.9";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.35.8",
+    "version": "0.35.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.35.8",
+            "version": "0.35.9",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.35.8",
+    "version": "0.35.9",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {

--- a/test/end-to-end/multitenancy.dynamic_login_methods.test.js
+++ b/test/end-to-end/multitenancy.dynamic_login_methods.test.js
@@ -39,6 +39,7 @@ import {
     isMultitenancyManagementEndpointsSupported,
     setupTenant,
     backendBeforeEach,
+    getTextByDataSupertokens,
 } from "../helpers";
 import {
     TEST_CLIENT_BASE_URL,
@@ -530,6 +531,7 @@ describe("SuperTokens Multitenancy dynamic login methods", function () {
         // Emailpassword
         const inputNames = await getInputNames(page);
         assert.deepStrictEqual(inputNames, []);
+        assert.strictEqual(await getTextByDataSupertokens(page, "headerTitle"), "Sign Up / Sign In");
     });
 
     it("should show thirdpartyemailpassword if FE has tpep and both emailpassword and thirdparty is enabled", async function () {


### PR DESCRIPTION
## Summary of change

Fixes ThirdPartyEmailPassword rendering sign in/up switcher even with disabled email password. 
Instead it'll now render `SignInAndUpHeader` in this case (overrideable as `ThirdPartySignInAndUpHeader`)

## Related issues

-   Issue reported on discord

## Test Plan

Updated existing test to check the header

## Documentation changes

-

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [x] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
