### PR TITLE
Update userContext type and add isNewPrimaryUser in GetRedirectionURLContext

### DIFF
--- a/lib/build/SuperTokensBranding.js
+++ b/lib/build/SuperTokensBranding.js
@@ -46,6 +46,7 @@ var Redirector = function (props) {
                                 successRedirectContext: {
                                     action: "SUCCESS",
                                     isNewRecipeUser: false,
+                                    isNewPrimaryUser: false,
                                     redirectToPath: genericComponentOverrideContext.getRedirectToPathFromURL(),
                                 },
                             },

--- a/lib/build/components/supertokensWrapper.d.ts
+++ b/lib/build/components/supertokensWrapper.d.ts
@@ -1,6 +1,7 @@
+import type { UserContext } from "../types";
 import type { PropsWithChildren } from "react";
 export declare const SuperTokensWrapper: React.FC<
     PropsWithChildren<{
-        userContext?: any;
+        userContext?: UserContext;
     }>
 >;

--- a/lib/build/emailpassword-shared6.js
+++ b/lib/build/emailpassword-shared6.js
@@ -1246,7 +1246,7 @@ function useChildProps(recipe$1, state, dispatch, navigate) {
                 },
                 onSuccess: onSignInSuccess,
                 forgotPasswordClick: function () {
-                    return recipe$1.redirect({ action: "RESET_PASSWORD" }, navigate, userContext);
+                    return recipe$1.redirect({ action: "RESET_PASSWORD" }, navigate, undefined, userContext);
                 },
             };
             var signUpForm = {
@@ -1537,10 +1537,22 @@ var EmailPasswordPreBuiltUI = /** @class */ (function (_super) {
         if (prop === void 0) {
             prop = {};
         }
-        return EmailPasswordPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("signinup", prop);
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(prop.userContext);
+        return EmailPasswordPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent(
+            "signinup",
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, prop), {
+                userContext: userContext,
+            })
+        );
     };
     EmailPasswordPreBuiltUI.ResetPasswordUsingToken = function (prop) {
-        return EmailPasswordPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("resetpassword", prop);
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(prop.userContext);
+        return EmailPasswordPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent(
+            "resetpassword",
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, prop), {
+                userContext: userContext,
+            })
+        );
     };
     EmailPasswordPreBuiltUI.ResetPasswordUsingTokenTheme = ResetPasswordUsingTokenThemeWrapper;
     EmailPasswordPreBuiltUI.SignInAndUpTheme = SignInAndUpThemeWrapper;

--- a/lib/build/emailpassword-shared6.js
+++ b/lib/build/emailpassword-shared6.js
@@ -1187,6 +1187,7 @@ function useChildProps(recipe$1, state, dispatch, navigate) {
                                 rid: recipe$1.config.recipeId,
                                 successRedirectContext: {
                                     action: "SUCCESS",
+                                    isNewPrimaryUser: false,
                                     isNewRecipeUser: false,
                                     redirectToPath: genericComponentOverrideContext.getRedirectToPathFromURL(),
                                 },
@@ -1211,6 +1212,7 @@ function useChildProps(recipe$1, state, dispatch, navigate) {
                                 rid: recipe$1.config.recipeId,
                                 successRedirectContext: {
                                     action: "SUCCESS",
+                                    isNewPrimaryUser: true,
                                     isNewRecipeUser: true,
                                     redirectToPath: genericComponentOverrideContext.getRedirectToPathFromURL(),
                                 },

--- a/lib/build/emailverification-shared.js
+++ b/lib/build/emailverification-shared.js
@@ -39,7 +39,7 @@ var EmailVerificationClaimClass = /** @class */ (function (_super) {
                             }
                             var recipe = EmailVerification.getInstanceOrThrow();
                             if (recipe.config.mode === "REQUIRED") {
-                                return recipe.getRedirectUrl({ action: "VERIFY_EMAIL" });
+                                return recipe.getRedirectUrl({ action: "VERIFY_EMAIL" }, args.userContext);
                             }
                             return undefined;
                         },

--- a/lib/build/emailverificationprebuiltui.js
+++ b/lib/build/emailverificationprebuiltui.js
@@ -961,13 +961,19 @@ var EmailVerification$1 = function (props) {
         function () {
             return genericComponentOverrideContext.__awaiter(void 0, void 0, void 0, function () {
                 var session;
-                return genericComponentOverrideContext.__generator(this, function (_a) {
-                    switch (_a.label) {
+                var _a;
+                return genericComponentOverrideContext.__generator(this, function (_b) {
+                    switch (_b.label) {
                         case 0:
                             session = recipe.Session.getInstanceOrThrow();
-                            return [4 /*yield*/, session.signOut(props.userContext)];
+                            return [
+                                4 /*yield*/,
+                                session.signOut({
+                                    userContext: (_a = props.userContext) !== null && _a !== void 0 ? _a : userContext,
+                                }),
+                            ];
                         case 1:
-                            _a.sent();
+                            _b.sent();
                             return [2 /*return*/, redirectToAuthWithHistory()];
                     }
                 });
@@ -1157,9 +1163,12 @@ var EmailVerificationPreBuiltUI = /** @class */ (function (_super) {
         return;
     };
     EmailVerificationPreBuiltUI.EmailVerification = function (props) {
-        return EmailVerificationPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent(
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(props.userContext);
+        EmailVerificationPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent(
             "emailverification",
-            props
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, props), {
+                userContext: userContext,
+            })
         );
     };
     EmailVerificationPreBuiltUI.EmailVerificationTheme = EmailVerificationTheme;

--- a/lib/build/genericComponentOverrideContext.js
+++ b/lib/build/genericComponentOverrideContext.js
@@ -241,6 +241,30 @@ typeof SuppressedError === "function"
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+/*
+ * Consts.
+ */
+var RECIPE_ID_QUERY_PARAM = "rid";
+var DEFAULT_API_BASE_PATH = "/auth";
+var DEFAULT_WEBSITE_BASE_PATH = "/auth";
+var ST_ROOT_ID = "supertokens-root";
+var SSR_ERROR =
+    "\nIf you are trying to use this method doing server-side-rendering, please make sure you move this method inside a componentDidMount method or useEffect hook.";
+
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 var package_version = "0.36.0";
 
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
@@ -274,30 +298,6 @@ function logDebugMessage(message) {
         );
     }
 }
-
-/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
- *
- * This software is licensed under the Apache License, Version 2.0 (the
- * "License") as published by the Apache Software Foundation.
- *
- * You may not use this file except in compliance with the License. You may
- * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-/*
- * Consts.
- */
-var RECIPE_ID_QUERY_PARAM = "rid";
-var DEFAULT_API_BASE_PATH = "/auth";
-var DEFAULT_WEBSITE_BASE_PATH = "/auth";
-var ST_ROOT_ID = "supertokens-root";
-var SSR_ERROR =
-    "\nIf you are trying to use this method doing server-side-rendering, please make sure you move this method inside a componentDidMount method or useEffect hook.";
 
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -1173,10 +1173,13 @@ var SuperTokens = /** @class */ (function () {
                             }
                             return [
                                 4 /*yield*/,
-                                this.getRedirectUrl({
-                                    action: "TO_AUTH",
-                                    showSignIn: options.show === "signin",
-                                }),
+                                this.getRedirectUrl(
+                                    {
+                                        action: "TO_AUTH",
+                                        showSignIn: options.show === "signin",
+                                    },
+                                    getNormalisedUserContext(undefined)
+                                ),
                             ];
                         case 1:
                             redirectUrl = _a.sent();

--- a/lib/build/index2.js
+++ b/lib/build/index2.js
@@ -1037,15 +1037,6 @@ var SessionAuth = function (_a) {
                             ];
                         case 1:
                             failureRedirectInfo = _a.sent();
-                            if (failureRedirectInfo.redirectPath === null) {
-                                setContext(toSetContext);
-                                genericComponentOverrideContext.logDebugMessage(
-                                    "Skipping redirection because the user override returned null for validator ".concat(
-                                        JSON.stringify(failureRedirectInfo.failedClaim, null, 2)
-                                    )
-                                );
-                                return [2 /*return*/];
-                            }
                             if (!(failureRedirectInfo.redirectPath !== undefined)) return [3 /*break*/, 3];
                             setContext(toSetContext);
                             return [

--- a/lib/build/passwordless-shared3.js
+++ b/lib/build/passwordless-shared3.js
@@ -351,6 +351,9 @@ var LinkClickedScreen = function (props) {
                                         rid: props.recipe.config.recipeId,
                                         successRedirectContext: {
                                             action: "SUCCESS",
+                                            isNewPrimaryUser:
+                                                response.createdNewRecipeUser &&
+                                                response.user.loginMethods.length === 1,
                                             isNewRecipeUser: response.createdNewRecipeUser,
                                             redirectToPath:
                                                 loginAttemptInfo === null || loginAttemptInfo === void 0
@@ -3961,6 +3964,7 @@ function useChildProps(recipe$1, dispatch, state, userContext, navigate) {
                             rid: recipe$1.config.recipeId,
                             successRedirectContext: {
                                 action: "SUCCESS",
+                                isNewPrimaryUser: result.createdNewRecipeUser && result.user.loginMethods.length === 1,
                                 isNewRecipeUser: result.createdNewRecipeUser,
                                 redirectToPath: genericComponentOverrideContext.getRedirectToPathFromURL(),
                             },

--- a/lib/build/passwordless-shared3.js
+++ b/lib/build/passwordless-shared3.js
@@ -4365,10 +4365,22 @@ var PasswordlessPreBuiltUI = /** @class */ (function (_super) {
         if (prop === void 0) {
             prop = {};
         }
-        return _a.getFeatureComponent("signInUp", prop);
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(prop.userContext);
+        return _a.getFeatureComponent(
+            "signInUp",
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, prop), {
+                userContext: userContext,
+            })
+        );
     };
     PasswordlessPreBuiltUI.LinkClicked = function (prop) {
-        return _a.getFeatureComponent("linkClickedScreen", prop);
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(prop.userContext);
+        return _a.getFeatureComponent(
+            "linkClickedScreen",
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, prop), {
+                userContext: userContext,
+            })
+        );
     };
     PasswordlessPreBuiltUI.SignInUpTheme = SignInUpThemeWrapper;
     return PasswordlessPreBuiltUI;

--- a/lib/build/recipe/authRecipe/index.d.ts
+++ b/lib/build/recipe/authRecipe/index.d.ts
@@ -1,6 +1,6 @@
 import RecipeModule from "../recipeModule";
 import type { NormalisedConfig, GetRedirectionURLContext, OnHandleEventContext } from "./types";
-import type { NormalisedConfigWithAppInfoAndRecipeID } from "../../types";
+import type { NormalisedConfigWithAppInfoAndRecipeID, UserContext } from "../../types";
 export default abstract class AuthRecipe<
     T,
     Action,
@@ -9,6 +9,6 @@ export default abstract class AuthRecipe<
 > extends RecipeModule<T | GetRedirectionURLContext, Action, R | OnHandleEventContext, N> {
     constructor(config: NormalisedConfigWithAppInfoAndRecipeID<N>);
     getAuthRecipeDefaultRedirectionURL: (context: GetRedirectionURLContext) => Promise<string>;
-    signOut: (input?: { userContext?: any }) => Promise<void>;
-    doesSessionExist: (input?: { userContext?: any }) => Promise<boolean>;
+    signOut: (input?: { userContext?: UserContext }) => Promise<void>;
+    doesSessionExist: (input?: { userContext?: UserContext }) => Promise<boolean>;
 }

--- a/lib/build/recipe/authRecipe/types.d.ts
+++ b/lib/build/recipe/authRecipe/types.d.ts
@@ -9,6 +9,7 @@ export declare type NormalisedConfig<T, Action, R> = NormalisedRecipeModuleConfi
 export declare type GetRedirectionURLContext = {
     action: "SUCCESS";
     isNewRecipeUser: boolean;
+    isNewPrimaryUser: boolean;
     redirectToPath?: string;
 };
 export declare type OnHandleEventContext = {

--- a/lib/build/recipe/emailpassword/index.d.ts
+++ b/lib/build/recipe/emailpassword/index.d.ts
@@ -2,6 +2,7 @@
 import { RecipeInterface } from "supertokens-web-js/recipe/emailpassword";
 import { UserInput } from "./types";
 import { GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
+import type { UserContext } from "../../types";
 import type { RecipeFunctionOptions } from "supertokens-web-js/recipe/emailpassword";
 import type { User } from "supertokens-web-js/types";
 export default class Wrapper {
@@ -13,14 +14,14 @@ export default class Wrapper {
         OnHandleEventContext,
         import("./types").NormalisedConfig
     >;
-    static signOut(input?: { userContext?: any }): Promise<void>;
+    static signOut(input?: { userContext?: UserContext }): Promise<void>;
     static submitNewPassword(input: {
         formFields: {
             id: string;
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK";
@@ -45,7 +46,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK" | "PASSWORD_RESET_NOT_ALLOWED";
@@ -66,7 +67,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK";
@@ -93,7 +94,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK";
@@ -118,12 +119,16 @@ export default class Wrapper {
               fetchResponse: Response;
           }
     >;
-    static doesEmailExist(input: { email: string; options?: RecipeFunctionOptions; userContext?: any }): Promise<{
+    static doesEmailExist(input: {
+        email: string;
+        options?: RecipeFunctionOptions;
+        userContext?: UserContext;
+    }): Promise<{
         status: "OK";
         doesExist: boolean;
         fetchResponse: Response;
     }>;
-    static getResetPasswordTokenFromURL(input?: { userContext?: any }): string;
+    static getResetPasswordTokenFromURL(input?: { userContext?: UserContext }): string;
     static ComponentsOverrideProvider: import("react").FC<
         import("react").PropsWithChildren<{
             components: import("./types").ComponentOverrideMap;

--- a/lib/build/recipe/emailpassword/prebuiltui.d.ts
+++ b/lib/build/recipe/emailpassword/prebuiltui.d.ts
@@ -4,7 +4,7 @@ import ResetPasswordUsingTokenTheme from "./components/themes/resetPasswordUsing
 import SignInAndUpTheme from "./components/themes/signInAndUp";
 import EmailPassword from "./recipe";
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { RecipeFeatureComponentMap, FeatureBaseProps } from "../../types";
+import type { RecipeFeatureComponentMap, FeatureBaseProps, UserContext } from "../../types";
 export declare class EmailPasswordPreBuiltUI extends RecipeRouter {
     readonly recipeInstance: EmailPassword;
     static instance?: EmailPasswordPreBuiltUI;
@@ -15,7 +15,7 @@ export declare class EmailPasswordPreBuiltUI extends RecipeRouter {
         componentName: "signinup" | "resetpassword",
         props: FeatureBaseProps<{
             redirectOnSessionExists?: boolean;
-            userContext?: any;
+            userContext: UserContext;
         }>,
         useComponentOverrides?: () => GenericComponentOverrideMap<any>
     ): JSX.Element;
@@ -24,20 +24,20 @@ export declare class EmailPasswordPreBuiltUI extends RecipeRouter {
         componentName: "signinup" | "resetpassword",
         props: FeatureBaseProps<{
             redirectOnSessionExists?: boolean;
-            userContext?: any;
+            userContext: UserContext;
         }>,
         useComponentOverrides?: () => GenericComponentOverrideMap<any>
     ) => JSX.Element;
     static reset(): void;
     static SignInAndUp: (
         prop?: FeatureBaseProps<{
-            redirectOnSessionExists?: boolean;
-            userContext?: any;
+            redirectOnSessionExists?: boolean | undefined;
+            userContext?: UserContext | undefined;
         }>
     ) => JSX.Element;
     static ResetPasswordUsingToken: (
         prop: FeatureBaseProps<{
-            userContext?: any;
+            userContext?: UserContext | undefined;
         }>
     ) => JSX.Element;
     static ResetPasswordUsingTokenTheme: typeof ResetPasswordUsingTokenTheme;
@@ -45,13 +45,13 @@ export declare class EmailPasswordPreBuiltUI extends RecipeRouter {
 }
 declare const SignInAndUp: (
     prop?: FeatureBaseProps<{
-        redirectOnSessionExists?: boolean;
-        userContext?: any;
+        redirectOnSessionExists?: boolean | undefined;
+        userContext?: UserContext | undefined;
     }>
 ) => JSX.Element;
 declare const ResetPasswordUsingToken: (
     prop: FeatureBaseProps<{
-        userContext?: any;
+        userContext?: UserContext | undefined;
     }>
 ) => JSX.Element;
 export { SignInAndUp, ResetPasswordUsingToken, ResetPasswordUsingTokenTheme, SignInAndUpTheme };

--- a/lib/build/recipe/emailpassword/types.d.ts
+++ b/lib/build/recipe/emailpassword/types.d.ts
@@ -18,6 +18,7 @@ import type {
     NormalisedBaseConfig,
     NormalisedFormField,
     ThemeBaseProps,
+    UserContext,
 } from "../../types";
 import type {
     GetRedirectionURLContext as AuthRecipeModuleGetRedirectionURLContext,
@@ -144,7 +145,7 @@ export declare type SignInAndUpThemeProps = {
     };
     dispatch: Dispatch<EmailPasswordSignInAndUpAction>;
     config: NormalisedConfig;
-    userContext?: any;
+    userContext?: UserContext;
 };
 export declare type FormFieldThemeProps = NormalisedFormField & {
     labelComponent?: JSX.Element;
@@ -166,7 +167,7 @@ export declare type PreAPIHookContext = {
     action: PreAndPostAPIHookAction;
     requestInit: RequestInit;
     url: string;
-    userContext: any;
+    userContext: UserContext;
 };
 export declare type GetRedirectionURLContext =
     | AuthRecipeModuleGetRedirectionURLContext
@@ -178,23 +179,23 @@ export declare type OnHandleEventContext =
     | {
           action: "RESET_PASSWORD_EMAIL_SENT";
           email: string;
-          userContext: any;
+          userContext: UserContext;
       }
     | {
           action: "PASSWORD_RESET_SUCCESSFUL";
-          userContext: any;
+          userContext: UserContext;
       }
     | {
           action: "SUCCESS";
           isNewRecipeUser: boolean;
           user: User;
-          userContext: any;
+          userContext: UserContext;
       };
 export declare type ResetPasswordUsingTokenThemeProps = {
     enterEmailForm: EnterEmailProps;
     submitNewPasswordForm: SubmitNewPasswordProps | undefined;
     config: NormalisedConfig;
-    userContext?: any;
+    userContext?: UserContext;
 };
 export declare type EnterEmailProps = NonSignUpFormThemeBaseProps & {
     recipeImplementation: RecipeInterface;

--- a/lib/build/recipe/emailverification/components/features/emailVerification/index.d.ts
+++ b/lib/build/recipe/emailverification/components/features/emailVerification/index.d.ts
@@ -1,10 +1,10 @@
 import * as React from "react";
-import type { FeatureBaseProps } from "../../../../../types";
+import type { FeatureBaseProps, UserContext } from "../../../../../types";
 import type Recipe from "../../../recipe";
 import type { ComponentOverrideMap } from "../../../types";
 declare type Prop = FeatureBaseProps<{
     recipe: Recipe;
-    userContext?: any;
+    userContext?: UserContext;
     useComponentOverrides: () => ComponentOverrideMap;
 }>;
 export declare const EmailVerification: React.FC<Prop>;

--- a/lib/build/recipe/emailverification/index.d.ts
+++ b/lib/build/recipe/emailverification/index.d.ts
@@ -2,6 +2,7 @@
 import { RecipeInterface } from "supertokens-web-js/recipe/emailverification";
 import { GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 import { UserInput } from "./types";
+import type { UserContext } from "../../types";
 import type { RecipeFunctionOptions } from "supertokens-web-js/recipe/emailverification";
 export default class Wrapper {
     static EmailVerificationClaim: import("../../claims/emailVerificationClaim").EmailVerificationClaimClass;
@@ -13,20 +14,20 @@ export default class Wrapper {
         OnHandleEventContext,
         import("./types").NormalisedConfig
     >;
-    static isEmailVerified(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static isEmailVerified(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;
     }>;
-    static verifyEmail(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static verifyEmail(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<{
         status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
         fetchResponse: Response;
     }>;
-    static sendVerificationEmail(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static sendVerificationEmail(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<{
         status: "EMAIL_ALREADY_VERIFIED_ERROR" | "OK";
         fetchResponse: Response;
     }>;
-    static getEmailVerificationTokenFromURL(input?: { userContext?: any }): string;
+    static getEmailVerificationTokenFromURL(input?: { userContext?: UserContext }): string;
     static ComponentsOverrideProvider: import("react").FC<
         import("react").PropsWithChildren<{
             components: import("./types").ComponentOverrideMap;

--- a/lib/build/recipe/emailverification/prebuiltui.d.ts
+++ b/lib/build/recipe/emailverification/prebuiltui.d.ts
@@ -3,7 +3,7 @@ import { RecipeRouter } from "../recipeRouter";
 import { EmailVerificationTheme } from "./components/themes/emailVerification";
 import EmailVerificationRecipe from "./recipe";
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { FeatureBaseProps, RecipeFeatureComponentMap } from "../../types";
+import type { FeatureBaseProps, RecipeFeatureComponentMap, UserContext } from "../../types";
 export declare class EmailVerificationPreBuiltUI extends RecipeRouter {
     readonly recipeInstance: EmailVerificationRecipe;
     static instance?: EmailVerificationPreBuiltUI;
@@ -19,21 +19,21 @@ export declare class EmailVerificationPreBuiltUI extends RecipeRouter {
     getFeatureComponent: (
         _: "emailverification",
         props: FeatureBaseProps<{
-            userContext?: any;
+            userContext: UserContext;
         }>,
         useComponentOverrides?: () => GenericComponentOverrideMap<any>
     ) => JSX.Element;
     static reset(): void;
     static EmailVerification: (
         props: FeatureBaseProps<{
-            userContext?: any;
+            userContext?: UserContext | undefined;
         }>
-    ) => JSX.Element;
+    ) => void;
     static EmailVerificationTheme: typeof EmailVerificationTheme;
 }
 declare const EmailVerification: (
     props: FeatureBaseProps<{
-        userContext?: any;
+        userContext?: UserContext | undefined;
     }>
-) => JSX.Element;
+) => void;
 export { EmailVerification, EmailVerificationTheme };

--- a/lib/build/recipe/emailverification/recipe.d.ts
+++ b/lib/build/recipe/emailverification/recipe.d.ts
@@ -8,7 +8,12 @@ import type {
     OnHandleEventContext,
     PreAndPostAPIHookAction,
 } from "./types";
-import type { NormalisedConfigWithAppInfoAndRecipeID, RecipeInitResult, WebJSRecipeInterface } from "../../types";
+import type {
+    NormalisedConfigWithAppInfoAndRecipeID,
+    RecipeInitResult,
+    UserContext,
+    WebJSRecipeInterface,
+} from "../../types";
 export default class EmailVerification extends RecipeModule<
     GetRedirectionURLContext,
     PreAndPostAPIHookAction,
@@ -28,7 +33,7 @@ export default class EmailVerification extends RecipeModule<
         config?: UserInput
     ): RecipeInitResult<GetRedirectionURLContext, PreAndPostAPIHookAction, OnHandleEventContext, NormalisedConfig>;
     static getInstanceOrThrow(): EmailVerification;
-    isEmailVerified(userContext: any): Promise<{
+    isEmailVerified(userContext: UserContext): Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;

--- a/lib/build/recipe/emailverification/types.d.ts
+++ b/lib/build/recipe/emailverification/types.d.ts
@@ -1,7 +1,7 @@
 import type { SendVerifyEmail } from "./components/themes/emailVerification/sendVerifyEmail";
 import type { VerifyEmailLinkClicked } from "./components/themes/emailVerification/verifyEmailLinkClicked";
 import type { ComponentOverride } from "../../components/componentOverride/componentOverride";
-import type { FeatureBaseConfig, ThemeBaseProps } from "../../types";
+import type { FeatureBaseConfig, ThemeBaseProps, UserContext } from "../../types";
 import type {
     Config as RecipeModuleConfig,
     NormalisedConfig as NormalisedRecipeModuleConfig,
@@ -47,17 +47,17 @@ export declare type PreAPIHookContext = {
     action: PreAndPostAPIHookAction;
     requestInit: RequestInit;
     url: string;
-    userContext: any;
+    userContext: UserContext;
 };
 export declare type OnHandleEventContext = {
     action: "VERIFY_EMAIL_SENT" | "EMAIL_VERIFIED_SUCCESSFUL";
-    userContext: any;
+    userContext: UserContext;
 };
 export declare type EmailVerificationThemeProps = {
     sendVerifyEmailScreen: SendVerifyEmailThemeProps;
     verifyEmailLinkClickedScreen?: VerifyEmailLinkClickedThemeProps;
     config: NormalisedConfig;
-    userContext?: any;
+    userContext?: UserContext;
 };
 export declare type SendVerifyEmailThemeProps = ThemeBaseProps & {
     recipeImplementation: RecipeInterface;

--- a/lib/build/recipe/multitenancy/recipe.d.ts
+++ b/lib/build/recipe/multitenancy/recipe.d.ts
@@ -1,7 +1,12 @@
 import MultitenancyWebJS from "supertokens-web-js/recipe/multitenancy";
 import { BaseRecipeModule } from "../recipeModule/baseRecipeModule";
 import type { NormalisedConfig, UserInput, GetLoginMethodsResponseNormalized } from "./types";
-import type { RecipeInitResult, NormalisedConfigWithAppInfoAndRecipeID, WebJSRecipeInterface } from "../../types";
+import type {
+    RecipeInitResult,
+    NormalisedConfigWithAppInfoAndRecipeID,
+    WebJSRecipeInterface,
+    UserContext,
+} from "../../types";
 export default class Multitenancy extends BaseRecipeModule<any, any, any, any> {
     readonly webJSRecipe: WebJSRecipeInterface<typeof MultitenancyWebJS>;
     static instance?: Multitenancy;
@@ -12,7 +17,9 @@ export default class Multitenancy extends BaseRecipeModule<any, any, any, any> {
         config: NormalisedConfigWithAppInfoAndRecipeID<NormalisedConfig>,
         webJSRecipe?: WebJSRecipeInterface<typeof MultitenancyWebJS>
     );
-    getCurrentDynamicLoginMethods(input: { userContext?: any }): Promise<GetLoginMethodsResponseNormalized | undefined>;
+    getCurrentDynamicLoginMethods(input: {
+        userContext: UserContext;
+    }): Promise<GetLoginMethodsResponseNormalized | undefined>;
     static getDynamicLoginMethods(
         input: Parameters<typeof MultitenancyWebJS.getLoginMethods>[0]
     ): Promise<GetLoginMethodsResponseNormalized>;

--- a/lib/build/recipe/passwordless/components/features/signInAndUp/index.d.ts
+++ b/lib/build/recipe/passwordless/components/features/signInAndUp/index.d.ts
@@ -1,25 +1,25 @@
 import * as React from "react";
-import type { Navigate, FeatureBaseProps } from "../../../../../types";
+import type { Navigate, FeatureBaseProps, UserContext } from "../../../../../types";
 import type Recipe from "../../../recipe";
 import type { ComponentOverrideMap } from "../../../types";
 import type { PasswordlessSignInUpAction, SignInUpState, SignInUpChildProps } from "../../../types";
 import type { RecipeInterface } from "supertokens-web-js/recipe/passwordless";
 export declare const useFeatureReducer: (
     recipeImpl: RecipeInterface | undefined,
-    userContext: any
+    userContext: UserContext
 ) => [SignInUpState, React.Dispatch<PasswordlessSignInUpAction>];
 export declare function useChildProps(
     recipe: Recipe,
     dispatch: React.Dispatch<PasswordlessSignInUpAction>,
     state: SignInUpState,
-    userContext: any,
+    userContext: UserContext,
     navigate?: Navigate
 ): SignInUpChildProps;
 export declare function useChildProps(
     recipe: Recipe | undefined,
     dispatch: React.Dispatch<PasswordlessSignInUpAction>,
     state: SignInUpState,
-    userContext: any,
+    userContext: UserContext,
     navigate?: Navigate
 ): SignInUpChildProps | undefined;
 export declare const SignInUpFeature: React.FC<

--- a/lib/build/recipe/passwordless/index.d.ts
+++ b/lib/build/recipe/passwordless/index.d.ts
@@ -2,6 +2,7 @@
 import { RecipeInterface } from "supertokens-web-js/recipe/passwordless";
 import { UserInput } from "./types";
 import { GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
+import type { UserContext } from "../../types";
 import type { RecipeFunctionOptions } from "supertokens-web-js/recipe/passwordless";
 import type { PasswordlessFlowType } from "supertokens-web-js/recipe/passwordless/types";
 import type { User } from "supertokens-web-js/types";
@@ -14,17 +15,17 @@ export default class Wrapper {
         OnHandleEventContext,
         import("./types").NormalisedConfig
     >;
-    static signOut(input?: { userContext?: any }): Promise<void>;
+    static signOut(input?: { userContext?: UserContext }): Promise<void>;
     static createCode(
         input:
             | {
                   email: string;
-                  userContext?: any;
+                  userContext?: UserContext;
                   options?: RecipeFunctionOptions;
               }
             | {
                   phoneNumber: string;
-                  userContext?: any;
+                  userContext?: UserContext;
                   options?: RecipeFunctionOptions;
               }
     ): Promise<
@@ -40,7 +41,7 @@ export default class Wrapper {
               reason: string;
           }
     >;
-    static resendCode(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static resendCode(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<{
         status: "OK" | "RESTART_FLOW_ERROR";
         fetchResponse: Response;
     }>;
@@ -48,11 +49,11 @@ export default class Wrapper {
         input?:
             | {
                   userInputCode: string;
-                  userContext?: any;
+                  userContext?: UserContext;
                   options?: RecipeFunctionOptions;
               }
             | {
-                  userContext?: any;
+                  userContext?: UserContext;
                   options?: RecipeFunctionOptions;
               }
     ): Promise<
@@ -78,23 +79,27 @@ export default class Wrapper {
               fetchResponse: Response;
           }
     >;
-    static getLinkCodeFromURL(input?: { userContext?: any }): string;
-    static getPreAuthSessionIdFromURL(input?: { userContext?: any }): string;
-    static doesEmailExist(input: { email: string; userContext?: any; options?: RecipeFunctionOptions }): Promise<{
-        status: "OK";
-        doesExist: boolean;
-        fetchResponse: Response;
-    }>;
-    static doesPhoneNumberExist(input: {
-        phoneNumber: string;
-        userContext?: any;
+    static getLinkCodeFromURL(input?: { userContext?: UserContext }): string;
+    static getPreAuthSessionIdFromURL(input?: { userContext?: UserContext }): string;
+    static doesEmailExist(input: {
+        email: string;
+        userContext?: UserContext;
         options?: RecipeFunctionOptions;
     }): Promise<{
         status: "OK";
         doesExist: boolean;
         fetchResponse: Response;
     }>;
-    static getLoginAttemptInfo<CustomLoginAttemptInfoProperties>(input?: { userContext?: any }): Promise<
+    static doesPhoneNumberExist(input: {
+        phoneNumber: string;
+        userContext?: UserContext;
+        options?: RecipeFunctionOptions;
+    }): Promise<{
+        status: "OK";
+        doesExist: boolean;
+        fetchResponse: Response;
+    }>;
+    static getLoginAttemptInfo<CustomLoginAttemptInfoProperties>(input?: { userContext?: UserContext }): Promise<
         | undefined
         | ({
               deviceId: string;
@@ -108,9 +113,9 @@ export default class Wrapper {
             preAuthSessionId: string;
             flowType: PasswordlessFlowType;
         } & CustomStateProperties;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<void>;
-    static clearLoginAttemptInfo(input?: { userContext?: any }): Promise<void>;
+    static clearLoginAttemptInfo(input?: { userContext?: UserContext }): Promise<void>;
     static ComponentsOverrideProvider: import("react").FC<
         import("react").PropsWithChildren<{
             components: import("./types").ComponentOverrideMap;

--- a/lib/build/recipe/passwordless/prebuiltui.d.ts
+++ b/lib/build/recipe/passwordless/prebuiltui.d.ts
@@ -2,7 +2,7 @@ import { RecipeRouter } from "../recipeRouter";
 import SignInUpTheme from "./components/themes/signInUp";
 import Passwordless from "./recipe";
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { RecipeFeatureComponentMap, FeatureBaseProps, Navigate } from "../../types";
+import type { RecipeFeatureComponentMap, FeatureBaseProps, Navigate, UserContext } from "../../types";
 import type { PropsWithChildren } from "react";
 export declare class PasswordlessPreBuiltUI extends RecipeRouter {
     readonly recipeInstance: Passwordless;
@@ -14,7 +14,7 @@ export declare class PasswordlessPreBuiltUI extends RecipeRouter {
         componentName: "signInUp" | "linkClickedScreen",
         props: FeatureBaseProps<{
             redirectOnSessionExists?: boolean;
-            userContext?: any;
+            userContext: UserContext;
         }>,
         useComponentOverrides?: () => GenericComponentOverrideMap<any>
     ): JSX.Element;
@@ -23,35 +23,35 @@ export declare class PasswordlessPreBuiltUI extends RecipeRouter {
         componentName: "signInUp" | "linkClickedScreen",
         props: FeatureBaseProps<{
             redirectOnSessionExists?: boolean;
-            userContext?: any;
+            userContext: UserContext;
         }>,
         useComponentOverrides?: () => GenericComponentOverrideMap<any>
     ) => JSX.Element;
     static reset(): void;
     static SignInUp: (
         prop?: PropsWithChildren<{
-            redirectOnSessionExists?: boolean;
-            navigate?: Navigate;
-            userContext?: any;
+            redirectOnSessionExists?: boolean | undefined;
+            navigate?: Navigate | undefined;
+            userContext?: UserContext | undefined;
         }>
     ) => JSX.Element;
     static LinkClicked: (
         prop: FeatureBaseProps<{
-            userContext?: any;
+            userContext?: UserContext | undefined;
         }>
     ) => JSX.Element;
     static SignInUpTheme: typeof SignInUpTheme;
 }
 declare const SignInUp: (
     prop?: PropsWithChildren<{
-        redirectOnSessionExists?: boolean;
-        navigate?: Navigate;
-        userContext?: any;
+        redirectOnSessionExists?: boolean | undefined;
+        navigate?: Navigate | undefined;
+        userContext?: UserContext | undefined;
     }>
 ) => JSX.Element;
 declare const LinkClicked: (
     prop: FeatureBaseProps<{
-        userContext?: any;
+        userContext?: UserContext | undefined;
     }>
 ) => JSX.Element;
 export { SignInUp, LinkClicked, SignInUpTheme };

--- a/lib/build/recipe/passwordless/types.d.ts
+++ b/lib/build/recipe/passwordless/types.d.ts
@@ -9,7 +9,7 @@ import type { UserInputCodeForm } from "./components/themes/signInUp/userInputCo
 import type { UserInputCodeFormFooter } from "./components/themes/signInUp/userInputCodeFormFooter";
 import type { UserInputCodeFormHeader } from "./components/themes/signInUp/userInputCodeFormHeader";
 import type { ComponentOverride } from "../../components/componentOverride/componentOverride";
-import type { FeatureBaseConfig, NormalisedBaseConfig, WebJSRecipeInterface } from "../../types";
+import type { FeatureBaseConfig, NormalisedBaseConfig, UserContext, WebJSRecipeInterface } from "../../types";
 import type {
     GetRedirectionURLContext as AuthRecipeModuleGetRedirectionURLContext,
     OnHandleEventContext as AuthRecipeModuleOnHandleEventContext,
@@ -128,7 +128,7 @@ export declare type SignInUpProps = {
         loaded: boolean;
         error: string | undefined;
     };
-    userContext?: any;
+    userContext?: UserContext;
 };
 export declare type LoginAttemptInfo = {
     deviceId: string;

--- a/lib/build/recipe/recipeModule/index.d.ts
+++ b/lib/build/recipe/recipeModule/index.d.ts
@@ -1,6 +1,6 @@
 import { BaseRecipeModule } from "./baseRecipeModule";
 import type { NormalisedConfig } from "./types";
-import type { Navigate } from "../../types";
+import type { Navigate, UserContext } from "../../types";
 export default abstract class RecipeModule<
     GetRedirectionURLContextType,
     Action,
@@ -11,8 +11,8 @@ export default abstract class RecipeModule<
         context: GetRedirectionURLContextType,
         navigate?: Navigate,
         queryParams?: Record<string, string>,
-        userContext?: any
+        userContext?: UserContext
     ) => Promise<void>;
-    getRedirectUrl: (context: GetRedirectionURLContextType, userContext?: any) => Promise<string | null>;
+    getRedirectUrl: (context: GetRedirectionURLContextType, userContext: UserContext) => Promise<string | null>;
     getDefaultRedirectionURL(_: GetRedirectionURLContextType): Promise<string>;
 }

--- a/lib/build/recipe/recipeModule/types.d.ts
+++ b/lib/build/recipe/recipeModule/types.d.ts
@@ -1,15 +1,16 @@
+import type { UserContext } from "../../types";
 export declare type RecipePreAPIHookContext<Action> = {
     requestInit: RequestInit;
     url: string;
     action: Action;
-    userContext: any;
+    userContext: UserContext;
 };
 export declare type RecipePostAPIHookContext<Action> = {
     action: Action;
     requestInit: RequestInit;
     url: string;
     fetchResponse: Response;
-    userContext: any;
+    userContext: UserContext;
 };
 export declare type RecipePreAPIHookFunction<Action> = (context: RecipePreAPIHookContext<Action>) => Promise<{
     url: string;
@@ -20,7 +21,7 @@ export declare type RecipeOnHandleEventFunction<EventType> = (context: EventType
 export declare type UserInput<GetRedirectionURLContextType, Action, OnHandleEventContextType> = {
     getRedirectionURL?: (
         context: GetRedirectionURLContextType,
-        userContext?: any
+        userContext: UserContext
     ) => Promise<string | undefined | null>;
     preAPIHook?: RecipePreAPIHookFunction<Action>;
     postAPIHook?: RecipePostAPIHookFunction<Action>;
@@ -34,7 +35,10 @@ export declare type Config<GetRedirectionURLContextType, Action, OnHandleEventCo
     OnHandleEventContextType
 >;
 export declare type NormalisedConfig<GetRedirectionURLContextType, Action, OnHandleEventContextType> = {
-    getRedirectionURL: (context: GetRedirectionURLContextType, userContext?: any) => Promise<string | undefined | null>;
+    getRedirectionURL: (
+        context: GetRedirectionURLContextType,
+        userContext: UserContext
+    ) => Promise<string | undefined | null>;
     onHandleEvent: RecipeOnHandleEventFunction<OnHandleEventContextType>;
     useShadowDom: boolean;
     rootStyle: string;

--- a/lib/build/recipe/session/index.d.ts
+++ b/lib/build/recipe/session/index.d.ts
@@ -6,6 +6,7 @@ import { PrimitiveArrayClaim } from "../../claims/primitiveArrayClaim";
 import { PrimitiveClaim } from "../../claims/primitiveClaim";
 import SessionContext from "./sessionContext";
 import { InputType, SessionContextType } from "./types";
+import type { UserContext } from "../../types";
 export default class SessionAPIWrapper {
     static useSessionContext: () => SessionContextType;
     static useClaimValue: <T>(claim: SessionClaim<T>) =>
@@ -20,27 +21,27 @@ export default class SessionAPIWrapper {
     static SessionAuth: import("react").FC<
         import("react").PropsWithChildren<
             import("./sessionAuth").SessionAuthProps & {
-                userContext?: any;
+                userContext?: UserContext | undefined;
             }
         >
     >;
     static init(config?: InputType): import("../../types").RecipeInitResult<unknown, unknown, unknown, any>;
-    static getUserId(input?: { userContext?: any }): Promise<string>;
-    static getAccessToken(input?: { userContext?: any }): Promise<string | undefined>;
-    static getAccessTokenPayloadSecurely(input?: { userContext?: any }): Promise<any>;
+    static getUserId(input?: { userContext?: UserContext }): Promise<string>;
+    static getAccessToken(input?: { userContext?: UserContext }): Promise<string | undefined>;
+    static getAccessTokenPayloadSecurely(input?: { userContext?: UserContext }): Promise<any>;
     static attemptRefreshingSession(): Promise<boolean>;
-    static doesSessionExist(input?: { userContext?: any }): Promise<boolean>;
+    static doesSessionExist(input?: { userContext?: UserContext }): Promise<boolean>;
     /**
      * @deprecated
      */
-    static addAxiosInterceptors(axiosInstance: any, userContext?: any): void;
-    static signOut(input?: { userContext?: any }): Promise<void>;
+    static addAxiosInterceptors(axiosInstance: any, userContext?: UserContext): void;
+    static signOut(input?: { userContext?: UserContext }): Promise<void>;
     static validateClaims(input?: {
         overrideGlobalClaimValidators?: (
             globalClaimValidators: SessionClaimValidator[],
-            userContext: any
+            userContext: UserContext
         ) => SessionClaimValidator[];
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<ClaimValidationError[]> | ClaimValidationError[];
     static getInvalidClaimsFromResponse(input: {
         response:
@@ -48,9 +49,9 @@ export default class SessionAPIWrapper {
                   data: any;
               }
             | Response;
-        userContext: any;
+        userContext: UserContext;
     }): Promise<ClaimValidationError[]>;
-    static getClaimValue<T>(input: { claim: SessionClaim<T>; userContext?: any }): Promise<T | undefined>;
+    static getClaimValue<T>(input: { claim: SessionClaim<T>; userContext?: UserContext }): Promise<T | undefined>;
     static ComponentsOverrideProvider: import("react").FC<
         import("react").PropsWithChildren<{
             components: import("./types").ComponentOverrideMap;
@@ -70,7 +71,7 @@ declare const useClaimValue: <T>(claim: SessionClaim<T>) =>
 declare const SessionAuth: import("react").FC<
     import("react").PropsWithChildren<
         import("./sessionAuth").SessionAuthProps & {
-            userContext?: any;
+            userContext?: UserContext | undefined;
         }
     >
 >;

--- a/lib/build/recipe/session/prebuiltui.d.ts
+++ b/lib/build/recipe/session/prebuiltui.d.ts
@@ -3,7 +3,7 @@ import { RecipeRouter } from "../recipeRouter";
 import { AccessDeniedScreenTheme } from "./components/themes/accessDeniedScreenTheme";
 import Session from "./recipe";
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { RecipeFeatureComponentMap, FeatureBaseProps } from "../../types";
+import type { RecipeFeatureComponentMap, FeatureBaseProps, UserContext } from "../../types";
 export declare class SessionPreBuiltUI extends RecipeRouter {
     readonly recipeInstance: Session;
     static instance?: SessionPreBuiltUI;
@@ -14,7 +14,7 @@ export declare class SessionPreBuiltUI extends RecipeRouter {
         componentName: "accessDenied",
         props: FeatureBaseProps<{
             redirectOnSessionExists?: boolean;
-            userContext?: any;
+            userContext: UserContext;
         }>,
         useComponentOverrides?: () => GenericComponentOverrideMap<any>
     ): JSX.Element;
@@ -22,21 +22,21 @@ export declare class SessionPreBuiltUI extends RecipeRouter {
     getFeatureComponent: (
         componentName: "accessDenied",
         props: FeatureBaseProps<{
-            userContext?: any;
+            userContext: UserContext;
         }>,
         useComponentOverrides?: () => GenericComponentOverrideMap<any>
     ) => JSX.Element;
     static reset(): void;
     static AccessDeniedScreen: (
         prop?: FeatureBaseProps<{
-            userContext?: any;
+            userContext?: UserContext | undefined;
         }>
     ) => React.ReactElement;
     static AccessDeniedScreenTheme: import("react").FC<import("./types").AccessDeniedThemeProps>;
 }
 declare const AccessDeniedScreen: (
     prop?: FeatureBaseProps<{
-        userContext?: any;
+        userContext?: UserContext | undefined;
     }>
 ) => React.ReactElement;
 export { AccessDeniedScreen, AccessDeniedScreenTheme };

--- a/lib/build/recipe/session/recipe.d.ts
+++ b/lib/build/recipe/session/recipe.d.ts
@@ -3,7 +3,7 @@ import WebJSSessionRecipe from "supertokens-web-js/recipe/session";
 import RecipeModule from "../recipeModule";
 import type { NormalisedSessionConfig } from "./types";
 import type { RecipeEventWithSessionContext, InputType } from "./types";
-import type { Navigate, NormalisedConfigWithAppInfoAndRecipeID, RecipeInitResult } from "../../types";
+import type { Navigate, NormalisedConfigWithAppInfoAndRecipeID, RecipeInitResult, UserContext } from "../../types";
 import type { ClaimValidationError, SessionClaimValidator } from "supertokens-web-js/recipe/session";
 import type { SessionClaim } from "supertokens-web-js/recipe/session";
 export default class Session extends RecipeModule<unknown, unknown, unknown, NormalisedSessionConfig> {
@@ -17,21 +17,21 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
         config: NormalisedConfigWithAppInfoAndRecipeID<NormalisedSessionConfig>,
         webJSRecipe?: Omit<typeof WebJSSessionRecipe, "init" | "default">
     );
-    getUserId: (input: { userContext: any }) => Promise<string>;
-    getAccessToken: (input: { userContext: any }) => Promise<string | undefined>;
+    getUserId: (input: { userContext: UserContext }) => Promise<string>;
+    getAccessToken: (input: { userContext: UserContext }) => Promise<string | undefined>;
     getClaimValue: <T extends unknown>(input: {
         claim: SessionWebJS.SessionClaim<T>;
-        userContext: any;
+        userContext: UserContext;
     }) => Promise<T | undefined>;
-    getAccessTokenPayloadSecurely: (input: { userContext: any }) => Promise<any>;
-    doesSessionExist: (input: { userContext: any }) => Promise<boolean>;
-    signOut: (input: { userContext: any }) => Promise<void>;
+    getAccessTokenPayloadSecurely: (input: { userContext: UserContext }) => Promise<any>;
+    doesSessionExist: (input: { userContext: UserContext }) => Promise<boolean>;
+    signOut: (input: { userContext: UserContext }) => Promise<void>;
     attemptRefreshingSession: () => Promise<boolean>;
     validateClaims: (input: {
         overrideGlobalClaimValidators?:
-            | ((globalClaimValidators: SessionClaimValidator[], userContext: any) => SessionClaimValidator[])
+            | ((globalClaimValidators: SessionClaimValidator[], userContext: UserContext) => SessionClaimValidator[])
             | undefined;
-        userContext: any;
+        userContext: UserContext;
     }) => Promise<ClaimValidationError[]> | ClaimValidationError[];
     getInvalidClaimsFromResponse: (input: {
         response:
@@ -39,7 +39,7 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
                   data: any;
               }
             | Response;
-        userContext: any;
+        userContext: UserContext;
     }) => Promise<ClaimValidationError[]>;
     /**
      * @returns Function to remove event listener
@@ -51,7 +51,7 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
             context: any,
             navigate?: Navigate,
             queryParams?: Record<string, string>,
-            userContext?: any
+            userContext?: UserContext
         ) => Promise<void>
     ) => void;
     validateGlobalClaimsAndHandleSuccessRedirection: (
@@ -63,7 +63,7 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
                 redirectToPath?: string;
             };
         },
-        userContext?: any,
+        userContext?: UserContext,
         navigate?: Navigate
     ) => Promise<void>;
     /**
@@ -73,7 +73,7 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
     getDefaultRedirectionURL: () => Promise<string>;
     private notifyListeners;
     private getSessionContext;
-    static addAxiosInterceptors(axiosInstance: any, userContext: any): void;
+    static addAxiosInterceptors(axiosInstance: any, userContext: UserContext): void;
     static init(config?: InputType): RecipeInitResult<unknown, unknown, unknown, any>;
     static getInstanceOrThrow(): Session;
     static getInstance(): Session | undefined;

--- a/lib/build/recipe/session/recipe.d.ts
+++ b/lib/build/recipe/session/recipe.d.ts
@@ -60,6 +60,7 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
             successRedirectContext: {
                 action: "SUCCESS";
                 isNewRecipeUser: boolean;
+                isNewPrimaryUser: boolean;
                 redirectToPath?: string;
             };
         },

--- a/lib/build/recipe/session/sessionAuth.d.ts
+++ b/lib/build/recipe/session/sessionAuth.d.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import type { Navigate, ReactComponentClass, SessionClaimValidator } from "../../types";
+import type { Navigate, ReactComponentClass, SessionClaimValidator, UserContext } from "../../types";
 import type { PropsWithChildren } from "react";
 import type { ClaimValidationError } from "supertokens-web-js/recipe/session";
 export declare type SessionAuthProps = {
@@ -12,20 +12,20 @@ export declare type SessionAuthProps = {
      */
     doRedirection?: boolean;
     accessDeniedScreen?: ReactComponentClass<{
-        userContext?: any;
+        userContext?: UserContext;
         navigate?: Navigate;
         validationError: ClaimValidationError;
     }>;
     onSessionExpired?: () => void;
     overrideGlobalClaimValidators?: (
         globalClaimValidators: SessionClaimValidator[],
-        userContext: any
+        userContext: UserContext
     ) => SessionClaimValidator[];
 };
 declare const SessionAuthWrapper: React.FC<
     PropsWithChildren<
         SessionAuthProps & {
-            userContext?: any;
+            userContext?: UserContext;
         }
     >
 >;

--- a/lib/build/recipe/session/utils.d.ts
+++ b/lib/build/recipe/session/utils.d.ts
@@ -1,4 +1,5 @@
 import type { InputType, NormalisedSessionConfig } from "./types";
+import type { UserContext } from "../../types";
 import type { SessionClaimValidator } from "../../types";
 import type { ClaimValidationError } from "supertokens-web-js/recipe/session";
 export declare function normaliseSessionConfig(config?: InputType): NormalisedSessionConfig;
@@ -9,10 +10,10 @@ export declare const getFailureRedirectionInfo: ({
 }: {
     invalidClaims: ClaimValidationError[];
     overrideGlobalClaimValidators?:
-        | ((globalClaimValidators: SessionClaimValidator[], userContext: any) => SessionClaimValidator[])
+        | ((globalClaimValidators: SessionClaimValidator[], userContext: UserContext) => SessionClaimValidator[])
         | undefined;
-    userContext: any;
+    userContext: UserContext;
 }) => Promise<{
-    redirectPath?: string | null | undefined;
+    redirectPath?: string | undefined;
     failedClaim?: ClaimValidationError | undefined;
 }>;

--- a/lib/build/recipe/thirdparty/components/themes/signInAndUp/index.d.ts
+++ b/lib/build/recipe/thirdparty/components/themes/signInAndUp/index.d.ts
@@ -1,8 +1,9 @@
 /// <reference types="react" />
+import type { UserContext } from "../../../../../types";
 import type { SignInAndUpThemeProps } from "../../../types";
 declare const SignInAndUpThemeWrapper: React.FC<
     SignInAndUpThemeProps & {
-        userContext?: any;
+        userContext?: UserContext;
     }
 >;
 export default SignInAndUpThemeWrapper;

--- a/lib/build/recipe/thirdparty/index.d.ts
+++ b/lib/build/recipe/thirdparty/index.d.ts
@@ -14,6 +14,7 @@ import LinkedIn from "./providers/linkedIn";
 import Okta from "./providers/okta";
 import Twitter from "./providers/twitter";
 import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
+import type { UserContext } from "../../types";
 import type { StateObject } from "supertokens-web-js/recipe/thirdparty";
 import type { RecipeFunctionOptions } from "supertokens-web-js/recipe/thirdpartyemailpassword";
 import type { User } from "supertokens-web-js/types";
@@ -26,21 +27,21 @@ export default class Wrapper {
         OnHandleEventContext,
         import("./types").NormalisedConfig
     >;
-    static signOut(input?: { userContext?: any }): Promise<void>;
-    static redirectToThirdPartyLogin(input: { thirdPartyId: string; userContext?: any }): Promise<{
+    static signOut(input?: { userContext?: UserContext }): Promise<void>;
+    static redirectToThirdPartyLogin(input: { thirdPartyId: string; userContext?: UserContext }): Promise<{
         status: "OK" | "ERROR";
     }>;
     static getStateAndOtherInfoFromStorage<CustomStateProperties>(input?: {
-        userContext?: any;
+        userContext?: UserContext;
     }): (StateObject & CustomStateProperties) | undefined;
     static getAuthorisationURLWithQueryParamsAndSetState(input: {
         thirdPartyId: string;
         frontendRedirectURI: string;
         redirectURIOnProviderDashboard?: string;
-        userContext?: any;
+        userContext?: UserContext;
         options?: RecipeFunctionOptions;
     }): Promise<string>;
-    static signInAndUp(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<
+    static signInAndUp(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<
         | {
               status: "OK";
               user: User;

--- a/lib/build/recipe/thirdparty/prebuiltui.d.ts
+++ b/lib/build/recipe/thirdparty/prebuiltui.d.ts
@@ -5,7 +5,7 @@ import { SignInAndUpCallbackTheme } from "./components/themes/signInAndUpCallbac
 import ThirdParty from "./recipe";
 import type { NormalisedConfig } from "./types";
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { RecipeFeatureComponentMap, FeatureBaseProps } from "../../types";
+import type { RecipeFeatureComponentMap, FeatureBaseProps, UserContext } from "../../types";
 export declare class ThirdPartyPreBuiltUI extends RecipeRouter {
     readonly recipeInstance: ThirdParty;
     static instance?: ThirdPartyPreBuiltUI;
@@ -16,7 +16,7 @@ export declare class ThirdPartyPreBuiltUI extends RecipeRouter {
         componentName: "signinup" | "signinupcallback",
         props: FeatureBaseProps<{
             redirectOnSessionExists?: boolean;
-            userContext?: any;
+            userContext: UserContext;
         }>,
         useComponentOverrides?: () => GenericComponentOverrideMap<any>
     ): JSX.Element;
@@ -25,38 +25,38 @@ export declare class ThirdPartyPreBuiltUI extends RecipeRouter {
         componentName: "signinup" | "signinupcallback",
         props: FeatureBaseProps<{
             redirectOnSessionExists?: boolean;
-            userContext?: any;
+            userContext: UserContext;
         }>,
         useComponentOverrides?: () => GenericComponentOverrideMap<any>
     ) => JSX.Element;
     static reset(): void;
     static SignInAndUp: (
         prop?: FeatureBaseProps<{
-            redirectOnSessionExists?: boolean;
-            userContext?: any;
+            redirectOnSessionExists?: boolean | undefined;
+            userContext?: UserContext | undefined;
         }>
     ) => JSX.Element;
     static SignInAndUpCallback: (
         prop: FeatureBaseProps<{
-            userContext?: any;
+            userContext?: UserContext | undefined;
         }>
     ) => JSX.Element;
     static SignInAndUpTheme: import("react").FC<
         import("./types").SignInAndUpThemeProps & {
-            userContext?: any;
+            userContext?: UserContext | undefined;
         }
     >;
     static SignInAndUpCallbackTheme: (props: { config: NormalisedConfig }) => JSX.Element;
 }
 declare const SignInAndUp: (
     prop?: FeatureBaseProps<{
-        redirectOnSessionExists?: boolean;
-        userContext?: any;
+        redirectOnSessionExists?: boolean | undefined;
+        userContext?: UserContext | undefined;
     }>
 ) => JSX.Element;
 declare const SignInAndUpCallback: (
     prop: FeatureBaseProps<{
-        userContext?: any;
+        userContext?: UserContext | undefined;
     }>
 ) => JSX.Element;
 export { SignInAndUp, SignInAndUpCallback, SignInAndUpCallbackTheme, SignInAndUpTheme };

--- a/lib/build/recipe/thirdparty/types.d.ts
+++ b/lib/build/recipe/thirdparty/types.d.ts
@@ -5,7 +5,7 @@ import type { SignInAndUpCallbackTheme } from "./components/themes/signInAndUpCa
 import type Provider from "./providers";
 import type { CustomProviderConfig } from "./providers/types";
 import type { ComponentOverride } from "../../components/componentOverride/componentOverride";
-import type { FeatureBaseConfig, NormalisedBaseConfig, WebJSRecipeInterface } from "../../types";
+import type { FeatureBaseConfig, NormalisedBaseConfig, UserContext, WebJSRecipeInterface } from "../../types";
 import type {
     GetRedirectionURLContext as AuthRecipeModuleGetRedirectionURLContext,
     OnHandleEventContext as AuthRecipeModuleOnHandleEventContext,
@@ -63,7 +63,7 @@ export declare type PreAPIHookContext = {
     action: PreAndPostAPIHookAction;
     requestInit: RequestInit;
     url: string;
-    userContext: any;
+    userContext: UserContext;
 };
 export declare type OnHandleEventContext =
     | AuthRecipeModuleOnHandleEventContext
@@ -71,7 +71,7 @@ export declare type OnHandleEventContext =
           action: "SUCCESS";
           isNewRecipeUser: boolean;
           user: User;
-          userContext: any;
+          userContext: UserContext;
       };
 export declare type SignInAndUpThemeProps = {
     featureState: {

--- a/lib/build/recipe/thirdparty/utils.d.ts
+++ b/lib/build/recipe/thirdparty/utils.d.ts
@@ -6,17 +6,17 @@ import type {
     SignInAndUpFeatureUserInput,
     Config,
 } from "./types";
-import type { WebJSRecipeInterface } from "../../types";
+import type { UserContext, WebJSRecipeInterface } from "../../types";
 import type ThirdPartyWebJS from "supertokens-web-js/recipe/thirdparty";
 export declare function normaliseThirdPartyConfig(config: Config | undefined): NormalisedConfig;
 export declare function normaliseSignInAndUpFeature(
     config: SignInAndUpFeatureUserInput | undefined
 ): NormalisedSignInAndUpFeatureConfig;
-export declare function matchRecipeIdUsingState(recipe: Recipe, userContext: any): boolean;
+export declare function matchRecipeIdUsingState(recipe: Recipe, userContext: UserContext): boolean;
 export declare function redirectToThirdPartyLogin(input: {
     thirdPartyId: string;
     config: NormalisedConfig;
-    userContext: any;
+    userContext: UserContext;
     recipeImplementation: WebJSRecipeInterface<typeof ThirdPartyWebJS>;
 }): Promise<{
     status: "OK" | "ERROR";

--- a/lib/build/recipe/thirdpartyemailpassword/components/themes/signInAndUp/index.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/components/themes/signInAndUp/index.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="react" />
+import type { UserContext } from "../../../../../types";
 import type { ThirdPartyEmailPasswordSignInAndUpThemeProps } from "../../../types";
 export default function SignInAndUpThemeWrapper(
     props: ThirdPartyEmailPasswordSignInAndUpThemeProps & {
-        userContext?: any;
+        userContext?: UserContext;
     }
 ): JSX.Element;

--- a/lib/build/recipe/thirdpartyemailpassword/index.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/index.d.ts
@@ -16,6 +16,7 @@ import {
     Twitter,
 } from "../thirdparty/";
 import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
+import type { UserContext } from "../../types";
 import type { StateObject } from "supertokens-web-js/recipe/thirdparty";
 import type { RecipeFunctionOptions } from "supertokens-web-js/recipe/thirdpartyemailpassword";
 import type { User } from "supertokens-web-js/types";
@@ -28,14 +29,14 @@ export default class Wrapper {
         OnHandleEventContext,
         import("./types").NormalisedConfig
     >;
-    static signOut(input?: { userContext?: any }): Promise<void>;
+    static signOut(input?: { userContext?: UserContext }): Promise<void>;
     static submitNewPassword(input: {
         formFields: {
             id: string;
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK";
@@ -60,7 +61,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK" | "PASSWORD_RESET_NOT_ALLOWED";
@@ -81,7 +82,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK";
@@ -108,7 +109,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK";
@@ -133,16 +134,20 @@ export default class Wrapper {
               fetchResponse: Response;
           }
     >;
-    static doesEmailExist(input: { email: string; options?: RecipeFunctionOptions; userContext?: any }): Promise<{
+    static doesEmailExist(input: {
+        email: string;
+        options?: RecipeFunctionOptions;
+        userContext?: UserContext;
+    }): Promise<{
         status: "OK";
         doesExist: boolean;
         fetchResponse: Response;
     }>;
-    static getResetPasswordTokenFromURL(input?: { userContext?: any }): string;
-    static redirectToThirdPartyLogin(input: { thirdPartyId: string; userContext?: any }): Promise<{
+    static getResetPasswordTokenFromURL(input?: { userContext?: UserContext }): string;
+    static redirectToThirdPartyLogin(input: { thirdPartyId: string; userContext?: UserContext }): Promise<{
         status: "OK" | "ERROR";
     }>;
-    static thirdPartySignInAndUp(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<
+    static thirdPartySignInAndUp(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<
         | {
               status: "OK";
               user: User;
@@ -160,13 +165,13 @@ export default class Wrapper {
           }
     >;
     static getStateAndOtherInfoFromStorage<CustomStateProperties>(input?: {
-        userContext?: any;
+        userContext?: UserContext;
     }): (StateObject & CustomStateProperties) | undefined;
     static getAuthorisationURLWithQueryParamsAndSetState(input: {
         thirdPartyId: string;
         frontendRedirectURI: string;
         redirectURIOnProviderDashboard?: string;
-        userContext?: any;
+        userContext?: UserContext;
         options?: RecipeFunctionOptions;
     }): Promise<string>;
     static Google: typeof Google;

--- a/lib/build/recipe/thirdpartyemailpassword/prebuiltui.d.ts
+++ b/lib/build/recipe/thirdpartyemailpassword/prebuiltui.d.ts
@@ -5,7 +5,7 @@ import { SignInAndUpCallbackTheme as ThirdPartySignInAndUpCallbackTheme } from "
 import SignInAndUpTheme from "./components/themes/signInAndUp";
 import ThirdPartyEmailPassword from "./recipe";
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { RecipeFeatureComponentMap, FeatureBaseProps } from "../../types";
+import type { RecipeFeatureComponentMap, FeatureBaseProps, UserContext } from "../../types";
 export declare class ThirdPartyEmailPasswordPreBuiltUI extends RecipeRouter {
     readonly recipeInstance: ThirdPartyEmailPassword;
     static instance?: ThirdPartyEmailPasswordPreBuiltUI;
@@ -18,7 +18,7 @@ export declare class ThirdPartyEmailPasswordPreBuiltUI extends RecipeRouter {
         componentName: "signinup" | "signinupcallback" | "resetpassword",
         props: FeatureBaseProps<{
             redirectOnSessionExists?: boolean;
-            userContext?: any;
+            userContext: UserContext;
         }>,
         useComponentOverrides?: () => GenericComponentOverrideMap<any>
     ): JSX.Element;
@@ -27,25 +27,25 @@ export declare class ThirdPartyEmailPasswordPreBuiltUI extends RecipeRouter {
         componentName: "signinup" | "signinupcallback" | "resetpassword",
         props: FeatureBaseProps<{
             redirectOnSessionExists?: boolean;
-            userContext?: any;
+            userContext: UserContext;
         }>,
         useComponentOverrides?: () => GenericComponentOverrideMap<any>
     ) => JSX.Element;
     static reset(): void;
     static ThirdPartySignInAndUpCallback: (
         prop: FeatureBaseProps<{
-            userContext?: any;
+            userContext?: UserContext | undefined;
         }>
     ) => JSX.Element;
     static ResetPasswordUsingToken: (
         prop: FeatureBaseProps<{
-            userContext?: any;
+            userContext?: UserContext | undefined;
         }>
     ) => JSX.Element;
     static SignInAndUp: (
         prop?: FeatureBaseProps<{
-            redirectOnSessionExists?: boolean;
-            userContext?: any;
+            redirectOnSessionExists?: boolean | undefined;
+            userContext?: UserContext | undefined;
         }>
     ) => JSX.Element;
     static ThirdPartySignInAndUpCallbackTheme: (props: {
@@ -56,18 +56,18 @@ export declare class ThirdPartyEmailPasswordPreBuiltUI extends RecipeRouter {
 }
 declare const ThirdPartySignInAndUpCallback: (
     prop: FeatureBaseProps<{
-        userContext?: any;
+        userContext?: UserContext | undefined;
     }>
 ) => JSX.Element;
 declare const ResetPasswordUsingToken: (
     prop: FeatureBaseProps<{
-        userContext?: any;
+        userContext?: UserContext | undefined;
     }>
 ) => JSX.Element;
 declare const SignInAndUp: (
     prop?: FeatureBaseProps<{
-        redirectOnSessionExists?: boolean;
-        userContext?: any;
+        redirectOnSessionExists?: boolean | undefined;
+        userContext?: UserContext | undefined;
     }>
 ) => JSX.Element;
 export {

--- a/lib/build/recipe/thirdpartypasswordless/index.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/index.d.ts
@@ -16,6 +16,7 @@ import {
     Twitter,
 } from "../thirdparty/";
 import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
+import type { UserContext } from "../../types";
 import type { StateObject } from "supertokens-web-js/recipe/thirdparty";
 import type { PasswordlessFlowType, RecipeFunctionOptions } from "supertokens-web-js/recipe/thirdpartypasswordless";
 import type { User } from "supertokens-web-js/types";
@@ -28,11 +29,11 @@ export default class Wrapper {
         OnHandleEventContext,
         import("./types").NormalisedConfig
     >;
-    static signOut(input?: { userContext?: any }): Promise<void>;
-    static redirectToThirdPartyLogin(input: { thirdPartyId: string; userContext?: any }): Promise<{
+    static signOut(input?: { userContext?: UserContext }): Promise<void>;
+    static redirectToThirdPartyLogin(input: { thirdPartyId: string; userContext?: UserContext }): Promise<{
         status: "OK" | "ERROR";
     }>;
-    static thirdPartySignInAndUp(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<
+    static thirdPartySignInAndUp(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<
         | {
               status: "OK";
               user: User;
@@ -50,25 +51,25 @@ export default class Wrapper {
           }
     >;
     static getThirdPartyStateAndOtherInfoFromStorage<CustomStateProperties>(input?: {
-        userContext?: any;
+        userContext?: UserContext;
     }): (StateObject & CustomStateProperties) | undefined;
     static getThirdPartyAuthorisationURLWithQueryParamsAndSetState(input: {
         thirdPartyId: string;
         frontendRedirectURI: string;
         redirectURIOnProviderDashboard?: string;
-        userContext?: any;
+        userContext?: UserContext;
         options?: RecipeFunctionOptions;
     }): Promise<string>;
     static createPasswordlessCode(
         input:
             | {
                   email: string;
-                  userContext?: any;
+                  userContext?: UserContext;
                   options?: RecipeFunctionOptions;
               }
             | {
                   phoneNumber: string;
-                  userContext?: any;
+                  userContext?: UserContext;
                   options?: RecipeFunctionOptions;
               }
     ): Promise<
@@ -85,7 +86,7 @@ export default class Wrapper {
               fetchResponse: Response;
           }
     >;
-    static resendPasswordlessCode(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static resendPasswordlessCode(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<{
         status: "OK" | "RESTART_FLOW_ERROR";
         fetchResponse: Response;
     }>;
@@ -93,11 +94,11 @@ export default class Wrapper {
         input?:
             | {
                   userInputCode: string;
-                  userContext?: any;
+                  userContext?: UserContext;
                   options?: RecipeFunctionOptions;
               }
             | {
-                  userContext?: any;
+                  userContext?: UserContext;
                   options?: RecipeFunctionOptions;
               }
     ): Promise<
@@ -123,11 +124,11 @@ export default class Wrapper {
               fetchResponse: Response;
           }
     >;
-    static getPasswordlessLinkCodeFromURL(input?: { userContext?: any }): string;
-    static getPasswordlessPreAuthSessionIdFromURL(input?: { userContext?: any }): string;
+    static getPasswordlessLinkCodeFromURL(input?: { userContext?: UserContext }): string;
+    static getPasswordlessPreAuthSessionIdFromURL(input?: { userContext?: UserContext }): string;
     static doesPasswordlessUserEmailExist(input: {
         email: string;
-        userContext?: any;
+        userContext?: UserContext;
         options?: RecipeFunctionOptions;
     }): Promise<{
         status: "OK";
@@ -136,14 +137,16 @@ export default class Wrapper {
     }>;
     static doesPasswordlessUserPhoneNumberExist(input: {
         phoneNumber: string;
-        userContext?: any;
+        userContext?: UserContext;
         options?: RecipeFunctionOptions;
     }): Promise<{
         status: "OK";
         doesExist: boolean;
         fetchResponse: Response;
     }>;
-    static getPasswordlessLoginAttemptInfo<CustomLoginAttemptInfoProperties>(input?: { userContext?: any }): Promise<
+    static getPasswordlessLoginAttemptInfo<CustomLoginAttemptInfoProperties>(input?: {
+        userContext?: UserContext;
+    }): Promise<
         | undefined
         | ({
               deviceId: string;
@@ -157,9 +160,9 @@ export default class Wrapper {
             preAuthSessionId: string;
             flowType: PasswordlessFlowType;
         } & CustomStateProperties;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<void>;
-    static clearPasswordlessLoginAttemptInfo(input?: { userContext?: any }): Promise<void>;
+    static clearPasswordlessLoginAttemptInfo(input?: { userContext?: UserContext }): Promise<void>;
     static Apple: typeof Apple;
     static Bitbucket: typeof Bitbucket;
     static Discord: typeof Discord;

--- a/lib/build/recipe/thirdpartypasswordless/prebuiltui.d.ts
+++ b/lib/build/recipe/thirdpartypasswordless/prebuiltui.d.ts
@@ -3,7 +3,7 @@ import { RecipeRouter } from "../recipeRouter";
 import SignInUpTheme from "./components/themes/signInUp";
 import ThirdPartyPasswordless from "./recipe";
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { RecipeFeatureComponentMap, FeatureBaseProps } from "../../types";
+import type { RecipeFeatureComponentMap, FeatureBaseProps, UserContext } from "../../types";
 export declare class ThirdPartyPasswordlessPreBuiltUI extends RecipeRouter {
     readonly recipeInstance: ThirdPartyPasswordless;
     static instance?: ThirdPartyPasswordlessPreBuiltUI;
@@ -16,7 +16,7 @@ export declare class ThirdPartyPasswordlessPreBuiltUI extends RecipeRouter {
         componentName: "signInUp" | "linkClickedScreen" | "signinupcallback",
         props: FeatureBaseProps<{
             redirectOnSessionExists?: boolean;
-            userContext?: any;
+            userContext: UserContext;
         }>,
         useComponentOverrides?: () => GenericComponentOverrideMap<any>
     ): JSX.Element;
@@ -24,7 +24,7 @@ export declare class ThirdPartyPasswordlessPreBuiltUI extends RecipeRouter {
         componentName: "signInUp" | "linkClickedScreen" | "signinupcallback",
         props: FeatureBaseProps<{
             redirectOnSessionExists?: boolean;
-            userContext?: any;
+            userContext: UserContext;
         }>,
         useComponentOverrides?: () => GenericComponentOverrideMap<any>
     ) => JSX.Element;
@@ -32,36 +32,36 @@ export declare class ThirdPartyPasswordlessPreBuiltUI extends RecipeRouter {
     static reset(): void;
     static SignInAndUp: (
         prop?: FeatureBaseProps<{
-            redirectOnSessionExists?: boolean;
-            userContext?: any;
+            redirectOnSessionExists?: boolean | undefined;
+            userContext?: UserContext | undefined;
         }>
     ) => JSX.Element;
     static ThirdPartySignInAndUpCallback: (
         prop: FeatureBaseProps<{
-            userContext?: any;
+            userContext?: UserContext | undefined;
         }>
     ) => JSX.Element;
     static SignInUpTheme: typeof SignInUpTheme;
     static PasswordlessLinkClicked: (
         prop: FeatureBaseProps<{
-            userContext?: any;
+            userContext?: UserContext | undefined;
         }>
     ) => JSX.Element;
 }
 declare const SignInAndUp: (
     prop?: FeatureBaseProps<{
-        redirectOnSessionExists?: boolean;
-        userContext?: any;
+        redirectOnSessionExists?: boolean | undefined;
+        userContext?: UserContext | undefined;
     }>
 ) => JSX.Element;
 declare const ThirdPartySignInAndUpCallback: (
     prop: FeatureBaseProps<{
-        userContext?: any;
+        userContext?: UserContext | undefined;
     }>
 ) => JSX.Element;
 declare const PasswordlessLinkClicked: (
     prop: FeatureBaseProps<{
-        userContext?: any;
+        userContext?: UserContext | undefined;
     }>
 ) => JSX.Element;
 export { SignInAndUp, ThirdPartySignInAndUpCallback, PasswordlessLinkClicked, SignInUpTheme };

--- a/lib/build/recipeModule-shared.js
+++ b/lib/build/recipeModule-shared.js
@@ -26,7 +26,13 @@ var RecipeModule = /** @class */ (function (_super) {
                 return genericComponentOverrideContext.__generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
-                            return [4 /*yield*/, this.getRedirectUrl(context, userContext)];
+                            return [
+                                4 /*yield*/,
+                                this.getRedirectUrl(
+                                    context,
+                                    genericComponentOverrideContext.getNormalisedUserContext(userContext)
+                                ),
+                            ];
                         case 1:
                             redirectUrl = _a.sent();
                             if (redirectUrl === null) {

--- a/lib/build/session-shared2.js
+++ b/lib/build/session-shared2.js
@@ -208,6 +208,7 @@ var Session = /** @class */ (function (_super) {
                 return genericComponentOverrideContext.__generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
+                            userContext = genericComponentOverrideContext.getNormalisedUserContext(userContext);
                             return [4 /*yield*/, this.doesSessionExist({ userContext: userContext })];
                         case 1:
                             // First we check if there is an active session
@@ -248,14 +249,6 @@ var Session = /** @class */ (function (_super) {
                             ];
                         case 5:
                             failureRedirectInfo = _a.sent();
-                            if (failureRedirectInfo.redirectPath === null) {
-                                genericComponentOverrideContext.logDebugMessage(
-                                    "Skipping redirection because the user override returned null for validator ".concat(
-                                        JSON.stringify(failureRedirectInfo.failedClaim, null, 2)
-                                    )
-                                );
-                                return [2 /*return*/];
-                            }
                             // if redirectPath is string that means failed claim had callback that returns path, we redirect there otherwise continue
                             if (failureRedirectInfo.redirectPath !== undefined) {
                                 return [

--- a/lib/build/session-shared2.js
+++ b/lib/build/session-shared2.js
@@ -296,6 +296,7 @@ var Session = /** @class */ (function (_super) {
                                 rid: Session.RECIPE_ID,
                                 successRedirectContext: {
                                     action: "SUCCESS",
+                                    isNewPrimaryUser: false,
                                     isNewRecipeUser: false,
                                 },
                             };

--- a/lib/build/sessionprebuiltui.js
+++ b/lib/build/sessionprebuiltui.js
@@ -316,7 +316,13 @@ var SessionPreBuiltUI = /** @class */ (function (_super) {
         if (prop === void 0) {
             prop = {};
         }
-        return _a.getFeatureComponent("accessDenied", prop);
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(prop.userContext);
+        return _a.getFeatureComponent(
+            "accessDenied",
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, prop), {
+                userContext: userContext,
+            })
+        );
     };
     SessionPreBuiltUI.AccessDeniedScreenTheme = AccessDeniedScreenTheme;
     return SessionPreBuiltUI;

--- a/lib/build/superTokens.d.ts
+++ b/lib/build/superTokens.d.ts
@@ -3,7 +3,7 @@ import type RecipeModule from "./recipe/recipeModule";
 import type { BaseRecipeModule } from "./recipe/recipeModule/baseRecipeModule";
 import type { NormalisedConfig as NormalisedRecipeModuleConfig } from "./recipe/recipeModule/types";
 import type { TranslationFunc, TranslationStore } from "./translation/translationHelpers";
-import type { Navigate, GetRedirectionURLContext, NormalisedAppInfo, SuperTokensConfig } from "./types";
+import type { Navigate, GetRedirectionURLContext, NormalisedAppInfo, SuperTokensConfig, UserContext } from "./types";
 export default class SuperTokens {
     private static instance?;
     static usesDynamicLoginMethods: boolean;
@@ -25,7 +25,7 @@ export default class SuperTokens {
     ): RecipeModule<T, S, R, N>;
     changeLanguage: (lang: string) => Promise<void>;
     loadTranslation(store: TranslationStore): void;
-    getRedirectUrl(context: GetRedirectionURLContext, userContext?: any): Promise<string | null>;
+    getRedirectUrl(context: GetRedirectionURLContext, userContext: UserContext): Promise<string | null>;
     redirectToAuth: (options: {
         show?: "signin" | "signup" | undefined;
         navigate?: Navigate | undefined;

--- a/lib/build/thirdparty-shared2.js
+++ b/lib/build/thirdparty-shared2.js
@@ -543,6 +543,8 @@ var SignInAndUpCallback$1 = function (props) {
                                     rid: props.recipe.config.recipeId,
                                     successRedirectContext: {
                                         action: "SUCCESS",
+                                        isNewPrimaryUser:
+                                            response.createdNewRecipeUser && response.user.loginMethods.length === 1,
                                         isNewRecipeUser: response.createdNewRecipeUser,
                                         redirectToPath: redirectToPath,
                                     },

--- a/lib/build/thirdparty-shared2.js
+++ b/lib/build/thirdparty-shared2.js
@@ -750,10 +750,22 @@ var ThirdPartyPreBuiltUI = /** @class */ (function (_super) {
         if (prop === void 0) {
             prop = {};
         }
-        return ThirdPartyPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("signinup", prop);
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(prop.userContext);
+        return ThirdPartyPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent(
+            "signinup",
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, prop), {
+                userContext: userContext,
+            })
+        );
     };
     ThirdPartyPreBuiltUI.SignInAndUpCallback = function (prop) {
-        return ThirdPartyPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("signinupcallback", prop);
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(prop.userContext);
+        return ThirdPartyPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent(
+            "signinupcallback",
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, prop), {
+                userContext: userContext,
+            })
+        );
     };
     ThirdPartyPreBuiltUI.SignInAndUpTheme = SignInAndUpThemeWrapper;
     ThirdPartyPreBuiltUI.SignInAndUpCallbackTheme = SignInAndUpCallbackTheme;

--- a/lib/build/thirdpartyemailpasswordprebuiltui.js
+++ b/lib/build/thirdpartyemailpasswordprebuiltui.js
@@ -530,16 +530,34 @@ var ThirdPartyEmailPasswordPreBuiltUI = /** @class */ (function (_super) {
     var _a;
     _a = ThirdPartyEmailPasswordPreBuiltUI;
     ThirdPartyEmailPasswordPreBuiltUI.ThirdPartySignInAndUpCallback = function (prop) {
-        return _a.getFeatureComponent("signinupcallback", prop);
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(prop.userContext);
+        return _a.getFeatureComponent(
+            "signinupcallback",
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, prop), {
+                userContext: userContext,
+            })
+        );
     };
     ThirdPartyEmailPasswordPreBuiltUI.ResetPasswordUsingToken = function (prop) {
-        return _a.getFeatureComponent("resetpassword", prop);
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(prop.userContext);
+        return _a.getFeatureComponent(
+            "resetpassword",
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, prop), {
+                userContext: userContext,
+            })
+        );
     };
     ThirdPartyEmailPasswordPreBuiltUI.SignInAndUp = function (prop) {
         if (prop === void 0) {
             prop = {};
         }
-        return _a.getFeatureComponent("signinup", prop);
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(prop.userContext);
+        return _a.getFeatureComponent(
+            "signinup",
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, prop), {
+                userContext: userContext,
+            })
+        );
     };
     ThirdPartyEmailPasswordPreBuiltUI.ThirdPartySignInAndUpCallbackTheme =
         thirdpartyprebuiltui.SignInAndUpCallbackTheme;

--- a/lib/build/thirdpartypasswordlessprebuiltui.js
+++ b/lib/build/thirdpartypasswordlessprebuiltui.js
@@ -635,14 +635,32 @@ var ThirdPartyPasswordlessPreBuiltUI = /** @class */ (function (_super) {
         if (prop === void 0) {
             prop = {};
         }
-        return _a.getFeatureComponent("signInUp", prop);
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(prop.userContext);
+        return _a.getFeatureComponent(
+            "signInUp",
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, prop), {
+                userContext: userContext,
+            })
+        );
     };
     ThirdPartyPasswordlessPreBuiltUI.ThirdPartySignInAndUpCallback = function (prop) {
-        return _a.getFeatureComponent("signinupcallback", prop);
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(prop.userContext);
+        return _a.getFeatureComponent(
+            "signinupcallback",
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, prop), {
+                userContext: userContext,
+            })
+        );
     };
     ThirdPartyPasswordlessPreBuiltUI.SignInUpTheme = SignInUpThemeWrapper;
     ThirdPartyPasswordlessPreBuiltUI.PasswordlessLinkClicked = function (prop) {
-        return _a.getFeatureComponent("linkClickedScreen", prop);
+        var userContext = genericComponentOverrideContext.getNormalisedUserContext(prop.userContext);
+        return _a.getFeatureComponent(
+            "linkClickedScreen",
+            genericComponentOverrideContext.__assign(genericComponentOverrideContext.__assign({}, prop), {
+                userContext: userContext,
+            })
+        );
     };
     return ThirdPartyPasswordlessPreBuiltUI;
 })(uiEntry.RecipeRouter);

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -13,7 +13,13 @@ export declare type GetRedirectionURLContext = {
     showSignIn?: boolean;
 };
 export declare type ValidationFailureCallback =
-    | (({ userContext, reason }: { userContext: any; reason: any }) => Promise<string | undefined> | string | undefined)
+    | (({
+          userContext,
+          reason,
+      }: {
+          userContext: UserContext;
+          reason: any;
+      }) => Promise<string | undefined> | string | undefined)
     | undefined;
 export declare type SessionClaimValidator = SessionClaimValidatorWebJS & {
     showAccessDeniedOnFailure?: boolean;
@@ -40,7 +46,10 @@ export declare type SuperTokensConfig = {
         translationFunc?: TranslationFunc;
     };
     enableDebugLogs?: boolean;
-    getRedirectionURL?: (context: GetRedirectionURLContext, userContext?: any) => Promise<string | undefined | null>;
+    getRedirectionURL?: (
+        context: GetRedirectionURLContext,
+        userContext: UserContext
+    ) => Promise<string | undefined | null>;
 };
 export declare type WebJSRecipeInterface<T> = Omit<T, "default" | "init" | "signOut">;
 export declare type CreateRecipeFunction<T, S, R, N extends NormalisedRecipeModuleConfig<T, S, R>> = (
@@ -121,7 +130,7 @@ export declare type NormalisedBaseConfig = {
 export declare type ThemeBaseProps = {
     styleFromInit?: string;
 };
-export declare type FeatureBaseProps<T = {}> = PropsWithChildren<
+export declare type FeatureBaseProps<T = Record<string, unknown>> = PropsWithChildren<
     {
         navigate?: Navigate;
     } & T
@@ -145,4 +154,5 @@ export declare type Navigate =
           goBack: () => void;
       }
     | NavigateFunction;
+export declare type UserContext = Record<string, unknown>;
 export {};

--- a/lib/build/usercontext/index.d.ts
+++ b/lib/build/usercontext/index.d.ts
@@ -1,7 +1,8 @@
 import React from "react";
+import type { UserContext } from "../types";
 export declare const UserContextContext: React.Context<any>;
-export declare const useUserContext: () => any;
+export declare const useUserContext: () => UserContext;
 export declare const UserContextProvider: React.FC<{
     children: React.ReactNode;
-    userContext?: any;
+    userContext?: UserContext;
 }>;

--- a/lib/build/usercontext/userContextWrapper.d.ts
+++ b/lib/build/usercontext/userContextWrapper.d.ts
@@ -1,2 +1,6 @@
 import React from "react";
-export default function UserContextWrapper(props: { children: React.ReactNode; userContext?: any }): JSX.Element;
+import type { UserContext } from "../types";
+export default function UserContextWrapper(props: {
+    children: React.ReactNode;
+    userContext?: UserContext;
+}): JSX.Element;

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -1,7 +1,14 @@
 import NormalisedURLDomain from "supertokens-web-js/utils/normalisedURLDomain";
 import NormalisedURLPath from "supertokens-web-js/utils/normalisedURLPath";
 import type { FormFieldError } from "./recipe/emailpassword/types";
-import type { APIFormField, AppInfoUserInput, Navigate, NormalisedAppInfo, NormalisedFormField } from "./types";
+import type {
+    APIFormField,
+    AppInfoUserInput,
+    Navigate,
+    NormalisedAppInfo,
+    NormalisedFormField,
+    UserContext,
+} from "./types";
 export declare function getRecipeIdFromSearch(search: string): string | null;
 export declare function clearQueryParams(paramNames: string[]): void;
 export declare function clearErrorQueryParam(): void;
@@ -33,7 +40,7 @@ export declare function setFrontendCookie(
     value: string | undefined,
     scope: string | undefined
 ): Promise<void>;
-export declare function getNormalisedUserContext(userContext?: any): any;
+export declare function getNormalisedUserContext(userContext?: UserContext): UserContext;
 /**
  * This function handles calling APIs that should only be called once during mount (mostly on mount of a route/feature component).
  * It's split into multiple callbacks (fetch + handleResponse/handleError) because we expect fetch to take longer and

--- a/lib/ts/claims/emailVerificationClaim.ts
+++ b/lib/ts/claims/emailVerificationClaim.ts
@@ -2,7 +2,7 @@ import { EmailVerificationClaimClass as EmailVerificationClaimClassWebJS } from 
 
 import EmailVerification from "../recipe/emailverification/recipe";
 
-import type { ValidationFailureCallback } from "../types";
+import type { UserContext, ValidationFailureCallback } from "../types";
 import type { RecipeInterface } from "supertokens-web-js/recipe/emailverification";
 
 export class EmailVerificationClaimClass extends EmailVerificationClaimClassWebJS {
@@ -18,13 +18,13 @@ export class EmailVerificationClaimClass extends EmailVerificationClaimClassWebJ
             ) => {
                 return {
                     ...validator(...args),
-                    onFailureRedirection: (args: { userContext: any; reason: any }) => {
+                    onFailureRedirection: (args: { userContext: UserContext; reason: any }) => {
                         if (onFailureRedirection !== undefined) {
                             return onFailureRedirection(args);
                         }
                         const recipe = EmailVerification.getInstanceOrThrow();
                         if (recipe.config.mode === "REQUIRED") {
-                            return recipe.getRedirectUrl({ action: "VERIFY_EMAIL" });
+                            return recipe.getRedirectUrl({ action: "VERIFY_EMAIL" }, args.userContext);
                         }
                         return undefined;
                     },

--- a/lib/ts/components/supertokensWrapper.tsx
+++ b/lib/ts/components/supertokensWrapper.tsx
@@ -1,10 +1,11 @@
 import SessionAuthWrapper from "../recipe/session/sessionAuth";
 
+import type { UserContext } from "../types";
 import type { PropsWithChildren } from "react";
 
 export const SuperTokensWrapper: React.FC<
     PropsWithChildren<{
-        userContext?: any;
+        userContext?: UserContext;
     }>
 > = (props) => {
     return <SessionAuthWrapper {...props} requireAuth={false} doRedirection={false} />;

--- a/lib/ts/recipe/authRecipe/authWidgetWrapper.tsx
+++ b/lib/ts/recipe/authRecipe/authWidgetWrapper.tsx
@@ -79,6 +79,7 @@ const Redirector = <T, S, R, N extends NormalisedConfig<T | GetRedirectionURLCon
                             successRedirectContext: {
                                 action: "SUCCESS",
                                 isNewRecipeUser: false,
+                                isNewPrimaryUser: false,
                                 redirectToPath: getRedirectToPathFromURL(),
                             },
                         },

--- a/lib/ts/recipe/authRecipe/index.ts
+++ b/lib/ts/recipe/authRecipe/index.ts
@@ -25,7 +25,7 @@ import Session from "../session/recipe";
 import SessionRecipe from "../session/recipe";
 
 import type { NormalisedConfig, GetRedirectionURLContext, OnHandleEventContext } from "./types";
-import type { NormalisedConfigWithAppInfoAndRecipeID } from "../../types";
+import type { NormalisedConfigWithAppInfoAndRecipeID, UserContext } from "../../types";
 
 export default abstract class AuthRecipe<
     T,
@@ -51,13 +51,13 @@ export default abstract class AuthRecipe<
         }
     };
 
-    signOut = async (input?: { userContext?: any }): Promise<void> => {
+    signOut = async (input?: { userContext?: UserContext }): Promise<void> => {
         return await Session.getInstanceOrThrow().signOut({
             userContext: getNormalisedUserContext(input?.userContext),
         });
     };
 
-    doesSessionExist = async (input?: { userContext?: any }): Promise<boolean> => {
+    doesSessionExist = async (input?: { userContext?: UserContext }): Promise<boolean> => {
         return await Session.getInstanceOrThrow().doesSessionExist({
             userContext: getNormalisedUserContext(input?.userContext),
         });

--- a/lib/ts/recipe/authRecipe/types.ts
+++ b/lib/ts/recipe/authRecipe/types.ts
@@ -28,6 +28,7 @@ export type NormalisedConfig<T, Action, R> = NormalisedRecipeModuleConfig<T, Act
 export type GetRedirectionURLContext = {
     action: "SUCCESS";
     isNewRecipeUser: boolean;
+    isNewPrimaryUser: boolean;
     redirectToPath?: string;
 };
 

--- a/lib/ts/recipe/emailpassword/components/features/signInAndUp/index.tsx
+++ b/lib/ts/recipe/emailpassword/components/features/signInAndUp/index.tsx
@@ -30,7 +30,7 @@ import Session from "../../../../session/recipe";
 import SignInAndUpTheme from "../../themes/signInAndUp";
 import { defaultTranslationsEmailPassword } from "../../themes/translations";
 
-import type { Navigate, FeatureBaseProps, NormalisedFormField } from "../../../../../types";
+import type { Navigate, FeatureBaseProps, NormalisedFormField, UserContext } from "../../../../../types";
 import type Recipe from "../../../recipe";
 import type { SignInAndUpState } from "../../../types";
 import type {
@@ -158,7 +158,7 @@ export function useChildProps(
             clearError: () => dispatch({ type: "setError", error: undefined }),
             onError: (error: string) => dispatch({ type: "setError", error }),
             onSuccess: onSignInSuccess,
-            forgotPasswordClick: () => recipe.redirect({ action: "RESET_PASSWORD" }, navigate, userContext),
+            forgotPasswordClick: () => recipe.redirect({ action: "RESET_PASSWORD" }, navigate, undefined, userContext),
         };
 
         const signUpForm = {
@@ -230,7 +230,7 @@ const getModifiedRecipeImplementation = (origImpl: RecipeInterface): RecipeInter
 function getThemeSignUpFeatureFormFields(
     formFields: NormalisedFormField[],
     recipe: Recipe,
-    userContext: any
+    userContext: UserContext
 ): FormFieldThemeProps[] {
     const emailPasswordOnly = formFields.length === 2;
     return formFields.map((field) => ({

--- a/lib/ts/recipe/emailpassword/components/features/signInAndUp/index.tsx
+++ b/lib/ts/recipe/emailpassword/components/features/signInAndUp/index.tsx
@@ -117,6 +117,7 @@ export function useChildProps(
                 rid: recipe!.config.recipeId,
                 successRedirectContext: {
                     action: "SUCCESS",
+                    isNewPrimaryUser: false,
                     isNewRecipeUser: false,
                     redirectToPath: getRedirectToPathFromURL(),
                 },
@@ -132,6 +133,7 @@ export function useChildProps(
                 rid: recipe!.config.recipeId,
                 successRedirectContext: {
                     action: "SUCCESS",
+                    isNewPrimaryUser: true,
                     isNewRecipeUser: true,
                     redirectToPath: getRedirectToPathFromURL(),
                 },

--- a/lib/ts/recipe/emailpassword/index.ts
+++ b/lib/ts/recipe/emailpassword/index.ts
@@ -22,6 +22,7 @@ import EmailPassword from "./recipe";
 import { UserInput } from "./types";
 import { GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 
+import type { UserContext } from "../../types";
 import type { RecipeFunctionOptions } from "supertokens-web-js/recipe/emailpassword";
 import type { User } from "supertokens-web-js/types";
 
@@ -30,7 +31,7 @@ export default class Wrapper {
         return EmailPassword.init(config);
     }
 
-    static async signOut(input?: { userContext?: any }): Promise<void> {
+    static async signOut(input?: { userContext?: UserContext }): Promise<void> {
         return EmailPassword.getInstanceOrThrow().signOut({
             userContext: getNormalisedUserContext(input?.userContext),
         });
@@ -42,7 +43,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK";
@@ -73,7 +74,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK" | "PASSWORD_RESET_NOT_ALLOWED";
@@ -100,7 +101,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK";
@@ -133,7 +134,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK";
@@ -164,7 +165,11 @@ export default class Wrapper {
         });
     }
 
-    static async doesEmailExist(input: { email: string; options?: RecipeFunctionOptions; userContext?: any }): Promise<{
+    static async doesEmailExist(input: {
+        email: string;
+        options?: RecipeFunctionOptions;
+        userContext?: UserContext;
+    }): Promise<{
         status: "OK";
         doesExist: boolean;
         fetchResponse: Response;
@@ -175,7 +180,7 @@ export default class Wrapper {
         });
     }
 
-    static getResetPasswordTokenFromURL(input?: { userContext?: any }): string {
+    static getResetPasswordTokenFromURL(input?: { userContext?: UserContext }): string {
         return EmailPassword.getInstanceOrThrow().webJSRecipe.getResetPasswordTokenFromURL({
             ...input,
             userContext: getNormalisedUserContext(input?.userContext),

--- a/lib/ts/recipe/emailpassword/prebuiltui.tsx
+++ b/lib/ts/recipe/emailpassword/prebuiltui.tsx
@@ -1,7 +1,7 @@
 import NormalisedURLPath from "supertokens-web-js/utils/normalisedURLPath";
 
 import UserContextWrapper from "../../usercontext/userContextWrapper";
-import { isTest, matchRecipeIdUsingQueryParams } from "../../utils";
+import { getNormalisedUserContext, isTest, matchRecipeIdUsingQueryParams } from "../../utils";
 import AuthWidgetWrapper from "../authRecipe/authWidgetWrapper";
 import { RecipeRouter } from "../recipeRouter";
 
@@ -20,7 +20,7 @@ import type {
     NormalisedConfig,
 } from "./types";
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { RecipeFeatureComponentMap, FeatureBaseProps } from "../../types";
+import type { RecipeFeatureComponentMap, FeatureBaseProps, UserContext } from "../../types";
 
 export class EmailPasswordPreBuiltUI extends RecipeRouter {
     static instance?: EmailPasswordPreBuiltUI;
@@ -45,7 +45,7 @@ export class EmailPasswordPreBuiltUI extends RecipeRouter {
     }
     static getFeatureComponent(
         componentName: "signinup" | "resetpassword",
-        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }>,
+        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext: UserContext }>,
         useComponentOverrides: () => GenericComponentOverrideMap<any> = useRecipeComponentOverrideContext
     ): JSX.Element {
         return EmailPasswordPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent(
@@ -86,7 +86,7 @@ export class EmailPasswordPreBuiltUI extends RecipeRouter {
     };
     getFeatureComponent = (
         componentName: "signinup" | "resetpassword",
-        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }>,
+        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext: UserContext }>,
         useComponentOverrides: () => GenericComponentOverrideMap<any> = useRecipeComponentOverrideContext
     ): JSX.Element => {
         if (componentName === "signinup") {
@@ -145,10 +145,22 @@ export class EmailPasswordPreBuiltUI extends RecipeRouter {
         return;
     }
 
-    static SignInAndUp = (prop: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }> = {}) =>
-        EmailPasswordPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("signinup", prop);
-    static ResetPasswordUsingToken = (prop: FeatureBaseProps<{ userContext?: any }>) =>
-        EmailPasswordPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("resetpassword", prop);
+    static SignInAndUp = (
+        prop: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: UserContext }> = {}
+    ) => {
+        const userContext = getNormalisedUserContext(prop.userContext);
+        return EmailPasswordPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("signinup", {
+            ...prop,
+            userContext,
+        });
+    };
+    static ResetPasswordUsingToken = (prop: FeatureBaseProps<{ userContext?: UserContext }>) => {
+        const userContext = getNormalisedUserContext(prop.userContext);
+        return EmailPasswordPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("resetpassword", {
+            ...prop,
+            userContext,
+        });
+    };
 
     static ResetPasswordUsingTokenTheme = ResetPasswordUsingTokenTheme;
     static SignInAndUpTheme = SignInAndUpTheme;

--- a/lib/ts/recipe/emailpassword/types.ts
+++ b/lib/ts/recipe/emailpassword/types.ts
@@ -33,6 +33,7 @@ import type {
     NormalisedBaseConfig,
     NormalisedFormField,
     ThemeBaseProps,
+    UserContext,
 } from "../../types";
 import type {
     GetRedirectionURLContext as AuthRecipeModuleGetRedirectionURLContext,
@@ -264,7 +265,7 @@ export type SignInAndUpThemeProps = {
     };
     dispatch: Dispatch<EmailPasswordSignInAndUpAction>;
     config: NormalisedConfig;
-    userContext?: any;
+    userContext?: UserContext;
 };
 
 export type FormFieldThemeProps = NormalisedFormField & {
@@ -323,7 +324,7 @@ export type PreAPIHookContext = {
      * URL
      */
     url: string;
-    userContext: any;
+    userContext: UserContext;
 };
 
 export type GetRedirectionURLContext =
@@ -343,27 +344,27 @@ export type OnHandleEventContext =
            */
           action: "RESET_PASSWORD_EMAIL_SENT";
           email: string;
-          userContext: any;
+          userContext: UserContext;
       }
     | {
           /*
            * On Handle Event actions
            */
           action: "PASSWORD_RESET_SUCCESSFUL";
-          userContext: any;
+          userContext: UserContext;
       }
     | {
           action: "SUCCESS";
           isNewRecipeUser: boolean;
           user: User;
-          userContext: any;
+          userContext: UserContext;
       };
 
 export type ResetPasswordUsingTokenThemeProps = {
     enterEmailForm: EnterEmailProps;
     submitNewPasswordForm: SubmitNewPasswordProps | undefined;
     config: NormalisedConfig;
-    userContext?: any;
+    userContext?: UserContext;
 };
 
 export type EnterEmailProps = NonSignUpFormThemeBaseProps & {

--- a/lib/ts/recipe/emailverification/components/features/emailVerification/index.tsx
+++ b/lib/ts/recipe/emailverification/components/features/emailVerification/index.tsx
@@ -29,12 +29,16 @@ import Session from "../../../../session/recipe";
 import EmailVerificationTheme from "../../themes/emailVerification";
 import { defaultTranslationsEmailVerification } from "../../themes/translations";
 
-import type { FeatureBaseProps } from "../../../../../types";
+import type { FeatureBaseProps, UserContext } from "../../../../../types";
 import type Recipe from "../../../recipe";
 import type { ComponentOverrideMap } from "../../../types";
 import type { RecipeInterface } from "supertokens-web-js/recipe/emailverification";
 
-type Prop = FeatureBaseProps<{ recipe: Recipe; userContext?: any; useComponentOverrides: () => ComponentOverrideMap }>;
+type Prop = FeatureBaseProps<{
+    recipe: Recipe;
+    userContext?: UserContext;
+    useComponentOverrides: () => ComponentOverrideMap;
+}>;
 
 export const EmailVerification: React.FC<Prop> = (props) => {
     const sessionContext = useContext(SessionContext);
@@ -110,7 +114,7 @@ export const EmailVerification: React.FC<Prop> = (props) => {
 
     const signOut = useCallback(async (): Promise<void> => {
         const session = Session.getInstanceOrThrow();
-        await session.signOut(props.userContext);
+        await session.signOut({ userContext: props.userContext ?? userContext });
         return redirectToAuthWithHistory();
     }, [props.recipe, redirectToAuthWithHistory]);
 

--- a/lib/ts/recipe/emailverification/index.ts
+++ b/lib/ts/recipe/emailverification/index.ts
@@ -25,6 +25,7 @@ import EmailVerificationRecipe from "./recipe";
 import { GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 import { UserInput } from "./types";
 
+import type { UserContext } from "../../types";
 import type { RecipeFunctionOptions } from "supertokens-web-js/recipe/emailverification";
 
 export default class Wrapper {
@@ -34,7 +35,7 @@ export default class Wrapper {
         return EmailVerificationRecipe.init(config);
     }
 
-    static async isEmailVerified(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static async isEmailVerified(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;
@@ -45,7 +46,7 @@ export default class Wrapper {
         });
     }
 
-    static async verifyEmail(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static async verifyEmail(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<{
         status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
         fetchResponse: Response;
     }> {
@@ -55,7 +56,10 @@ export default class Wrapper {
         });
     }
 
-    static async sendVerificationEmail(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static async sendVerificationEmail(input?: {
+        userContext?: UserContext;
+        options?: RecipeFunctionOptions;
+    }): Promise<{
         status: "EMAIL_ALREADY_VERIFIED_ERROR" | "OK";
         fetchResponse: Response;
     }> {
@@ -65,7 +69,7 @@ export default class Wrapper {
         });
     }
 
-    static getEmailVerificationTokenFromURL(input?: { userContext?: any }): string {
+    static getEmailVerificationTokenFromURL(input?: { userContext?: UserContext }): string {
         return EmailVerificationRecipe.getInstanceOrThrow().webJSRecipe.getEmailVerificationTokenFromURL({
             ...input,
             userContext: getNormalisedUserContext(input?.userContext),

--- a/lib/ts/recipe/emailverification/prebuiltui.tsx
+++ b/lib/ts/recipe/emailverification/prebuiltui.tsx
@@ -2,7 +2,7 @@ import NormalisedURLPath from "supertokens-web-js/utils/normalisedURLPath";
 
 import { UserContextContext } from "../../usercontext";
 import UserContextWrapper from "../../usercontext/userContextWrapper";
-import { isTest, matchRecipeIdUsingQueryParams } from "../../utils";
+import { getNormalisedUserContext, isTest, matchRecipeIdUsingQueryParams } from "../../utils";
 import { RecipeRouter } from "../recipeRouter";
 import { SessionAuth } from "../session";
 
@@ -13,7 +13,7 @@ import { DEFAULT_VERIFY_EMAIL_PATH } from "./constants";
 import EmailVerificationRecipe from "./recipe";
 
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { FeatureBaseProps, RecipeFeatureComponentMap } from "../../types";
+import type { FeatureBaseProps, RecipeFeatureComponentMap, UserContext } from "../../types";
 
 export class EmailVerificationPreBuiltUI extends RecipeRouter {
     static instance?: EmailVerificationPreBuiltUI;
@@ -67,7 +67,7 @@ export class EmailVerificationPreBuiltUI extends RecipeRouter {
     getFeatureComponent = (
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         _: "emailverification",
-        props: FeatureBaseProps<{ userContext?: any }>,
+        props: FeatureBaseProps<{ userContext: UserContext }>,
         useComponentOverrides: () => GenericComponentOverrideMap<any> = useRecipeComponentOverrideContext
     ): JSX.Element => {
         return (
@@ -115,8 +115,13 @@ export class EmailVerificationPreBuiltUI extends RecipeRouter {
         return;
     }
 
-    static EmailVerification = (props: FeatureBaseProps<{ userContext?: any }>) =>
-        EmailVerificationPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("emailverification", props);
+    static EmailVerification = (props: FeatureBaseProps<{ userContext?: UserContext }>) => {
+        const userContext = getNormalisedUserContext(props.userContext);
+        EmailVerificationPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("emailverification", {
+            ...props,
+            userContext,
+        });
+    };
     static EmailVerificationTheme = EmailVerificationTheme;
 }
 

--- a/lib/ts/recipe/emailverification/recipe.tsx
+++ b/lib/ts/recipe/emailverification/recipe.tsx
@@ -37,7 +37,12 @@ import type {
     OnHandleEventContext,
     PreAndPostAPIHookAction,
 } from "./types";
-import type { NormalisedConfigWithAppInfoAndRecipeID, RecipeInitResult, WebJSRecipeInterface } from "../../types";
+import type {
+    NormalisedConfigWithAppInfoAndRecipeID,
+    RecipeInitResult,
+    UserContext,
+    WebJSRecipeInterface,
+} from "../../types";
 import type { NormalisedAppInfo } from "../../types";
 
 export default class EmailVerification extends RecipeModule<
@@ -117,7 +122,7 @@ export default class EmailVerification extends RecipeModule<
         return EmailVerification.instance;
     }
 
-    async isEmailVerified(userContext: any): Promise<{
+    async isEmailVerified(userContext: UserContext): Promise<{
         status: "OK";
         isVerified: boolean;
         fetchResponse: Response;

--- a/lib/ts/recipe/emailverification/types.ts
+++ b/lib/ts/recipe/emailverification/types.ts
@@ -15,7 +15,7 @@
 import type { SendVerifyEmail } from "./components/themes/emailVerification/sendVerifyEmail";
 import type { VerifyEmailLinkClicked } from "./components/themes/emailVerification/verifyEmailLinkClicked";
 import type { ComponentOverride } from "../../components/componentOverride/componentOverride";
-import type { FeatureBaseConfig, ThemeBaseProps } from "../../types";
+import type { FeatureBaseConfig, ThemeBaseProps, UserContext } from "../../types";
 import type {
     Config as RecipeModuleConfig,
     NormalisedConfig as NormalisedRecipeModuleConfig,
@@ -71,19 +71,19 @@ export type PreAPIHookContext = {
     action: PreAndPostAPIHookAction;
     requestInit: RequestInit;
     url: string;
-    userContext: any;
+    userContext: UserContext;
 };
 
 export type OnHandleEventContext = {
     action: "VERIFY_EMAIL_SENT" | "EMAIL_VERIFIED_SUCCESSFUL";
-    userContext: any;
+    userContext: UserContext;
 };
 
 export type EmailVerificationThemeProps = {
     sendVerifyEmailScreen: SendVerifyEmailThemeProps;
     verifyEmailLinkClickedScreen?: VerifyEmailLinkClickedThemeProps;
     config: NormalisedConfig;
-    userContext?: any;
+    userContext?: UserContext;
 };
 
 export type SendVerifyEmailThemeProps = ThemeBaseProps & {

--- a/lib/ts/recipe/multitenancy/recipe.ts
+++ b/lib/ts/recipe/multitenancy/recipe.ts
@@ -29,7 +29,12 @@ import { hasIntersectingRecipes } from "./utils";
 import { normaliseMultitenancyConfig } from "./utils";
 
 import type { NormalisedConfig, UserInput, GetLoginMethodsResponseNormalized } from "./types";
-import type { RecipeInitResult, NormalisedConfigWithAppInfoAndRecipeID, WebJSRecipeInterface } from "../../types";
+import type {
+    RecipeInitResult,
+    NormalisedConfigWithAppInfoAndRecipeID,
+    WebJSRecipeInterface,
+    UserContext,
+} from "../../types";
 import type { NormalisedAppInfo } from "../../types";
 
 /*
@@ -51,7 +56,7 @@ export default class Multitenancy extends BaseRecipeModule<any, any, any, any> {
     }
 
     public async getCurrentDynamicLoginMethods(input: {
-        userContext?: any;
+        userContext: UserContext;
     }): Promise<GetLoginMethodsResponseNormalized | undefined> {
         if (SuperTokens.usesDynamicLoginMethods === false) {
             return undefined;

--- a/lib/ts/recipe/passwordless/components/features/linkClickedScreen/index.tsx
+++ b/lib/ts/recipe/passwordless/components/features/linkClickedScreen/index.tsx
@@ -109,6 +109,7 @@ const LinkClickedScreen: React.FC<PropType> = (props) => {
                         rid: props.recipe.config.recipeId,
                         successRedirectContext: {
                             action: "SUCCESS",
+                            isNewPrimaryUser: response.createdNewRecipeUser && response.user.loginMethods.length === 1,
                             isNewRecipeUser: response.createdNewRecipeUser,
                             redirectToPath: loginAttemptInfo?.redirectToPath,
                         },

--- a/lib/ts/recipe/passwordless/components/features/signInAndUp/index.tsx
+++ b/lib/ts/recipe/passwordless/components/features/signInAndUp/index.tsx
@@ -175,6 +175,7 @@ export function useChildProps(
                         rid: recipe.config.recipeId,
                         successRedirectContext: {
                             action: "SUCCESS",
+                            isNewPrimaryUser: result.createdNewRecipeUser && result.user.loginMethods.length === 1,
                             isNewRecipeUser: result.createdNewRecipeUser,
                             redirectToPath: getRedirectToPathFromURL(),
                         },

--- a/lib/ts/recipe/passwordless/components/features/signInAndUp/index.tsx
+++ b/lib/ts/recipe/passwordless/components/features/signInAndUp/index.tsx
@@ -29,7 +29,7 @@ import { getPhoneNumberUtils } from "../../../phoneNumberUtils";
 import SignInUpThemeWrapper from "../../themes/signInUp";
 import { defaultTranslationsPasswordless } from "../../themes/translations";
 
-import type { Navigate, FeatureBaseProps } from "../../../../../types";
+import type { Navigate, FeatureBaseProps, UserContext } from "../../../../../types";
 import type Recipe from "../../../recipe";
 import type { AdditionalLoginAttemptInfoProperties, ComponentOverrideMap } from "../../../types";
 import type { PasswordlessSignInUpAction, SignInUpState, SignInUpChildProps, NormalisedConfig } from "../../../types";
@@ -38,7 +38,7 @@ import type { User } from "supertokens-web-js/types";
 
 export const useFeatureReducer = (
     recipeImpl: RecipeInterface | undefined,
-    userContext: any
+    userContext: UserContext
 ): [SignInUpState, React.Dispatch<PasswordlessSignInUpAction>] => {
     const [state, dispatch] = React.useReducer(
         (oldState: SignInUpState, action: PasswordlessSignInUpAction) => {
@@ -141,14 +141,14 @@ export function useChildProps(
     recipe: Recipe,
     dispatch: React.Dispatch<PasswordlessSignInUpAction>,
     state: SignInUpState,
-    userContext: any,
+    userContext: UserContext,
     navigate?: Navigate
 ): SignInUpChildProps;
 export function useChildProps(
     recipe: Recipe | undefined,
     dispatch: React.Dispatch<PasswordlessSignInUpAction>,
     state: SignInUpState,
-    userContext: any,
+    userContext: UserContext,
     navigate?: Navigate
 ): SignInUpChildProps | undefined;
 
@@ -156,7 +156,7 @@ export function useChildProps(
     recipe: Recipe | undefined,
     dispatch: React.Dispatch<PasswordlessSignInUpAction>,
     state: SignInUpState,
-    userContext: any,
+    userContext: UserContext,
     navigate?: Navigate
 ): SignInUpChildProps | undefined {
     const recipeImplementation = React.useMemo(

--- a/lib/ts/recipe/passwordless/index.ts
+++ b/lib/ts/recipe/passwordless/index.ts
@@ -22,6 +22,7 @@ import Passwordless from "./recipe";
 import { UserInput } from "./types";
 import { GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 
+import type { UserContext } from "../../types";
 import type { RecipeFunctionOptions } from "supertokens-web-js/recipe/passwordless";
 import type { PasswordlessFlowType } from "supertokens-web-js/recipe/passwordless/types";
 import type { User } from "supertokens-web-js/types";
@@ -31,7 +32,7 @@ export default class Wrapper {
         return Passwordless.init(config);
     }
 
-    static async signOut(input?: { userContext?: any }): Promise<void> {
+    static async signOut(input?: { userContext?: UserContext }): Promise<void> {
         return Passwordless.getInstanceOrThrow().signOut({
             userContext: getNormalisedUserContext(input?.userContext),
         });
@@ -39,8 +40,8 @@ export default class Wrapper {
 
     static async createCode(
         input:
-            | { email: string; userContext?: any; options?: RecipeFunctionOptions }
-            | { phoneNumber: string; userContext?: any; options?: RecipeFunctionOptions }
+            | { email: string; userContext?: UserContext; options?: RecipeFunctionOptions }
+            | { phoneNumber: string; userContext?: UserContext; options?: RecipeFunctionOptions }
     ): Promise<
         | {
               status: "OK";
@@ -60,7 +61,7 @@ export default class Wrapper {
         });
     }
 
-    static async resendCode(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static async resendCode(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<{
         status: "OK" | "RESTART_FLOW_ERROR";
         fetchResponse: Response;
     }> {
@@ -74,11 +75,11 @@ export default class Wrapper {
         input?:
             | {
                   userInputCode: string;
-                  userContext?: any;
+                  userContext?: UserContext;
                   options?: RecipeFunctionOptions;
               }
             | {
-                  userContext?: any;
+                  userContext?: UserContext;
                   options?: RecipeFunctionOptions;
               }
     ): Promise<
@@ -103,21 +104,25 @@ export default class Wrapper {
         });
     }
 
-    static getLinkCodeFromURL(input?: { userContext?: any }): string {
+    static getLinkCodeFromURL(input?: { userContext?: UserContext }): string {
         return Passwordless.getInstanceOrThrow().webJSRecipe.getLinkCodeFromURL({
             ...input,
             userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static getPreAuthSessionIdFromURL(input?: { userContext?: any }): string {
+    static getPreAuthSessionIdFromURL(input?: { userContext?: UserContext }): string {
         return Passwordless.getInstanceOrThrow().webJSRecipe.getPreAuthSessionIdFromURL({
             ...input,
             userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static async doesEmailExist(input: { email: string; userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static async doesEmailExist(input: {
+        email: string;
+        userContext?: UserContext;
+        options?: RecipeFunctionOptions;
+    }): Promise<{
         status: "OK";
         doesExist: boolean;
         fetchResponse: Response;
@@ -130,7 +135,7 @@ export default class Wrapper {
 
     static async doesPhoneNumberExist(input: {
         phoneNumber: string;
-        userContext?: any;
+        userContext?: UserContext;
         options?: RecipeFunctionOptions;
     }): Promise<{
         status: "OK";
@@ -143,7 +148,7 @@ export default class Wrapper {
         });
     }
 
-    static async getLoginAttemptInfo<CustomLoginAttemptInfoProperties>(input?: { userContext?: any }): Promise<
+    static async getLoginAttemptInfo<CustomLoginAttemptInfoProperties>(input?: { userContext?: UserContext }): Promise<
         | undefined
         | ({
               deviceId: string;
@@ -163,7 +168,7 @@ export default class Wrapper {
             preAuthSessionId: string;
             flowType: PasswordlessFlowType;
         } & CustomStateProperties;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<void> {
         return Passwordless.getInstanceOrThrow().webJSRecipe.setLoginAttemptInfo({
             ...input,
@@ -171,7 +176,7 @@ export default class Wrapper {
         });
     }
 
-    static async clearLoginAttemptInfo(input?: { userContext?: any }): Promise<void> {
+    static async clearLoginAttemptInfo(input?: { userContext?: UserContext }): Promise<void> {
         return Passwordless.getInstanceOrThrow().webJSRecipe.clearLoginAttemptInfo({
             ...input,
             userContext: getNormalisedUserContext(input?.userContext),

--- a/lib/ts/recipe/passwordless/prebuiltui.tsx
+++ b/lib/ts/recipe/passwordless/prebuiltui.tsx
@@ -1,7 +1,7 @@
 import NormalisedURLPath from "supertokens-web-js/utils/normalisedURLPath";
 
 import UserContextWrapper from "../../usercontext/userContextWrapper";
-import { isTest, matchRecipeIdUsingQueryParams } from "../../utils";
+import { getNormalisedUserContext, isTest, matchRecipeIdUsingQueryParams } from "../../utils";
 import AuthWidgetWrapper from "../authRecipe/authWidgetWrapper";
 import { RecipeRouter } from "../recipeRouter";
 
@@ -18,7 +18,7 @@ import type {
     NormalisedConfig,
 } from "./types";
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { RecipeFeatureComponentMap, FeatureBaseProps, Navigate } from "../../types";
+import type { RecipeFeatureComponentMap, FeatureBaseProps, Navigate, UserContext } from "../../types";
 import type { PropsWithChildren } from "react";
 
 export class PasswordlessPreBuiltUI extends RecipeRouter {
@@ -43,7 +43,7 @@ export class PasswordlessPreBuiltUI extends RecipeRouter {
     }
     static getFeatureComponent(
         componentName: "signInUp" | "linkClickedScreen",
-        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }>,
+        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext: UserContext }>,
         useComponentOverrides: () => GenericComponentOverrideMap<any> = useRecipeComponentOverrideContext
     ): JSX.Element {
         return PasswordlessPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent(
@@ -84,7 +84,7 @@ export class PasswordlessPreBuiltUI extends RecipeRouter {
     };
     getFeatureComponent = (
         componentName: "signInUp" | "linkClickedScreen",
-        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }>,
+        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext: UserContext }>,
         useComponentOverrides: () => GenericComponentOverrideMap<any> = useRecipeComponentOverrideContext
     ): JSX.Element => {
         if (componentName === "signInUp") {
@@ -145,11 +145,20 @@ export class PasswordlessPreBuiltUI extends RecipeRouter {
     }
 
     static SignInUp = (
-        prop: PropsWithChildren<{ redirectOnSessionExists?: boolean; navigate?: Navigate; userContext?: any }> = {}
-    ) => this.getFeatureComponent("signInUp", prop);
+        prop: PropsWithChildren<{
+            redirectOnSessionExists?: boolean;
+            navigate?: Navigate;
+            userContext?: UserContext;
+        }> = {}
+    ) => {
+        const userContext = getNormalisedUserContext(prop.userContext);
+        return this.getFeatureComponent("signInUp", { ...prop, userContext });
+    };
 
-    static LinkClicked = (prop: FeatureBaseProps<{ userContext?: any }>) =>
-        this.getFeatureComponent("linkClickedScreen", prop);
+    static LinkClicked = (prop: FeatureBaseProps<{ userContext?: UserContext }>) => {
+        const userContext = getNormalisedUserContext(prop.userContext);
+        return this.getFeatureComponent("linkClickedScreen", { ...prop, userContext });
+    };
 
     static SignInUpTheme = SignInUpTheme;
 }

--- a/lib/ts/recipe/passwordless/types.ts
+++ b/lib/ts/recipe/passwordless/types.ts
@@ -24,7 +24,7 @@ import type { UserInputCodeForm } from "./components/themes/signInUp/userInputCo
 import type { UserInputCodeFormFooter } from "./components/themes/signInUp/userInputCodeFormFooter";
 import type { UserInputCodeFormHeader } from "./components/themes/signInUp/userInputCodeFormHeader";
 import type { ComponentOverride } from "../../components/componentOverride/componentOverride";
-import type { FeatureBaseConfig, NormalisedBaseConfig, WebJSRecipeInterface } from "../../types";
+import type { FeatureBaseConfig, NormalisedBaseConfig, UserContext, WebJSRecipeInterface } from "../../types";
 import type {
     GetRedirectionURLContext as AuthRecipeModuleGetRedirectionURLContext,
     OnHandleEventContext as AuthRecipeModuleOnHandleEventContext,
@@ -192,7 +192,7 @@ export type SignInUpProps = {
         loaded: boolean;
         error: string | undefined;
     };
-    userContext?: any;
+    userContext?: UserContext;
 };
 export type LoginAttemptInfo = {
     deviceId: string;

--- a/lib/ts/recipe/recipeModule/index.ts
+++ b/lib/ts/recipe/recipeModule/index.ts
@@ -15,12 +15,12 @@
 
 import { logDebugMessage } from "../../logger";
 import SuperTokens from "../../superTokens";
-import { appendQueryParamsToURL } from "../../utils";
+import { appendQueryParamsToURL, getNormalisedUserContext } from "../../utils";
 
 import { BaseRecipeModule } from "./baseRecipeModule";
 
 import type { NormalisedConfig } from "./types";
-import type { Navigate } from "../../types";
+import type { Navigate, UserContext } from "../../types";
 
 export default abstract class RecipeModule<
     GetRedirectionURLContextType,
@@ -32,9 +32,10 @@ export default abstract class RecipeModule<
         context: GetRedirectionURLContextType,
         navigate?: Navigate,
         queryParams?: Record<string, string>,
-        userContext?: any
+        userContext?: UserContext
     ): Promise<void> => {
-        let redirectUrl = await this.getRedirectUrl(context, userContext);
+        // NOTE: We cannot make userContext required in args because it follows optional parameters. Instead we will normalise it if it wasn't passed in.
+        let redirectUrl = await this.getRedirectUrl(context, getNormalisedUserContext(userContext));
 
         if (redirectUrl === null) {
             logDebugMessage(
@@ -52,7 +53,10 @@ export default abstract class RecipeModule<
     };
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    getRedirectUrl = async (context: GetRedirectionURLContextType, userContext?: any): Promise<string | null> => {
+    getRedirectUrl = async (
+        context: GetRedirectionURLContextType,
+        userContext: UserContext
+    ): Promise<string | null> => {
         // If getRedirectionURL provided by user.
         const redirectUrl = await this.config.getRedirectionURL(context, userContext);
         if (redirectUrl !== undefined) {

--- a/lib/ts/recipe/recipeModule/types.ts
+++ b/lib/ts/recipe/recipeModule/types.ts
@@ -1,8 +1,10 @@
+import type { UserContext } from "../../types";
+
 export type RecipePreAPIHookContext<Action> = {
     requestInit: RequestInit;
     url: string;
     action: Action;
-    userContext: any;
+    userContext: UserContext;
 };
 
 export type RecipePostAPIHookContext<Action> = {
@@ -10,7 +12,7 @@ export type RecipePostAPIHookContext<Action> = {
     requestInit: RequestInit;
     url: string;
     fetchResponse: Response;
-    userContext: any;
+    userContext: UserContext;
 };
 
 export type RecipePreAPIHookFunction<Action> = (
@@ -22,7 +24,10 @@ export type RecipePostAPIHookFunction<Action> = (context: RecipePostAPIHookConte
 export type RecipeOnHandleEventFunction<EventType> = (context: EventType) => void;
 
 export type UserInput<GetRedirectionURLContextType, Action, OnHandleEventContextType> = {
-    getRedirectionURL?: (context: GetRedirectionURLContextType, userContext: any) => Promise<string | undefined | null>;
+    getRedirectionURL?: (
+        context: GetRedirectionURLContextType,
+        userContext: UserContext
+    ) => Promise<string | undefined | null>;
     preAPIHook?: RecipePreAPIHookFunction<Action>;
     postAPIHook?: RecipePostAPIHookFunction<Action>;
     onHandleEvent?: RecipeOnHandleEventFunction<OnHandleEventContextType>;
@@ -37,7 +42,10 @@ export type Config<GetRedirectionURLContextType, Action, OnHandleEventContextTyp
 >;
 
 export type NormalisedConfig<GetRedirectionURLContextType, Action, OnHandleEventContextType> = {
-    getRedirectionURL: (context: GetRedirectionURLContextType, userContext: any) => Promise<string | undefined | null>;
+    getRedirectionURL: (
+        context: GetRedirectionURLContextType,
+        userContext: UserContext
+    ) => Promise<string | undefined | null>;
     onHandleEvent: RecipeOnHandleEventFunction<OnHandleEventContextType>;
     useShadowDom: boolean;
     rootStyle: string;

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -29,6 +29,8 @@ import { InputType, SessionContextType } from "./types";
 import { useClaimValue as useClaimValueFunc } from "./useClaimValue";
 import useSessionContextFunc from "./useSessionContext";
 
+import type { UserContext } from "../../types";
+
 export default class SessionAPIWrapper {
     static useSessionContext = useSessionContextFunc;
     static useClaimValue = useClaimValueFunc;
@@ -39,19 +41,19 @@ export default class SessionAPIWrapper {
         return Session.init(config);
     }
 
-    static async getUserId(input?: { userContext?: any }): Promise<string> {
+    static async getUserId(input?: { userContext?: UserContext }): Promise<string> {
         return Session.getInstanceOrThrow().getUserId({
             userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static async getAccessToken(input?: { userContext?: any }): Promise<string | undefined> {
+    static async getAccessToken(input?: { userContext?: UserContext }): Promise<string | undefined> {
         return Session.getInstanceOrThrow().getAccessToken({
             userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static async getAccessTokenPayloadSecurely(input?: { userContext?: any }): Promise<any> {
+    static async getAccessTokenPayloadSecurely(input?: { userContext?: UserContext }): Promise<any> {
         return Session.getInstanceOrThrow().getAccessTokenPayloadSecurely({
             userContext: getNormalisedUserContext(input?.userContext),
         });
@@ -61,7 +63,7 @@ export default class SessionAPIWrapper {
         return Session.getInstanceOrThrow().attemptRefreshingSession();
     }
 
-    static async doesSessionExist(input?: { userContext?: any }): Promise<boolean> {
+    static async doesSessionExist(input?: { userContext?: UserContext }): Promise<boolean> {
         return Session.getInstanceOrThrow().doesSessionExist({
             userContext: getNormalisedUserContext(input?.userContext),
         });
@@ -70,11 +72,11 @@ export default class SessionAPIWrapper {
     /**
      * @deprecated
      */
-    static addAxiosInterceptors(axiosInstance: any, userContext?: any): void {
+    static addAxiosInterceptors(axiosInstance: any, userContext?: UserContext): void {
         return Session.addAxiosInterceptors(axiosInstance, getNormalisedUserContext(userContext));
     }
 
-    static async signOut(input?: { userContext?: any }): Promise<void> {
+    static async signOut(input?: { userContext?: UserContext }): Promise<void> {
         return Session.getInstanceOrThrow().signOut({
             userContext: getNormalisedUserContext(input?.userContext),
         });
@@ -83,9 +85,9 @@ export default class SessionAPIWrapper {
     static validateClaims(input?: {
         overrideGlobalClaimValidators?: (
             globalClaimValidators: SessionClaimValidator[],
-            userContext: any
+            userContext: UserContext
         ) => SessionClaimValidator[];
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<ClaimValidationError[]> | ClaimValidationError[] {
         return Session.getInstanceOrThrow().validateClaims({
             overrideGlobalClaimValidators: input?.overrideGlobalClaimValidators,
@@ -95,12 +97,12 @@ export default class SessionAPIWrapper {
 
     static getInvalidClaimsFromResponse(input: {
         response: { data: any } | Response;
-        userContext: any;
+        userContext: UserContext;
     }): Promise<ClaimValidationError[]> {
         return Session.getInstanceOrThrow().getInvalidClaimsFromResponse(input);
     }
 
-    static getClaimValue<T>(input: { claim: SessionClaim<T>; userContext?: any }): Promise<T | undefined> {
+    static getClaimValue<T>(input: { claim: SessionClaim<T>; userContext?: UserContext }): Promise<T | undefined> {
         return Session.getInstanceOrThrow().getClaimValue({
             claim: input.claim,
             userContext: getNormalisedUserContext(input?.userContext),

--- a/lib/ts/recipe/session/prebuiltui.tsx
+++ b/lib/ts/recipe/session/prebuiltui.tsx
@@ -1,5 +1,5 @@
 import UserContextWrapper from "../../usercontext/userContextWrapper";
-import { isTest } from "../../utils";
+import { getNormalisedUserContext, isTest } from "../../utils";
 import { RecipeRouter } from "../recipeRouter";
 
 import { useRecipeComponentOverrideContext } from "./componentOverrideContext";
@@ -8,7 +8,7 @@ import { AccessDeniedScreenTheme } from "./components/themes/accessDeniedScreenT
 import Session from "./recipe";
 
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { RecipeFeatureComponentMap, FeatureBaseProps } from "../../types";
+import type { RecipeFeatureComponentMap, FeatureBaseProps, UserContext } from "../../types";
 
 export class SessionPreBuiltUI extends RecipeRouter {
     static instance?: SessionPreBuiltUI;
@@ -32,7 +32,7 @@ export class SessionPreBuiltUI extends RecipeRouter {
     }
     static getFeatureComponent(
         componentName: "accessDenied",
-        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }>,
+        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext: UserContext }>,
         useComponentOverrides: () => GenericComponentOverrideMap<any> = useRecipeComponentOverrideContext
     ): JSX.Element {
         return SessionPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent(
@@ -51,7 +51,7 @@ export class SessionPreBuiltUI extends RecipeRouter {
     };
     getFeatureComponent = (
         componentName: "accessDenied",
-        props: FeatureBaseProps<{ userContext?: any }>,
+        props: FeatureBaseProps<{ userContext: UserContext }>,
         useComponentOverrides: () => GenericComponentOverrideMap<any> = useRecipeComponentOverrideContext
     ): JSX.Element => {
         if (componentName === "accessDenied") {
@@ -77,8 +77,10 @@ export class SessionPreBuiltUI extends RecipeRouter {
         return;
     }
 
-    static AccessDeniedScreen = (prop: FeatureBaseProps<{ userContext?: any }> = {}): React.ReactElement =>
-        this.getFeatureComponent("accessDenied", prop);
+    static AccessDeniedScreen = (prop: FeatureBaseProps<{ userContext?: UserContext }> = {}): React.ReactElement => {
+        const userContext = getNormalisedUserContext(prop.userContext);
+        return this.getFeatureComponent("accessDenied", { ...prop, userContext });
+    };
 
     static AccessDeniedScreenTheme = AccessDeniedScreenTheme;
 }

--- a/lib/ts/recipe/session/recipe.tsx
+++ b/lib/ts/recipe/session/recipe.tsx
@@ -20,7 +20,13 @@ import SessionWebJS from "supertokens-web-js/recipe/session";
 import WebJSSessionRecipe from "supertokens-web-js/recipe/session";
 
 import SuperTokens from "../../superTokens";
-import { getLocalStorage, isTest, removeFromLocalStorage, setLocalStorage } from "../../utils";
+import {
+    getLocalStorage,
+    getNormalisedUserContext,
+    isTest,
+    removeFromLocalStorage,
+    setLocalStorage,
+} from "../../utils";
 import RecipeModule from "../recipeModule";
 
 import { getFailureRedirectionInfo, normaliseSessionConfig } from "./utils";
@@ -32,6 +38,7 @@ import type {
     NormalisedAppInfo,
     NormalisedConfigWithAppInfoAndRecipeID,
     RecipeInitResult,
+    UserContext,
 } from "../../types";
 import type { ClaimValidationError, SessionClaimValidator } from "supertokens-web-js/recipe/session";
 import type { SessionClaim } from "supertokens-web-js/recipe/session";
@@ -46,7 +53,12 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
     private eventListeners = new Set<(ctx: RecipeEventWithSessionContext) => void>();
     private redirectionHandlersFromAuthRecipes = new Map<
         string,
-        (ctx: any, navigate?: Navigate, queryParams?: Record<string, string>, userContext?: any) => Promise<void>
+        (
+            ctx: any,
+            navigate?: Navigate,
+            queryParams?: Record<string, string>,
+            userContext?: UserContext
+        ) => Promise<void>
     >();
 
     constructor(
@@ -56,30 +68,30 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
         super(config);
     }
 
-    getUserId = (input: { userContext: any }): Promise<string> => {
+    getUserId = (input: { userContext: UserContext }): Promise<string> => {
         return this.webJSRecipe.getUserId(input);
     };
 
-    getAccessToken = (input: { userContext: any }): Promise<string | undefined> => {
+    getAccessToken = (input: { userContext: UserContext }): Promise<string | undefined> => {
         return this.webJSRecipe.getAccessToken(input);
     };
 
     getClaimValue = <T extends unknown>(input: {
         claim: SessionClaim<T>;
-        userContext: any;
+        userContext: UserContext;
     }): Promise<T | undefined> => {
         return this.webJSRecipe.getClaimValue(input);
     };
 
-    getAccessTokenPayloadSecurely = async (input: { userContext: any }): Promise<any> => {
+    getAccessTokenPayloadSecurely = async (input: { userContext: UserContext }): Promise<any> => {
         return this.webJSRecipe.getAccessTokenPayloadSecurely(input);
     };
 
-    doesSessionExist = (input: { userContext: any }): Promise<boolean> => {
+    doesSessionExist = (input: { userContext: UserContext }): Promise<boolean> => {
         return this.webJSRecipe.doesSessionExist(input);
     };
 
-    signOut = (input: { userContext: any }): Promise<void> => {
+    signOut = (input: { userContext: UserContext }): Promise<void> => {
         return this.webJSRecipe.signOut(input);
     };
 
@@ -90,16 +102,16 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
     validateClaims = (input: {
         overrideGlobalClaimValidators?: (
             globalClaimValidators: SessionClaimValidator[],
-            userContext: any
+            userContext: UserContext
         ) => SessionClaimValidator[];
-        userContext: any;
+        userContext: UserContext;
     }): Promise<ClaimValidationError[]> | ClaimValidationError[] => {
         return this.webJSRecipe.validateClaims(input);
     };
 
     getInvalidClaimsFromResponse = (input: {
         response: { data: any } | Response;
-        userContext: any;
+        userContext: UserContext;
     }): Promise<ClaimValidationError[]> => {
         return this.webJSRecipe.getInvalidClaimsFromResponse(input);
     };
@@ -119,7 +131,7 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
             context: any,
             navigate?: Navigate,
             queryParams?: Record<string, string>,
-            userContext?: any
+            userContext?: UserContext
         ) => Promise<void>
     ) => {
         this.redirectionHandlersFromAuthRecipes.set(rid, redirect);
@@ -134,9 +146,10 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
                 redirectToPath?: string;
             };
         },
-        userContext?: any,
+        userContext?: UserContext,
         navigate?: Navigate
     ): Promise<void> => {
+        userContext = getNormalisedUserContext(userContext);
         // First we check if there is an active session
         if (!(await this.doesSessionExist({ userContext }))) {
             // If there is none, we have no way of checking claims, so we redirect to the auth page
@@ -264,7 +277,7 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    static addAxiosInterceptors(axiosInstance: any, userContext: any): void {
+    static addAxiosInterceptors(axiosInstance: any, userContext: UserContext): void {
         return WebJSSessionRecipe.addAxiosInterceptors(axiosInstance, userContext);
     }
 

--- a/lib/ts/recipe/session/recipe.tsx
+++ b/lib/ts/recipe/session/recipe.tsx
@@ -143,6 +143,7 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
             successRedirectContext: {
                 action: "SUCCESS";
                 isNewRecipeUser: boolean;
+                isNewPrimaryUser: boolean;
                 redirectToPath?: string;
             };
         },
@@ -202,6 +203,7 @@ export default class Session extends RecipeModule<unknown, unknown, unknown, Nor
                     rid: Session.RECIPE_ID,
                     successRedirectContext: {
                         action: "SUCCESS",
+                        isNewPrimaryUser: false,
                         isNewRecipeUser: false,
                     },
                 };

--- a/lib/ts/recipe/session/sessionAuth.tsx
+++ b/lib/ts/recipe/session/sessionAuth.tsx
@@ -29,7 +29,7 @@ import SessionContext from "./sessionContext";
 import { getFailureRedirectionInfo } from "./utils";
 
 import type { LoadedSessionContext, RecipeEventWithSessionContext, SessionContextType } from "./types";
-import type { Navigate, ReactComponentClass, SessionClaimValidator } from "../../types";
+import type { Navigate, ReactComponentClass, SessionClaimValidator, UserContext } from "../../types";
 import type { PropsWithChildren } from "react";
 import type { ClaimValidationError } from "supertokens-web-js/recipe/session";
 
@@ -44,14 +44,14 @@ export type SessionAuthProps = {
     doRedirection?: boolean;
 
     accessDeniedScreen?: ReactComponentClass<{
-        userContext?: any;
+        userContext?: UserContext;
         navigate?: Navigate;
         validationError: ClaimValidationError;
     }>;
     onSessionExpired?: () => void;
     overrideGlobalClaimValidators?: (
         globalClaimValidators: SessionClaimValidator[],
-        userContext: any
+        userContext: UserContext
     ) => SessionClaimValidator[];
 };
 
@@ -316,7 +316,7 @@ const SessionAuth: React.FC<PropsWithChildren<SessionAuthProps>> = ({ children, 
 const SessionAuthWrapper: React.FC<
     PropsWithChildren<
         SessionAuthProps & {
-            userContext?: any;
+            userContext?: UserContext;
         }
     >
 > = (props) => {

--- a/lib/ts/recipe/session/utils.ts
+++ b/lib/ts/recipe/session/utils.ts
@@ -18,7 +18,7 @@ import { getGlobalClaimValidators } from "supertokens-web-js/utils";
 import { normaliseRecipeModuleConfig } from "../recipeModule/utils";
 
 import type { InputType, NormalisedSessionConfig } from "./types";
-import type { NormalisedBaseConfig } from "../../types";
+import type { NormalisedBaseConfig, UserContext } from "../../types";
 import type { SessionClaimValidator } from "../../types";
 import type { ClaimValidationError } from "supertokens-web-js/recipe/session";
 import type { RecipeInterface } from "supertokens-web-js/recipe/session";
@@ -54,9 +54,9 @@ export const getFailureRedirectionInfo = async ({
     invalidClaims: ClaimValidationError[];
     overrideGlobalClaimValidators?: (
         globalClaimValidators: SessionClaimValidator[],
-        userContext: any
+        userContext: UserContext
     ) => SessionClaimValidator[];
-    userContext: any;
+    userContext: UserContext;
 }): Promise<{ redirectPath?: string; failedClaim?: ClaimValidationError }> => {
     const globalValidators = getGlobalClaimValidators({
         overrideGlobalClaimValidators,

--- a/lib/ts/recipe/thirdparty/components/features/signInAndUpCallback/index.tsx
+++ b/lib/ts/recipe/thirdparty/components/features/signInAndUpCallback/index.tsx
@@ -76,6 +76,7 @@ const SignInAndUpCallback: React.FC<PropType> = (props) => {
                         rid: props.recipe.config.recipeId,
                         successRedirectContext: {
                             action: "SUCCESS",
+                            isNewPrimaryUser: response.createdNewRecipeUser && response.user.loginMethods.length === 1,
                             isNewRecipeUser: response.createdNewRecipeUser,
                             redirectToPath,
                         },

--- a/lib/ts/recipe/thirdparty/components/themes/signInAndUp/index.tsx
+++ b/lib/ts/recipe/thirdparty/components/themes/signInAndUp/index.tsx
@@ -22,6 +22,7 @@ import { ProvidersForm } from "./providersForm";
 import { SignInAndUpHeader } from "./signInAndUpHeader";
 import { SignUpFooter } from "./signUpFooter";
 
+import type { UserContext } from "../../../../../types";
 import type { SignInAndUpThemeProps } from "../../../types";
 
 const SignInAndUpTheme: React.FC<SignInAndUpThemeProps> = (props) => {
@@ -48,7 +49,7 @@ const SignInAndUpTheme: React.FC<SignInAndUpThemeProps> = (props) => {
 
 const SignInAndUpThemeWrapper: React.FC<
     SignInAndUpThemeProps & {
-        userContext?: any;
+        userContext?: UserContext;
     }
 > = (props) => {
     const hasFont = hasFontDefined(props.config.rootStyle);

--- a/lib/ts/recipe/thirdparty/index.ts
+++ b/lib/ts/recipe/thirdparty/index.ts
@@ -40,6 +40,7 @@ import ThirdParty from "./recipe";
 import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 import { redirectToThirdPartyLogin as UtilsRedirectToThirdPartyLogin } from "./utils";
 
+import type { UserContext } from "../../types";
 import type { StateObject } from "supertokens-web-js/recipe/thirdparty";
 import type { RecipeFunctionOptions } from "supertokens-web-js/recipe/thirdpartyemailpassword";
 import type { User } from "supertokens-web-js/types";
@@ -53,7 +54,7 @@ export default class Wrapper {
         return ThirdParty.init(config);
     }
 
-    static async signOut(input?: { userContext?: any }): Promise<void> {
+    static async signOut(input?: { userContext?: UserContext }): Promise<void> {
         return ThirdParty.getInstanceOrThrow().signOut({
             userContext: getNormalisedUserContext(input?.userContext),
         });
@@ -61,7 +62,7 @@ export default class Wrapper {
 
     static async redirectToThirdPartyLogin(input: {
         thirdPartyId: string;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<{ status: "OK" | "ERROR" }> {
         const recipeInstance: ThirdParty = ThirdParty.getInstanceOrThrow();
 
@@ -74,7 +75,7 @@ export default class Wrapper {
     }
 
     static getStateAndOtherInfoFromStorage<CustomStateProperties>(input?: {
-        userContext?: any;
+        userContext?: UserContext;
     }): (StateObject & CustomStateProperties) | undefined {
         return ThirdParty.getInstanceOrThrow().webJSRecipe.getStateAndOtherInfoFromStorage({
             ...input,
@@ -86,7 +87,7 @@ export default class Wrapper {
         thirdPartyId: string;
         frontendRedirectURI: string;
         redirectURIOnProviderDashboard?: string;
-        userContext?: any;
+        userContext?: UserContext;
         options?: RecipeFunctionOptions;
     }): Promise<string> {
         return ThirdParty.getInstanceOrThrow().webJSRecipe.getAuthorisationURLWithQueryParamsAndSetState({
@@ -95,7 +96,7 @@ export default class Wrapper {
         });
     }
 
-    static async signInAndUp(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<
+    static async signInAndUp(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<
         | {
               status: "OK";
               user: User;

--- a/lib/ts/recipe/thirdparty/prebuiltui.tsx
+++ b/lib/ts/recipe/thirdparty/prebuiltui.tsx
@@ -1,7 +1,7 @@
 import NormalisedURLPath from "supertokens-web-js/utils/normalisedURLPath";
 
 import UserContextWrapper from "../../usercontext/userContextWrapper";
-import { isTest, matchRecipeIdUsingQueryParams } from "../../utils";
+import { getNormalisedUserContext, isTest, matchRecipeIdUsingQueryParams } from "../../utils";
 import AuthWidgetWrapper from "../authRecipe/authWidgetWrapper";
 import { RecipeRouter } from "../recipeRouter";
 
@@ -20,7 +20,7 @@ import type {
     OnHandleEventContext,
 } from "./types";
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { RecipeFeatureComponentMap, FeatureBaseProps } from "../../types";
+import type { RecipeFeatureComponentMap, FeatureBaseProps, UserContext } from "../../types";
 
 export class ThirdPartyPreBuiltUI extends RecipeRouter {
     static instance?: ThirdPartyPreBuiltUI;
@@ -44,7 +44,7 @@ export class ThirdPartyPreBuiltUI extends RecipeRouter {
     }
     static getFeatureComponent(
         componentName: "signinup" | "signinupcallback",
-        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }>,
+        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext: UserContext }>,
         useComponentOverrides: () => GenericComponentOverrideMap<any> = useRecipeComponentOverrideContext
     ): JSX.Element {
         return ThirdPartyPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent(
@@ -84,7 +84,7 @@ export class ThirdPartyPreBuiltUI extends RecipeRouter {
     };
     getFeatureComponent = (
         componentName: "signinup" | "signinupcallback",
-        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }>,
+        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext: UserContext }>,
         useComponentOverrides: () => GenericComponentOverrideMap<any> = useRecipeComponentOverrideContext
     ): JSX.Element => {
         if (componentName === "signinup") {
@@ -143,10 +143,22 @@ export class ThirdPartyPreBuiltUI extends RecipeRouter {
         return;
     }
 
-    static SignInAndUp = (prop: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }> = {}) =>
-        ThirdPartyPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("signinup", prop);
-    static SignInAndUpCallback = (prop: FeatureBaseProps<{ userContext?: any }>) =>
-        ThirdPartyPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("signinupcallback", prop);
+    static SignInAndUp = (
+        prop: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: UserContext }> = {}
+    ) => {
+        const userContext = getNormalisedUserContext(prop.userContext);
+        return ThirdPartyPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("signinup", {
+            ...prop,
+            userContext,
+        });
+    };
+    static SignInAndUpCallback = (prop: FeatureBaseProps<{ userContext?: UserContext }>) => {
+        const userContext = getNormalisedUserContext(prop.userContext);
+        return ThirdPartyPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent("signinupcallback", {
+            ...prop,
+            userContext,
+        });
+    };
     static SignInAndUpTheme = SignInAndUpTheme;
     static SignInAndUpCallbackTheme = SignInAndUpCallbackTheme;
 }

--- a/lib/ts/recipe/thirdparty/types.ts
+++ b/lib/ts/recipe/thirdparty/types.ts
@@ -20,7 +20,7 @@ import type { SignInAndUpCallbackTheme } from "./components/themes/signInAndUpCa
 import type Provider from "./providers";
 import type { CustomProviderConfig } from "./providers/types";
 import type { ComponentOverride } from "../../components/componentOverride/componentOverride";
-import type { FeatureBaseConfig, NormalisedBaseConfig, WebJSRecipeInterface } from "../../types";
+import type { FeatureBaseConfig, NormalisedBaseConfig, UserContext, WebJSRecipeInterface } from "../../types";
 import type {
     GetRedirectionURLContext as AuthRecipeModuleGetRedirectionURLContext,
     OnHandleEventContext as AuthRecipeModuleOnHandleEventContext,
@@ -117,7 +117,7 @@ export type PreAPIHookContext = {
     action: PreAndPostAPIHookAction;
     requestInit: RequestInit;
     url: string;
-    userContext: any;
+    userContext: UserContext;
 };
 
 export type OnHandleEventContext =
@@ -126,7 +126,7 @@ export type OnHandleEventContext =
           action: "SUCCESS";
           isNewRecipeUser: boolean;
           user: User;
-          userContext: any;
+          userContext: UserContext;
       };
 
 export type SignInAndUpThemeProps = {

--- a/lib/ts/recipe/thirdparty/utils.ts
+++ b/lib/ts/recipe/thirdparty/utils.ts
@@ -45,7 +45,7 @@ import type {
     Config,
     CustomStateProperties,
 } from "./types";
-import type { WebJSRecipeInterface } from "../../types";
+import type { UserContext, WebJSRecipeInterface } from "../../types";
 import type { RecipeInterface } from "supertokens-web-js/recipe/thirdparty";
 import type ThirdPartyWebJS from "supertokens-web-js/recipe/thirdparty";
 
@@ -119,7 +119,7 @@ export function normaliseSignInAndUpFeature(
     };
 }
 
-export function matchRecipeIdUsingState(recipe: Recipe, userContext: any): boolean {
+export function matchRecipeIdUsingState(recipe: Recipe, userContext: UserContext): boolean {
     const stateResponse = recipe.webJSRecipe.getStateAndOtherInfoFromStorage<CustomStateProperties>({
         userContext,
     });
@@ -135,7 +135,7 @@ export function matchRecipeIdUsingState(recipe: Recipe, userContext: any): boole
 export async function redirectToThirdPartyLogin(input: {
     thirdPartyId: string;
     config: NormalisedConfig;
-    userContext: any;
+    userContext: UserContext;
     recipeImplementation: WebJSRecipeInterface<typeof ThirdPartyWebJS>;
 }): Promise<{ status: "OK" | "ERROR" }> {
     const loginMethods = await Multitenancy.getInstanceOrThrow().getCurrentDynamicLoginMethods({

--- a/lib/ts/recipe/thirdpartyemailpassword/components/themes/signInAndUp/index.tsx
+++ b/lib/ts/recipe/thirdpartyemailpassword/components/themes/signInAndUp/index.tsx
@@ -34,6 +34,7 @@ import { ThemeBase } from "../themeBase";
 
 import { Header } from "./header";
 
+import type { UserContext } from "../../../../../types";
 import type { ThirdPartyEmailPasswordSignInAndUpThemeProps } from "../../../types";
 
 const SignInAndUpTheme: React.FC<ThirdPartyEmailPasswordSignInAndUpThemeProps> = (props) => {
@@ -110,7 +111,7 @@ const SignInAndUpTheme: React.FC<ThirdPartyEmailPasswordSignInAndUpThemeProps> =
 
 export default function SignInAndUpThemeWrapper(
     props: ThirdPartyEmailPasswordSignInAndUpThemeProps & {
-        userContext?: any;
+        userContext?: UserContext;
     }
 ): JSX.Element {
     const hasFont = hasFontDefined(props.config.rootStyle);

--- a/lib/ts/recipe/thirdpartyemailpassword/index.ts
+++ b/lib/ts/recipe/thirdpartyemailpassword/index.ts
@@ -36,6 +36,7 @@ import { RecipeComponentsOverrideContextProvider } from "./componentOverrideCont
 import ThirdPartyEmailPassword from "./recipe";
 import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 
+import type { UserContext } from "../../types";
 import type { StateObject } from "supertokens-web-js/recipe/thirdparty";
 import type { RecipeFunctionOptions } from "supertokens-web-js/recipe/thirdpartyemailpassword";
 import type { User } from "supertokens-web-js/types";
@@ -45,7 +46,7 @@ export default class Wrapper {
         return ThirdPartyEmailPassword.init(config);
     }
 
-    static async signOut(input?: { userContext?: any }): Promise<void> {
+    static async signOut(input?: { userContext?: UserContext }): Promise<void> {
         return ThirdPartyEmailPassword.getInstanceOrThrow().signOut({
             userContext: getNormalisedUserContext(input?.userContext),
         });
@@ -57,7 +58,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK";
@@ -88,7 +89,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK" | "PASSWORD_RESET_NOT_ALLOWED";
@@ -115,7 +116,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK";
@@ -148,7 +149,7 @@ export default class Wrapper {
             value: string;
         }[];
         options?: RecipeFunctionOptions;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | {
               status: "OK";
@@ -179,7 +180,11 @@ export default class Wrapper {
         });
     }
 
-    static async doesEmailExist(input: { email: string; options?: RecipeFunctionOptions; userContext?: any }): Promise<{
+    static async doesEmailExist(input: {
+        email: string;
+        options?: RecipeFunctionOptions;
+        userContext?: UserContext;
+    }): Promise<{
         status: "OK";
         doesExist: boolean;
         fetchResponse: Response;
@@ -190,7 +195,7 @@ export default class Wrapper {
         });
     }
 
-    static getResetPasswordTokenFromURL(input?: { userContext?: any }): string {
+    static getResetPasswordTokenFromURL(input?: { userContext?: UserContext }): string {
         return ThirdPartyEmailPassword.getInstanceOrThrow().webJSRecipe.getResetPasswordTokenFromURL({
             ...input,
             userContext: getNormalisedUserContext(input?.userContext),
@@ -199,7 +204,7 @@ export default class Wrapper {
 
     static async redirectToThirdPartyLogin(input: {
         thirdPartyId: string;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<{ status: "OK" | "ERROR" }> {
         const recipeInstance: ThirdPartyEmailPassword = ThirdPartyEmailPassword.getInstanceOrThrow();
 
@@ -217,7 +222,7 @@ export default class Wrapper {
         });
     }
 
-    static async thirdPartySignInAndUp(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<
+    static async thirdPartySignInAndUp(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<
         | {
               status: "OK";
               user: User;
@@ -241,7 +246,7 @@ export default class Wrapper {
     }
 
     static getStateAndOtherInfoFromStorage<CustomStateProperties>(input?: {
-        userContext?: any;
+        userContext?: UserContext;
     }): (StateObject & CustomStateProperties) | undefined {
         return ThirdPartyEmailPassword.getInstanceOrThrow().webJSRecipe.getStateAndOtherInfoFromStorage({
             ...input,
@@ -253,7 +258,7 @@ export default class Wrapper {
         thirdPartyId: string;
         frontendRedirectURI: string;
         redirectURIOnProviderDashboard?: string;
-        userContext?: any;
+        userContext?: UserContext;
         options?: RecipeFunctionOptions;
     }): Promise<string> {
         return ThirdPartyEmailPassword.getInstanceOrThrow().webJSRecipe.getAuthorisationURLWithQueryParamsAndSetState({

--- a/lib/ts/recipe/thirdpartyemailpassword/prebuiltui.tsx
+++ b/lib/ts/recipe/thirdpartyemailpassword/prebuiltui.tsx
@@ -1,7 +1,7 @@
 import NormalisedURLPath from "supertokens-web-js/utils/normalisedURLPath";
 
 import UserContextWrapper from "../../usercontext/userContextWrapper";
-import { isTest, matchRecipeIdUsingQueryParams } from "../../utils";
+import { getNormalisedUserContext, isTest, matchRecipeIdUsingQueryParams } from "../../utils";
 import AuthWidgetWrapper from "../authRecipe/authWidgetWrapper";
 import ResetPasswordUsingTokenTheme from "../emailpassword/components/themes/resetPasswordUsingToken";
 import { EmailPasswordPreBuiltUI } from "../emailpassword/prebuiltui";
@@ -21,7 +21,7 @@ import type {
     PreAndPostAPIHookAction,
 } from "./types";
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { RecipeFeatureComponentMap, FeatureBaseProps } from "../../types";
+import type { RecipeFeatureComponentMap, FeatureBaseProps, UserContext } from "../../types";
 
 export class ThirdPartyEmailPasswordPreBuiltUI extends RecipeRouter {
     static instance?: ThirdPartyEmailPasswordPreBuiltUI;
@@ -56,7 +56,7 @@ export class ThirdPartyEmailPasswordPreBuiltUI extends RecipeRouter {
     }
     static getFeatureComponent(
         componentName: "signinup" | "signinupcallback" | "resetpassword",
-        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }>,
+        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext: UserContext }>,
         useComponentOverrides: () => GenericComponentOverrideMap<any> = useRecipeComponentOverrideContext
     ): JSX.Element {
         return ThirdPartyEmailPasswordPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent(
@@ -101,7 +101,7 @@ export class ThirdPartyEmailPasswordPreBuiltUI extends RecipeRouter {
     };
     getFeatureComponent = (
         componentName: "signinup" | "signinupcallback" | "resetpassword",
-        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }>,
+        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext: UserContext }>,
         useComponentOverrides: () => GenericComponentOverrideMap<any> = useRecipeComponentOverrideContext
     ): JSX.Element => {
         if (componentName === "signinup") {
@@ -162,12 +162,20 @@ export class ThirdPartyEmailPasswordPreBuiltUI extends RecipeRouter {
         return;
     }
 
-    static ThirdPartySignInAndUpCallback = (prop: FeatureBaseProps<{ userContext?: any }>) =>
-        this.getFeatureComponent("signinupcallback", prop);
-    static ResetPasswordUsingToken = (prop: FeatureBaseProps<{ userContext?: any }>) =>
-        this.getFeatureComponent("resetpassword", prop);
-    static SignInAndUp = (prop: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }> = {}) =>
-        this.getFeatureComponent("signinup", prop);
+    static ThirdPartySignInAndUpCallback = (prop: FeatureBaseProps<{ userContext?: UserContext }>) => {
+        const userContext = getNormalisedUserContext(prop.userContext);
+        return this.getFeatureComponent("signinupcallback", { ...prop, userContext });
+    };
+    static ResetPasswordUsingToken = (prop: FeatureBaseProps<{ userContext?: UserContext }>) => {
+        const userContext = getNormalisedUserContext(prop.userContext);
+        return this.getFeatureComponent("resetpassword", { ...prop, userContext });
+    };
+    static SignInAndUp = (
+        prop: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: UserContext }> = {}
+    ) => {
+        const userContext = getNormalisedUserContext(prop.userContext);
+        return this.getFeatureComponent("signinup", { ...prop, userContext });
+    };
     static ThirdPartySignInAndUpCallbackTheme = ThirdPartySignInAndUpCallbackTheme;
     static ResetPasswordUsingTokenTheme = ResetPasswordUsingTokenTheme;
     static SignInAndUpTheme = SignInAndUpTheme;

--- a/lib/ts/recipe/thirdpartypasswordless/index.ts
+++ b/lib/ts/recipe/thirdpartypasswordless/index.ts
@@ -36,6 +36,7 @@ import { RecipeComponentsOverrideContextProvider } from "./componentOverrideCont
 import ThirdPartyPasswordless from "./recipe";
 import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventContext } from "./types";
 
+import type { UserContext } from "../../types";
 import type { StateObject } from "supertokens-web-js/recipe/thirdparty";
 import type { PasswordlessFlowType, RecipeFunctionOptions } from "supertokens-web-js/recipe/thirdpartypasswordless";
 import type { User } from "supertokens-web-js/types";
@@ -45,7 +46,7 @@ export default class Wrapper {
         return ThirdPartyPasswordless.init(config);
     }
 
-    static async signOut(input?: { userContext?: any }): Promise<void> {
+    static async signOut(input?: { userContext?: UserContext }): Promise<void> {
         return ThirdPartyPasswordless.getInstanceOrThrow().signOut({
             userContext: getNormalisedUserContext(input?.userContext),
         });
@@ -53,7 +54,7 @@ export default class Wrapper {
 
     static async redirectToThirdPartyLogin(input: {
         thirdPartyId: string;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<{ status: "OK" | "ERROR" }> {
         const recipeInstance: ThirdPartyPasswordless = ThirdPartyPasswordless.getInstanceOrThrow();
 
@@ -71,7 +72,7 @@ export default class Wrapper {
         });
     }
 
-    static async thirdPartySignInAndUp(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<
+    static async thirdPartySignInAndUp(input?: { userContext?: UserContext; options?: RecipeFunctionOptions }): Promise<
         | {
               status: "OK";
               user: User;
@@ -95,7 +96,7 @@ export default class Wrapper {
     }
 
     static getThirdPartyStateAndOtherInfoFromStorage<CustomStateProperties>(input?: {
-        userContext?: any;
+        userContext?: UserContext;
     }): (StateObject & CustomStateProperties) | undefined {
         return ThirdPartyPasswordless.getInstanceOrThrow().webJSRecipe.getThirdPartyStateAndOtherInfoFromStorage({
             ...input,
@@ -107,7 +108,7 @@ export default class Wrapper {
         thirdPartyId: string;
         frontendRedirectURI: string;
         redirectURIOnProviderDashboard?: string;
-        userContext?: any;
+        userContext?: UserContext;
         options?: RecipeFunctionOptions;
     }): Promise<string> {
         return ThirdPartyPasswordless.getInstanceOrThrow().webJSRecipe.getThirdPartyAuthorisationURLWithQueryParamsAndSetState(
@@ -120,8 +121,8 @@ export default class Wrapper {
 
     static async createPasswordlessCode(
         input:
-            | { email: string; userContext?: any; options?: RecipeFunctionOptions }
-            | { phoneNumber: string; userContext?: any; options?: RecipeFunctionOptions }
+            | { email: string; userContext?: UserContext; options?: RecipeFunctionOptions }
+            | { phoneNumber: string; userContext?: UserContext; options?: RecipeFunctionOptions }
     ): Promise<
         | {
               status: "OK";
@@ -142,7 +143,10 @@ export default class Wrapper {
         });
     }
 
-    static async resendPasswordlessCode(input?: { userContext?: any; options?: RecipeFunctionOptions }): Promise<{
+    static async resendPasswordlessCode(input?: {
+        userContext?: UserContext;
+        options?: RecipeFunctionOptions;
+    }): Promise<{
         status: "OK" | "RESTART_FLOW_ERROR";
         fetchResponse: Response;
     }> {
@@ -156,11 +160,11 @@ export default class Wrapper {
         input?:
             | {
                   userInputCode: string;
-                  userContext?: any;
+                  userContext?: UserContext;
                   options?: RecipeFunctionOptions;
               }
             | {
-                  userContext?: any;
+                  userContext?: UserContext;
                   options?: RecipeFunctionOptions;
               }
     ): Promise<
@@ -185,14 +189,14 @@ export default class Wrapper {
         });
     }
 
-    static getPasswordlessLinkCodeFromURL(input?: { userContext?: any }): string {
+    static getPasswordlessLinkCodeFromURL(input?: { userContext?: UserContext }): string {
         return ThirdPartyPasswordless.getInstanceOrThrow().webJSRecipe.getPasswordlessLinkCodeFromURL({
             ...input,
             userContext: getNormalisedUserContext(input?.userContext),
         });
     }
 
-    static getPasswordlessPreAuthSessionIdFromURL(input?: { userContext?: any }): string {
+    static getPasswordlessPreAuthSessionIdFromURL(input?: { userContext?: UserContext }): string {
         return ThirdPartyPasswordless.getInstanceOrThrow().webJSRecipe.getPasswordlessPreAuthSessionIdFromURL({
             ...input,
             userContext: getNormalisedUserContext(input?.userContext),
@@ -201,7 +205,7 @@ export default class Wrapper {
 
     static async doesPasswordlessUserEmailExist(input: {
         email: string;
-        userContext?: any;
+        userContext?: UserContext;
         options?: RecipeFunctionOptions;
     }): Promise<{
         status: "OK";
@@ -216,7 +220,7 @@ export default class Wrapper {
 
     static async doesPasswordlessUserPhoneNumberExist(input: {
         phoneNumber: string;
-        userContext?: any;
+        userContext?: UserContext;
         options?: RecipeFunctionOptions;
     }): Promise<{
         status: "OK";
@@ -230,7 +234,7 @@ export default class Wrapper {
     }
 
     static async getPasswordlessLoginAttemptInfo<CustomLoginAttemptInfoProperties>(input?: {
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<
         | undefined
         | ({
@@ -251,7 +255,7 @@ export default class Wrapper {
             preAuthSessionId: string;
             flowType: PasswordlessFlowType;
         } & CustomStateProperties;
-        userContext?: any;
+        userContext?: UserContext;
     }): Promise<void> {
         return ThirdPartyPasswordless.getInstanceOrThrow().webJSRecipe.setPasswordlessLoginAttemptInfo({
             ...input,
@@ -259,7 +263,7 @@ export default class Wrapper {
         });
     }
 
-    static async clearPasswordlessLoginAttemptInfo(input?: { userContext?: any }): Promise<void> {
+    static async clearPasswordlessLoginAttemptInfo(input?: { userContext?: UserContext }): Promise<void> {
         return ThirdPartyPasswordless.getInstanceOrThrow().webJSRecipe.clearPasswordlessLoginAttemptInfo({
             ...input,
             userContext: getNormalisedUserContext(input?.userContext),

--- a/lib/ts/recipe/thirdpartypasswordless/prebuiltui.tsx
+++ b/lib/ts/recipe/thirdpartypasswordless/prebuiltui.tsx
@@ -1,7 +1,7 @@
 import NormalisedURLPath from "supertokens-web-js/utils/normalisedURLPath";
 
 import UserContextWrapper from "../../usercontext/userContextWrapper";
-import { isTest, matchRecipeIdUsingQueryParams } from "../../utils";
+import { getNormalisedUserContext, isTest, matchRecipeIdUsingQueryParams } from "../../utils";
 import AuthWidgetWrapper from "../authRecipe/authWidgetWrapper";
 import { PasswordlessPreBuiltUI } from "../passwordless/prebuiltui";
 import { RecipeRouter } from "../recipeRouter";
@@ -19,7 +19,7 @@ import type {
     PreAndPostAPIHookAction,
 } from "./types";
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
-import type { RecipeFeatureComponentMap, FeatureBaseProps } from "../../types";
+import type { RecipeFeatureComponentMap, FeatureBaseProps, UserContext } from "../../types";
 
 export class ThirdPartyPasswordlessPreBuiltUI extends RecipeRouter {
     static instance?: ThirdPartyPasswordlessPreBuiltUI;
@@ -54,7 +54,7 @@ export class ThirdPartyPasswordlessPreBuiltUI extends RecipeRouter {
     }
     static getFeatureComponent(
         componentName: "signInUp" | "linkClickedScreen" | "signinupcallback",
-        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }>,
+        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext: UserContext }>,
         useComponentOverrides: () => GenericComponentOverrideMap<any> = useRecipeComponentOverrideContext
     ): JSX.Element {
         return ThirdPartyPasswordlessPreBuiltUI.getInstanceOrInitAndGetInstance().getFeatureComponent(
@@ -67,7 +67,7 @@ export class ThirdPartyPasswordlessPreBuiltUI extends RecipeRouter {
     // Instance methods
     getFeatureComponent = (
         componentName: "signInUp" | "linkClickedScreen" | "signinupcallback",
-        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }>,
+        props: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext: UserContext }>,
         useComponentOverrides: () => GenericComponentOverrideMap<any> = useRecipeComponentOverrideContext
     ): JSX.Element => {
         if (componentName === "signInUp") {
@@ -169,14 +169,22 @@ export class ThirdPartyPasswordlessPreBuiltUI extends RecipeRouter {
         return;
     }
 
-    static SignInAndUp = (prop: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: any }> = {}) =>
-        this.getFeatureComponent("signInUp", prop);
-    static ThirdPartySignInAndUpCallback = (prop: FeatureBaseProps<{ userContext?: any }>) =>
-        this.getFeatureComponent("signinupcallback", prop);
+    static SignInAndUp = (
+        prop: FeatureBaseProps<{ redirectOnSessionExists?: boolean; userContext?: UserContext }> = {}
+    ) => {
+        const userContext = getNormalisedUserContext(prop.userContext);
+        return this.getFeatureComponent("signInUp", { ...prop, userContext });
+    };
+    static ThirdPartySignInAndUpCallback = (prop: FeatureBaseProps<{ userContext?: UserContext }>) => {
+        const userContext = getNormalisedUserContext(prop.userContext);
+        return this.getFeatureComponent("signinupcallback", { ...prop, userContext });
+    };
 
     static SignInUpTheme = SignInUpTheme;
-    static PasswordlessLinkClicked = (prop: FeatureBaseProps<{ userContext?: any }>) =>
-        this.getFeatureComponent("linkClickedScreen", prop);
+    static PasswordlessLinkClicked = (prop: FeatureBaseProps<{ userContext?: UserContext }>) => {
+        const userContext = getNormalisedUserContext(prop.userContext);
+        return this.getFeatureComponent("linkClickedScreen", { ...prop, userContext });
+    };
 }
 
 const SignInAndUp = ThirdPartyPasswordlessPreBuiltUI.SignInAndUp;

--- a/lib/ts/superTokens.tsx
+++ b/lib/ts/superTokens.tsx
@@ -30,6 +30,7 @@ import {
     appendTrailingSlashToURL,
     getCurrentNormalisedUrlPath,
     getDefaultCookieScope,
+    getNormalisedUserContext,
     getOriginOfPage,
     isTest,
     normaliseCookieScopeOrThrowError,
@@ -42,7 +43,7 @@ import type RecipeModule from "./recipe/recipeModule";
 import type { BaseRecipeModule } from "./recipe/recipeModule/baseRecipeModule";
 import type { NormalisedConfig as NormalisedRecipeModuleConfig } from "./recipe/recipeModule/types";
 import type { TranslationFunc, TranslationStore } from "./translation/translationHelpers";
-import type { Navigate, GetRedirectionURLContext, NormalisedAppInfo, SuperTokensConfig } from "./types";
+import type { Navigate, GetRedirectionURLContext, NormalisedAppInfo, SuperTokensConfig, UserContext } from "./types";
 
 /*
  * Class.
@@ -167,7 +168,7 @@ export default class SuperTokens {
         this.languageTranslations.translationEventSource.emit("TranslationLoaded", store);
     }
 
-    async getRedirectUrl(context: GetRedirectionURLContext, userContext?: any): Promise<string | null> {
+    async getRedirectUrl(context: GetRedirectionURLContext, userContext: UserContext): Promise<string | null> {
         if (this.userGetRedirectionURL) {
             const userRes = await this.userGetRedirectionURL(context, userContext);
             if (userRes !== undefined) {
@@ -195,10 +196,13 @@ export default class SuperTokens {
             queryParams.redirectToPath = getCurrentNormalisedUrlPath().getAsStringDangerous();
         }
 
-        let redirectUrl = await this.getRedirectUrl({
-            action: "TO_AUTH",
-            showSignIn: options.show === "signin",
-        });
+        let redirectUrl = await this.getRedirectUrl(
+            {
+                action: "TO_AUTH",
+                showSignIn: options.show === "signin",
+            },
+            getNormalisedUserContext(undefined)
+        );
 
         if (redirectUrl === null) {
             logDebugMessage("Skipping redirection because the user override returned null");

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -30,7 +30,13 @@ export type GetRedirectionURLContext = {
 };
 
 export type ValidationFailureCallback =
-    | (({ userContext, reason }: { userContext: any; reason: any }) => Promise<string | undefined> | string | undefined)
+    | (({
+          userContext,
+          reason,
+      }: {
+          userContext: UserContext;
+          reason: any;
+      }) => Promise<string | undefined> | string | undefined)
     | undefined;
 
 export type SessionClaimValidator = SessionClaimValidatorWebJS & {
@@ -98,7 +104,10 @@ export type SuperTokensConfig = {
         translationFunc?: TranslationFunc;
     };
     enableDebugLogs?: boolean;
-    getRedirectionURL?: (context: GetRedirectionURLContext, userContext?: any) => Promise<string | undefined | null>;
+    getRedirectionURL?: (
+        context: GetRedirectionURLContext,
+        userContext: UserContext
+    ) => Promise<string | undefined | null>;
 };
 
 export type WebJSRecipeInterface<T> = Omit<T, "default" | "init" | "signOut">;
@@ -358,3 +367,5 @@ export type Navigate =
           goBack: () => void;
       }
     | NavigateFunction;
+
+export type UserContext = Record<string, unknown>;

--- a/lib/ts/usercontext/index.tsx
+++ b/lib/ts/usercontext/index.tsx
@@ -17,15 +17,17 @@ import React, { useState } from "react";
 
 import { getNormalisedUserContext } from "../utils";
 
+import type { UserContext } from "../types";
+
 export const UserContextContext = React.createContext<any>(undefined);
 
-export const useUserContext = (): any => {
+export const useUserContext = (): UserContext => {
     return React.useContext(UserContextContext);
 };
 
 export const UserContextProvider: React.FC<{
     children: React.ReactNode;
-    userContext?: any;
+    userContext?: UserContext;
 }> = ({ children, userContext }) => {
     const [currentUserContext] = useState(getNormalisedUserContext(userContext));
 

--- a/lib/ts/usercontext/userContextWrapper.tsx
+++ b/lib/ts/usercontext/userContextWrapper.tsx
@@ -14,9 +14,14 @@
  */
 import React from "react";
 
+import type { UserContext } from "../types";
+
 import { UserContextContext, UserContextProvider } from ".";
 
-export default function UserContextWrapper(props: { children: React.ReactNode; userContext?: any }): JSX.Element {
+export default function UserContextWrapper(props: {
+    children: React.ReactNode;
+    userContext?: UserContext;
+}): JSX.Element {
     /**
      * If we receive a userContext as a props we should assume that the user
      * is either trying to use a theme component as standalone or that they

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -22,7 +22,14 @@ import { WindowHandlerReference } from "supertokens-web-js/utils/windowHandler";
 import { DEFAULT_API_BASE_PATH, DEFAULT_WEBSITE_BASE_PATH, RECIPE_ID_QUERY_PARAM } from "./constants";
 
 import type { FormFieldError } from "./recipe/emailpassword/types";
-import type { APIFormField, AppInfoUserInput, Navigate, NormalisedAppInfo, NormalisedFormField } from "./types";
+import type {
+    APIFormField,
+    AppInfoUserInput,
+    Navigate,
+    NormalisedAppInfo,
+    NormalisedFormField,
+    UserContext,
+} from "./types";
 
 /*
  * getRecipeIdFromPath
@@ -389,7 +396,7 @@ export async function setFrontendCookie(
     }
 }
 
-export function getNormalisedUserContext(userContext?: any): any {
+export function getNormalisedUserContext(userContext?: UserContext): UserContext {
     return userContext === undefined ? {} : userContext;
 }
 


### PR DESCRIPTION
## Summary of change

This PR - 

- Updates type of `userContext` from `any` to `Record<string, unknown>`
- Make `userContext` required in internal functions wherever possible
-  Uses `getNormalisedUserContext` to populate `userContext` wherever it was not available/passed
- Add `isNewPrimaryUser` boolean in GetRedirectionURLContext


## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
