### PR TITLE
fix: move SignInAndUpHeader inside ThirdPartyEmailPasswordHeader to improve overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.35.9] - 2023-12-06
 
--   Fixes ThirdPartyEmailPassword rendering sign in/up switcher even with disabled email password. Instead it'll now render `SignInAndUpHeader` in this case (overrideable as `ThirdPartySignInAndUpHeader`)
+-   Fixes ThirdPartyEmailPassword rendering sign in/up switcher even with disabled email password. Instead it'll now render `SignInAndUpHeader_Override` in this case (overrideable as `ThirdPartySignInAndUpHeader`). Overriding `ThirdPartyEmailPasswordHeader_Override` should still cover all cases.
+-   Added a new prop to `ThirdPartyEmailPasswordHeader_Override` you can use to check if email password is enabled.
 
 ## [0.35.8] - 2023-11-26
 

--- a/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/submitNewPassword.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/resetPasswordUsingToken/submitNewPassword.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 export declare const SubmitNewPassword: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: import("../../../types").FormFieldThemeProps[];
+        formFields: Omit<import("../../../types").FormFieldThemeProps, "inputComponent">[];
         error: string | undefined;
     } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signIn.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signIn.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 export declare const SignIn: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: import("../../../types").FormFieldThemeProps[];
+        formFields: Omit<import("../../../types").FormFieldThemeProps, "inputComponent">[];
         error: string | undefined;
     } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;
@@ -10,6 +10,6 @@ export declare const SignIn: import("react").ComponentType<
         config: import("../../../types").NormalisedConfig;
         signUpClicked?: (() => void) | undefined;
         forgotPasswordClick: () => void;
-        onSuccess: () => void;
+        onSuccess: (result: { user: import("supertokens-web-js/types").User }) => void;
     }
 >;

--- a/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUp.d.ts
+++ b/lib/build/recipe/emailpassword/components/themes/signInAndUp/signUp.d.ts
@@ -1,14 +1,13 @@
 /// <reference types="react" />
 export declare const SignUp: import("react").ComponentType<
     import("../../../../../types").ThemeBaseProps & {
-        formFields: import("../../../types").FormFieldThemeProps[];
-        error: string | undefined;
-    } & {
         recipeImplementation: import("supertokens-web-js/recipe/emailpassword").RecipeInterface;
         clearError: () => void;
         onError: (error: string) => void;
         config: import("../../../types").NormalisedConfig;
         signInClicked?: (() => void) | undefined;
-        onSuccess: () => void;
+        onSuccess: (result: { user: import("supertokens-web-js/types").User }) => void;
+        formFields: import("../../../types").FormFieldThemeProps[];
+        error: string | undefined;
     }
 >;

--- a/lib/build/recipe/thirdpartyemailpassword/components/themes/signInAndUp/header.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/components/themes/signInAndUp/header.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="react" />
 export declare const Header: import("react").ComponentType<{
+    emailPasswordEnabled: boolean;
     isSignUp: boolean;
     setIsSignUp: (isSignUp: boolean) => void;
 }>;

--- a/lib/build/recipe/thirdpartyemailpassword/components/themes/translations.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/components/themes/translations.d.ts
@@ -58,6 +58,9 @@ export declare const defaultTranslationsThirdPartyEmailPassword: {
         "Password must contain at least one alphabet": undefined;
         "Password must contain at least one number": undefined;
         "Email is invalid": undefined;
+        "Reset password link was not created because of account take over risk. Please contact support. (ERR_CODE_001)": undefined;
+        "Cannot sign up due to security reasons. Please try logging in, use a different login method or contact support. (ERR_CODE_007)": undefined;
+        "Cannot sign in due to security reasons. Please try resetting your password, use a different login method or contact support. (ERR_CODE_008)": undefined;
         EMAIL_VERIFICATION_RESEND_SUCCESS: string;
         EMAIL_VERIFICATION_SEND_TITLE: string;
         EMAIL_VERIFICATION_SEND_DESC_START: string;
@@ -86,5 +89,8 @@ export declare const defaultTranslationsThirdPartyEmailPassword: {
         THIRD_PARTY_PROVIDER_DEFAULT_BTN_START: string;
         THIRD_PARTY_PROVIDER_DEFAULT_BTN_END: string;
         THIRD_PARTY_ERROR_NO_EMAIL: string;
+        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_004)": undefined;
+        "Cannot sign in / up because new email cannot be applied to existing account. Please contact support. (ERR_CODE_005)": undefined;
+        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_006)": undefined;
     };
 };

--- a/lib/build/recipe/thirdpartypasswordless/components/themes/translations.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/components/themes/translations.d.ts
@@ -57,6 +57,8 @@ export declare const defaultTranslationsThirdPartyPasswordless: {
         "Failed to generate a one time code. Please try again": undefined;
         "Phone number is invalid": undefined;
         "Email is invalid": undefined;
+        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_002)": undefined;
+        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_003)": undefined;
         BRANDING_POWERED_BY_START: string;
         BRANDING_POWERED_BY_END: string;
         SOMETHING_WENT_WRONG_ERROR: string;
@@ -69,5 +71,8 @@ export declare const defaultTranslationsThirdPartyPasswordless: {
         THIRD_PARTY_PROVIDER_DEFAULT_BTN_START: string;
         THIRD_PARTY_PROVIDER_DEFAULT_BTN_END: string;
         THIRD_PARTY_ERROR_NO_EMAIL: string;
+        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_004)": undefined;
+        "Cannot sign in / up because new email cannot be applied to existing account. Please contact support. (ERR_CODE_005)": undefined;
+        "Cannot sign in / up due to security reasons. Please try a different login method or contact support. (ERR_CODE_006)": undefined;
     };
 };

--- a/lib/build/thirdpartyemailpasswordprebuiltui.js
+++ b/lib/build/thirdpartyemailpasswordprebuiltui.js
@@ -96,15 +96,13 @@ var ThemeBase = function (_a) {
     });
 };
 
-/*
- * Component.
- */
 var Header = uiEntry.withOverride("ThirdPartyEmailPasswordHeader", function ThirdPartyEmailPasswordHeader(_a) {
     var isSignUp = _a.isSignUp,
-        setIsSignUp = _a.setIsSignUp;
-    /*
-     * Render.
-     */
+        setIsSignUp = _a.setIsSignUp,
+        emailPasswordEnabled = _a.emailPasswordEnabled;
+    if (emailPasswordEnabled !== true) {
+        return jsxRuntime.jsx(thirdpartyprebuiltui.SignInAndUpHeader, {});
+    }
     if (isSignUp === true) {
         return jsxRuntime.jsx(emailpasswordprebuiltui.SignUpHeader, {
             onClick: function () {
@@ -141,7 +139,7 @@ var SignInAndUpTheme = function (props) {
         ((loginMethods === null || loginMethods === void 0 ? void 0 : loginMethods.thirdparty.enabled) && hasProviders);
     var emailPasswordEnabled =
         (props.emailPasswordRecipe !== undefined && usesDynamicLoginMethods === false) ||
-        (loginMethods === null || loginMethods === void 0 ? void 0 : loginMethods.emailpassword.enabled);
+        (loginMethods === null || loginMethods === void 0 ? void 0 : loginMethods.emailpassword.enabled) === true;
     if (thirdPartyEnabled === false && emailPasswordEnabled === false) {
         return null;
     }
@@ -157,16 +155,13 @@ var SignInAndUpTheme = function (props) {
                             { "data-supertokens": "row" },
                             {
                                 children: [
-                                    emailPasswordEnabled
-                                        ? jsxRuntime.jsx(Header, {
-                                              isSignUp: props.epState.isSignUp,
-                                              setIsSignUp: function (isSignUp) {
-                                                  return props.epDispatch({
-                                                      type: isSignUp ? "setSignUp" : "setSignIn",
-                                                  });
-                                              },
-                                          })
-                                        : jsxRuntime.jsx(thirdpartyprebuiltui.SignInAndUpHeader, {}),
+                                    jsxRuntime.jsx(Header, {
+                                        isSignUp: props.epState.isSignUp,
+                                        setIsSignUp: function (isSignUp) {
+                                            return props.epDispatch({ type: isSignUp ? "setSignUp" : "setSignIn" });
+                                        },
+                                        emailPasswordEnabled: emailPasswordEnabled,
+                                    }),
                                     props.commonState.error &&
                                         jsxRuntime.jsx(generalError.GeneralError, { error: props.commonState.error }),
                                     props.tpChildProps !== undefined &&

--- a/lib/ts/recipe/thirdpartyemailpassword/components/themes/signInAndUp/header.tsx
+++ b/lib/ts/recipe/thirdpartyemailpassword/components/themes/signInAndUp/header.tsx
@@ -12,28 +12,26 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-/*
- * Imports.
- */
 import { withOverride } from "../../../../../components/componentOverride/withOverride";
 import { SignInHeader } from "../../../../emailpassword/components/themes/signInAndUp/signInHeader";
 import { SignUpHeader } from "../../../../emailpassword/components/themes/signInAndUp/signUpHeader";
+import { SignInAndUpHeader } from "../../../../thirdparty/components/themes/signInAndUp/signInAndUpHeader";
 
-/*
- * Component.
- */
 export const Header = withOverride(
     "ThirdPartyEmailPasswordHeader",
     function ThirdPartyEmailPasswordHeader({
         isSignUp,
         setIsSignUp,
+        emailPasswordEnabled,
     }: {
+        emailPasswordEnabled: boolean;
         isSignUp: boolean;
         setIsSignUp: (isSignUp: boolean) => void;
     }): JSX.Element {
-        /*
-         * Render.
-         */
+        if (emailPasswordEnabled !== true) {
+            return <SignInAndUpHeader />;
+        }
+
         if (isSignUp === true) {
             return <SignUpHeader onClick={() => setIsSignUp(false)} />;
         } else {

--- a/lib/ts/recipe/thirdpartyemailpassword/components/themes/signInAndUp/index.tsx
+++ b/lib/ts/recipe/thirdpartyemailpassword/components/themes/signInAndUp/index.tsx
@@ -30,7 +30,6 @@ import { SignUpFooter } from "../../../../emailpassword/components/themes/signIn
 import { SignUpForm } from "../../../../emailpassword/components/themes/signInAndUp/signUpForm";
 import { useDynamicLoginMethods } from "../../../../multitenancy/dynamicLoginMethodsContext";
 import { ProvidersForm } from "../../../../thirdparty/components/themes/signInAndUp/providersForm";
-import { SignInAndUpHeader } from "../../../../thirdparty/components/themes/signInAndUp/signInAndUpHeader";
 import { ThemeBase } from "../themeBase";
 
 import { Header } from "./header";
@@ -54,7 +53,7 @@ const SignInAndUpTheme: React.FC<ThirdPartyEmailPasswordSignInAndUpThemeProps> =
         (usesDynamicLoginMethods === false && hasProviders) || (loginMethods?.thirdparty.enabled && hasProviders);
     const emailPasswordEnabled =
         (props.emailPasswordRecipe !== undefined && usesDynamicLoginMethods === false) ||
-        loginMethods?.emailpassword.enabled;
+        loginMethods?.emailpassword.enabled === true;
 
     if (thirdPartyEnabled === false && emailPasswordEnabled === false) {
         return null;
@@ -63,14 +62,11 @@ const SignInAndUpTheme: React.FC<ThirdPartyEmailPasswordSignInAndUpThemeProps> =
     return (
         <div data-supertokens="container">
             <div data-supertokens="row">
-                {emailPasswordEnabled ? (
-                    <Header
-                        isSignUp={props.epState.isSignUp}
-                        setIsSignUp={(isSignUp) => props.epDispatch({ type: isSignUp ? "setSignUp" : "setSignIn" })}
-                    />
-                ) : (
-                    <SignInAndUpHeader />
-                )}
+                <Header
+                    isSignUp={props.epState.isSignUp}
+                    setIsSignUp={(isSignUp) => props.epDispatch({ type: isSignUp ? "setSignUp" : "setSignIn" })}
+                    emailPasswordEnabled={emailPasswordEnabled}
+                />
                 {props.commonState.error && <GeneralError error={props.commonState.error} />}
                 {props.tpChildProps !== undefined && thirdPartyEnabled && (
                     <ProvidersForm {...props.tpChildProps} featureState={props.tpState} dispatch={props.tpDispatch} />


### PR DESCRIPTION
## Summary of change

move SignInAndUpHeader inside ThirdPartyEmailPasswordHeader to improve overrides

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
