### PR TITLE
fix: breaking e2e tests due to removal of success screen

### DIFF
--- a/test/end-to-end/passwordless.test.js
+++ b/test/end-to-end/passwordless.test.js
@@ -1632,8 +1632,6 @@ export function getPasswordlessTestCases({ authRecipe, logId, generalErrorRecipe
                 await anotherTab.goto(device.codes[0].urlWithLinkCode);
                 await anotherTab.waitForSelector(".sessionInfo-user-id");
 
-                await waitForText(page, "[data-supertokens~=headerTitle]", "Success!");
-
                 await page.reload({ waitUntil: ["networkidle0"] });
 
                 await page.waitForSelector(".sessionInfo-user-id");
@@ -1768,8 +1766,6 @@ export function getPasswordlessTestCases({ authRecipe, logId, generalErrorRecipe
                 await waitForSTElement(anotherTab, "[data-supertokens~=input][name=userInputCode]");
                 await setInputValues(anotherTab, [{ name: "userInputCode", value: device.codes[0].userInputCode }]);
                 await submitForm(anotherTab);
-
-                await waitForText(page, "[data-supertokens~=headerTitle]", "Success!");
 
                 await page.reload({ waitUntil: ["networkidle0"] });
 


### PR DESCRIPTION
## Summary of change

This PR fixes e2e tests that broke due to removal of success screen in #766 

## Test Plan

Tested the breaking e2e tests locally. 

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
