### PR TITLE
fix: preserve query params when redirectBack is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.36.1] - 2023-12-20
+
+### Fixes
+
+-   Previously, when calling `redirectToAuth` with the `redirectBack` option, query parameters were stripped when redirecting back to the previous page after authentication. This issue has been fixed, and now query parameters are preserved as intended.
+
 ## [0.36.0] - 2023-12-07
 
 ### Changes

--- a/lib/build/genericComponentOverrideContext.js
+++ b/lib/build/genericComponentOverrideContext.js
@@ -265,7 +265,7 @@ var SSR_ERROR =
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var package_version = "0.36.0";
+var package_version = "0.36.1";
 
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -356,7 +356,17 @@ function getRedirectToPathFromURL() {
         try {
             var normalisedURLPath = new NormalisedURLPath__default.default(param).getAsStringDangerous();
             var pathQueryParams = param.split("?")[1] !== undefined ? "?".concat(param.split("?")[1]) : "";
-            return normalisedURLPath + pathQueryParams;
+            var pathWithQueryParams = normalisedURLPath + pathQueryParams;
+            // Ensure a leading "/" if `normalisedUrlPath` is empty but `pathWithQueryParams` is not to ensure proper redirection.
+            // Example: "?test=1" will not redirect the user to `/?test=1` if we don't add a leading "/".
+            if (
+                normalisedURLPath.length === 0 &&
+                pathWithQueryParams.length > 0 &&
+                !pathWithQueryParams.startsWith("/")
+            ) {
+                return "/" + pathWithQueryParams;
+            }
+            return pathWithQueryParams;
         } catch (_a) {
             return undefined;
         }
@@ -472,6 +482,13 @@ function validateForm(inputs, configFormFields) {
 function getCurrentNormalisedUrlPath() {
     return new NormalisedURLPath__default.default(
         windowHandler.WindowHandlerReference.getReferenceOrThrow().windowHandler.location.getPathName()
+    );
+}
+function getCurrentNormalisedUrlPathWithQueryParams() {
+    var normalisedUrlPath = getCurrentNormalisedUrlPath().getAsStringDangerous();
+    return (
+        normalisedUrlPath +
+        windowHandler.WindowHandlerReference.getReferenceOrThrow().windowHandler.location.getSearch()
     );
 }
 function appendQueryParamsToURL(stringUrl, queryParams) {
@@ -1169,7 +1186,7 @@ var SuperTokens = /** @class */ (function () {
                                 queryParams.show = options.show;
                             }
                             if (options.redirectBack === true) {
-                                queryParams.redirectToPath = getCurrentNormalisedUrlPath().getAsStringDangerous();
+                                queryParams.redirectToPath = getCurrentNormalisedUrlPathWithQueryParams();
                             }
                             return [
                                 4 /*yield*/,

--- a/lib/build/utils.d.ts
+++ b/lib/build/utils.d.ts
@@ -22,6 +22,7 @@ export declare function validateForm(
     configFormFields: NormalisedFormField[]
 ): Promise<FormFieldError[]>;
 export declare function getCurrentNormalisedUrlPath(): NormalisedURLPath;
+export declare function getCurrentNormalisedUrlPathWithQueryParams(): string;
 export declare function appendQueryParamsToURL(stringUrl: string, queryParams?: Record<string, string>): string;
 export declare function appendTrailingSlashToURL(stringUrl: string): string;
 export declare function matchRecipeIdUsingQueryParams(recipeId: string): () => boolean;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.36.0";
+export declare const package_version = "0.36.1";

--- a/lib/ts/superTokens.tsx
+++ b/lib/ts/superTokens.tsx
@@ -28,7 +28,7 @@ import { saveCurrentLanguage, TranslationController } from "./translation/transl
 import {
     appendQueryParamsToURL,
     appendTrailingSlashToURL,
-    getCurrentNormalisedUrlPath,
+    getCurrentNormalisedUrlPathWithQueryParams,
     getDefaultCookieScope,
     getOriginOfPage,
     isTest,
@@ -193,7 +193,7 @@ export default class SuperTokens {
             queryParams.show = options.show;
         }
         if (options.redirectBack === true) {
-            queryParams.redirectToPath = getCurrentNormalisedUrlPath().getAsStringDangerous();
+            queryParams.redirectToPath = getCurrentNormalisedUrlPathWithQueryParams();
         }
 
         let redirectUrl = await this.getRedirectUrl(

--- a/lib/ts/utils.ts
+++ b/lib/ts/utils.ts
@@ -80,7 +80,18 @@ export function getRedirectToPathFromURL(): string | undefined {
         try {
             const normalisedURLPath = new NormalisedURLPath(param).getAsStringDangerous();
             const pathQueryParams = param.split("?")[1] !== undefined ? `?${param.split("?")[1]}` : "";
-            return normalisedURLPath + pathQueryParams;
+            const pathWithQueryParams = normalisedURLPath + pathQueryParams;
+
+            // Ensure a leading "/" if `normalisedUrlPath` is empty but `pathWithQueryParams` is not to ensure proper redirection.
+            // Example: "?test=1" will not redirect the user to `/?test=1` if we don't add a leading "/".
+            if (
+                normalisedURLPath.length === 0 &&
+                pathWithQueryParams.length > 0 &&
+                !pathWithQueryParams.startsWith("/")
+            ) {
+                return "/" + pathWithQueryParams;
+            }
+            return pathWithQueryParams;
         } catch {
             return undefined;
         }
@@ -187,6 +198,11 @@ export async function validateForm(
  */
 export function getCurrentNormalisedUrlPath(): NormalisedURLPath {
     return new NormalisedURLPath(WindowHandlerReference.getReferenceOrThrow().windowHandler.location.getPathName());
+}
+
+export function getCurrentNormalisedUrlPathWithQueryParams(): string {
+    const normalisedUrlPath = getCurrentNormalisedUrlPath().getAsStringDangerous();
+    return normalisedUrlPath + WindowHandlerReference.getReferenceOrThrow().windowHandler.location.getSearch();
 }
 
 export function appendQueryParamsToURL(stringUrl: string, queryParams?: Record<string, string>): string {

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.36.0";
+export const package_version = "0.36.1";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.36.0",
+    "version": "0.36.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.36.0",
+            "version": "0.36.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.36.0",
+    "version": "0.36.1",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {
@@ -105,6 +105,7 @@
         "build": "rm -rf lib/build && npx rollup -c",
         "watch": "npx rollup -cw",
         "watch-mac": "chokidar lib/ts/* -c 'npx rollup -c'",
+        "watch-mac-2": "chokidar lib/ts/* -c 'npx rollup -c && cp -r lib recipe ui index.d.ts index.js package.json rollup.config.mjs webJsInterfaceSupported.json ../../supertokens-demo/frontend/node_modules/supertokens-auth-react/ && rm -rf ../../supertokens-demo/frontend/node_modules/.cache'",
         "pretty": "npx pretty-quick .",
         "build-pretty": "npm run build && npm run pretty && npm run pretty",
         "lint": "node other/checkTranslationKeys.js && cd lib && eslint ./ts --ext .ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
         "build": "rm -rf lib/build && npx rollup -c",
         "watch": "npx rollup -cw",
         "watch-mac": "chokidar lib/ts/* -c 'npx rollup -c'",
-        "watch-mac-2": "chokidar lib/ts/* -c 'npx rollup -c && cp -r lib recipe ui index.d.ts index.js package.json rollup.config.mjs webJsInterfaceSupported.json ../../supertokens-demo/frontend/node_modules/supertokens-auth-react/ && rm -rf ../../supertokens-demo/frontend/node_modules/.cache'",
         "pretty": "npx pretty-quick .",
         "build-pretty": "npm run build && npm run pretty && npm run pretty",
         "lint": "node other/checkTranslationKeys.js && cd lib && eslint ./ts --ext .ts,.tsx",

--- a/test/end-to-end/emailverification.test.js
+++ b/test/end-to-end/emailverification.test.js
@@ -52,6 +52,8 @@ import {
     setGeneralErrorToLocalStorage,
     isAccountLinkingSupported,
     backendBeforeEach,
+    getDefaultSignUpFieldValues,
+    getTestEmail,
 } from "../helpers";
 
 describe("SuperTokens Email Verification", function () {
@@ -114,14 +116,11 @@ describe("SuperTokens Email Verification", function () {
                 page.waitForNavigation({ waitUntil: "networkidle0" }),
             ]);
             await toggleSignInSignUp(page);
-            const email = `john.doe${Date.now()}@supertokens.io`;
-            await signUp(page, [
-                { name: "email", value: email },
-                { name: "password", value: "Str0ngP@ssw0rd" },
-                { name: "name", value: "John Doe" },
-                { name: "age", value: "20" },
-                { name: "country", value: "" },
-            ]);
+
+            const email = getTestEmail();
+            const { fieldValues, postValues } = getDefaultSignUpFieldValues({ email });
+            await signUp(page, fieldValues, postValues, "emailpassword");
+
             await waitForSTElement(page, "[data-supertokens~='sendVerifyEmailIcon']");
 
             await fetch(`${TEST_APPLICATION_SERVER_BASE_URL}/deleteUser`, {
@@ -169,14 +168,10 @@ describe("SuperTokens Email Verification", function () {
                 page.waitForNavigation({ waitUntil: "networkidle0" }),
             ]);
             await toggleSignInSignUp(page);
-            const email = `john.doe${Date.now()}@supertokens.io`;
-            await signUp(page, [
-                { name: "email", value: email },
-                { name: "password", value: "Str0ngP@ssw0rd" },
-                { name: "name", value: "John Doe" },
-                { name: "age", value: "20" },
-                { name: "country", value: "" },
-            ]);
+            const email = getTestEmail();
+            const { fieldValues, postValues } = getDefaultSignUpFieldValues({ email });
+            await signUp(page, fieldValues, postValues, "emailpassword");
+
             await waitForSTElement(page, "[data-supertokens~='sendVerifyEmailIcon']");
             let pathname = await page.evaluate(() => window.location.pathname);
             assert.deepStrictEqual(pathname, "/auth/verify-email");
@@ -264,24 +259,15 @@ describe("SuperTokens Email Verification", function () {
             ]);
         });
 
-        it("Should redirect to verify email screen on successful sign up when mode is REQUIRED and email is not verified and then post verification should redirect with original redirectPath and newUser", async function () {
+        it("Should redirect to verify email screen on successful sign up when mode is REQUIRED and email is not verified and then post verification should redirect with original redirectPath (w/ leading slash) and newUser", async function () {
             await Promise.all([
-                page.goto(`${TEST_CLIENT_BASE_URL}/auth?redirectToPath=%2Fredirect-here`),
+                page.goto(`${TEST_CLIENT_BASE_URL}/auth?redirectToPath=%2Fredirect-here%3Ffoo%3Dbar`),
                 page.waitForNavigation({ waitUntil: "networkidle0" }),
             ]);
             await toggleSignInSignUp(page);
-            const rid = "emailpassword";
-            await signUp(
-                page,
-                [
-                    { name: "email", value: "john.doe2@supertokens.io" },
-                    { name: "password", value: "Str0ngP@ssw0rd" },
-                    { name: "name", value: "John Doe" },
-                    { name: "age", value: "20" },
-                ],
-                '{"formFields":[{"id":"email","value":"john.doe2@supertokens.io"},{"id":"password","value":"Str0ngP@ssw0rd"},{"id":"name","value":"John Doe"},{"id":"age","value":"20"},{"id":"country","value":""}]}',
-                rid
-            );
+            const { fieldValues, postValues } = getDefaultSignUpFieldValues({ email: "john.doe2@supertokens.io" });
+            await signUp(page, fieldValues, postValues, "emailpassword");
+
             let pathname = await page.evaluate(() => window.location.pathname);
             assert.deepStrictEqual(pathname, "/auth/verify-email");
 
@@ -295,9 +281,36 @@ describe("SuperTokens Email Verification", function () {
             // click on the continue button
             await Promise.all([submitForm(page), page.waitForNavigation({ waitUntil: "networkidle0" })]);
 
-            // check that we are in /redirect-here
-            pathname = await page.evaluate(() => window.location.pathname);
-            assert.deepStrictEqual(pathname, "/redirect-here");
+            // check that we are in /redirect-here?foo=bar
+            const urlWithQP = await page.evaluate(() => window.location.pathname + window.location.search);
+            assert.deepStrictEqual(urlWithQP, "/redirect-here?foo=bar");
+        });
+
+        it("Should redirect to verify email screen on successful sign up when mode is REQUIRED and email is not verified and then post verification should redirect with original redirectPath (w/o leading slash) and newUser", async function () {
+            await Promise.all([
+                page.goto(`${TEST_CLIENT_BASE_URL}/auth?redirectToPath=%3Ffoo%3Dbar`),
+                page.waitForNavigation({ waitUntil: "networkidle0" }),
+            ]);
+            await toggleSignInSignUp(page);
+            const { fieldValues, postValues } = getDefaultSignUpFieldValues({ email: getTestEmail() });
+            await signUp(page, fieldValues, postValues, "emailpassword");
+
+            let pathname = await page.evaluate(() => window.location.pathname);
+            assert.deepStrictEqual(pathname, "/auth/verify-email");
+
+            // we wait for email to be created
+            await new Promise((r) => setTimeout(r, 1000));
+
+            // we fetch the email verification link and go to that
+            const latestURLWithToken = await getLatestURLWithToken();
+            await Promise.all([page.waitForNavigation({ waitUntil: "networkidle0" }), page.goto(latestURLWithToken)]);
+
+            // click on the continue button
+            await Promise.all([submitForm(page), page.waitForNavigation({ waitUntil: "networkidle0" })]);
+
+            // check that we are in /?foo=bar
+            const urlWithQP = await page.evaluate(() => window.location.pathname + window.location.search);
+            assert.deepStrictEqual(urlWithQP, "/?foo=bar");
         });
 
         it("Should redirect to verify email screen on successful sign in when mode is REQUIRED and email is not verified", async function () {
@@ -451,17 +464,8 @@ describe("SuperTokens Email Verification", function () {
 
         it('Should show "Email Verification successful" screen when token is valid with an active session', async function () {
             await toggleSignInSignUp(page);
-            await signUp(
-                page,
-                [
-                    { name: "email", value: "john.doe3@supertokens.io" },
-                    { name: "password", value: "Str0ngP@ssw0rd" },
-                    { name: "name", value: "John Doe" },
-                    { name: "age", value: "20" },
-                ],
-                '{"formFields":[{"id":"email","value":"john.doe3@supertokens.io"},{"id":"password","value":"Str0ngP@ssw0rd"},{"id":"name","value":"John Doe"},{"id":"age","value":"20"},{"id":"country","value":""}]}',
-                "emailpassword"
-            );
+            const { fieldValues, postValues } = getDefaultSignUpFieldValues({ email: "john.doe3@supertokens.io" });
+            await signUp(page, fieldValues, postValues, "emailpassword");
 
             const latestURLWithToken = await getLatestURLWithToken();
             await Promise.all([page.waitForNavigation({ waitUntil: "networkidle0" }), page.goto(latestURLWithToken)]);
@@ -518,17 +522,8 @@ describe("SuperTokens Email Verification", function () {
             ]);
             await toggleSignInSignUp(page);
 
-            await signUp(
-                page,
-                [
-                    { name: "email", value: "john.doe4@supertokens.io" },
-                    { name: "password", value: "Str0ngP@ssw0rd" },
-                    { name: "name", value: "John Doe" },
-                    { name: "age", value: "20" },
-                ],
-                '{"formFields":[{"id":"email","value":"john.doe4@supertokens.io"},{"id":"password","value":"Str0ngP@ssw0rd"},{"id":"name","value":"John Doe"},{"id":"age","value":"20"},{"id":"country","value":""}]}',
-                "emailpassword"
-            );
+            const { fieldValues, postValues } = getDefaultSignUpFieldValues({ email: "john.doe4@supertokens.io" });
+            await signUp(page, fieldValues, postValues, "emailpassword");
 
             const latestURLWithToken = await getLatestURLWithToken();
             await Promise.all([
@@ -708,17 +703,8 @@ describe("SuperTokens Email Verification general errors", function () {
 
         it('Should show "General Error" when API returns "GENERAL_ERROR"', async function () {
             await toggleSignInSignUp(page);
-            await signUp(
-                page,
-                [
-                    { name: "email", value: "john.doe3@supertokens.io" },
-                    { name: "password", value: "Str0ngP@ssw0rd" },
-                    { name: "name", value: "John Doe" },
-                    { name: "age", value: "20" },
-                ],
-                '{"formFields":[{"id":"email","value":"john.doe3@supertokens.io"},{"id":"password","value":"Str0ngP@ssw0rd"},{"id":"name","value":"John Doe"},{"id":"age","value":"20"},{"id":"country","value":""}]}',
-                "emailpassword"
-            );
+            const { fieldValues, postValues } = getDefaultSignUpFieldValues({ email: "john.doe3@supertokens.io" });
+            await signUp(page, fieldValues, postValues, "emailpassword");
 
             const latestURLWithToken = await getLatestURLWithToken();
             await page.goto(latestURLWithToken);
@@ -903,18 +889,8 @@ describe("Email verification signOut errors", function () {
         await toggleSignInSignUp(page);
         await page.evaluate(() => localStorage.setItem("SHOW_GENERAL_ERROR", "SESSION SIGN_OUT"));
 
-        const rid = "emailpassword";
-        await signUp(
-            page,
-            [
-                { name: "email", value: "john.doe2@supertokens.io" },
-                { name: "password", value: "Str0ngP@ssw0rd" },
-                { name: "name", value: "John Doe" },
-                { name: "age", value: "20" },
-            ],
-            '{"formFields":[{"id":"email","value":"john.doe2@supertokens.io"},{"id":"password","value":"Str0ngP@ssw0rd"},{"id":"name","value":"John Doe"},{"id":"age","value":"20"},{"id":"country","value":""}]}',
-            rid
-        );
+        const { fieldValues, postValues } = getDefaultSignUpFieldValues({ email: "john.doe2@supertokens.io" });
+        await signUp(page, fieldValues, postValues, "emailpassword");
 
         let pathname = await page.evaluate(() => window.location.pathname);
         assert.deepStrictEqual(pathname, "/auth/verify-email");

--- a/test/end-to-end/signin.test.js
+++ b/test/end-to-end/signin.test.js
@@ -547,7 +547,7 @@ describe("SuperTokens SignIn", function () {
             );
         });
 
-        it("Successful emailPassword Sign In with redirect to keeping query params", async function () {
+        it("Successful emailPassword Sign In with redirectToPath (w/ leading slash) keeping query params", async function () {
             await Promise.all([
                 page.goto(`${TEST_CLIENT_BASE_URL}/auth?redirectToPath=%2Fredirect-here%3Ffoo%3Dbar`),
                 page.waitForNavigation({ waitUntil: "networkidle0" }),
@@ -566,6 +566,27 @@ describe("SuperTokens SignIn", function () {
             ]);
             const { pathname, search } = await page.evaluate(() => window.location);
             assert.deepStrictEqual(pathname + search, "/redirect-here?foo=bar");
+        });
+
+        it("Successful emailPassword Sign In with redirectToPath (w/o leading slash) keeping query params", async function () {
+            await Promise.all([
+                page.goto(`${TEST_CLIENT_BASE_URL}/auth?redirectToPath=%3Ffoo%3Dbar`),
+                page.waitForNavigation({ waitUntil: "networkidle0" }),
+            ]);
+
+            // Set correct values.
+            await setInputValues(page, [
+                { name: "email", value: "john.doe@supertokens.io" },
+                { name: "password", value: "Str0ngP@ssw0rd" },
+            ]);
+
+            // Submit.
+            await Promise.all([
+                submitFormReturnRequestAndResponse(page, SIGN_IN_API),
+                page.waitForNavigation({ waitUntil: "networkidle0" }),
+            ]);
+            const { pathname, search } = await page.evaluate(() => window.location);
+            assert.deepStrictEqual(pathname + search, "/?foo=bar");
         });
 
         describe("Successful Sign In with redirect to, with EmailPasswordAuth", async function () {

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -134,10 +134,18 @@ describe("SuperTokens SignUp", function () {
             await page.evaluate(() => window.SuperTokens.redirectToAuth());
             await page.waitForNavigation({ waitUntil: "networkidle0" });
             let text = await getAuthPageHeaderText(page);
-            let { pathname: pathAfterRedirectToAuth } = await page.evaluate(() => window.location);
+            let { pathname: pathAfterRedirectToAuth, href: hrefAfterRedirectToAuth } = await page.evaluate(
+                () => window.location
+            );
+
+            const url = new URL(hrefAfterRedirectToAuth);
+            const redirectToPath = url.searchParams.get("redirectToPath");
+
             assert.equal(pathAfterRedirectToAuth, "/auth/");
             // Only the EmailPassword recipe has this header on the sign in page
             assert.deepStrictEqual(text, "Sign In");
+            // Test that redirecToPath contains query params
+            assert.equal(redirectToPath, "?authRecipe=both");
         });
     });
 

--- a/test/end-to-end/signup.test.js
+++ b/test/end-to-end/signup.test.js
@@ -42,6 +42,7 @@ import {
     setSelectDropdownValue,
     getInputField,
     isReact16,
+    getDefaultSignUpFieldValues,
 } from "../helpers";
 
 import {
@@ -126,12 +127,12 @@ describe("SuperTokens SignUp", function () {
             assert.deepStrictEqual(text, "Sign Up");
         });
 
-        it("should redirect to sign in w/ first auth recipe", async function () {
+        it("should redirect to sign in w/ first auth recipe and set redirectToPath", async function () {
             await Promise.all([
                 page.goto(`${TEST_CLIENT_BASE_URL}?authRecipe=both`),
                 page.waitForNavigation({ waitUntil: "networkidle0" }),
             ]);
-            await page.evaluate(() => window.SuperTokens.redirectToAuth());
+            await page.evaluate(() => window.SuperTokens.redirectToAuth({ redirectBack: true }));
             await page.waitForNavigation({ waitUntil: "networkidle0" });
             let text = await getAuthPageHeaderText(page);
             let { pathname: pathAfterRedirectToAuth, href: hrefAfterRedirectToAuth } = await page.evaluate(
@@ -146,6 +147,28 @@ describe("SuperTokens SignUp", function () {
             assert.deepStrictEqual(text, "Sign In");
             // Test that redirecToPath contains query params
             assert.equal(redirectToPath, "?authRecipe=both");
+        });
+
+        it("should redirect to sign in w/ first auth recipe without setting redirectToPath", async function () {
+            await Promise.all([
+                page.goto(`${TEST_CLIENT_BASE_URL}?authRecipe=both`),
+                page.waitForNavigation({ waitUntil: "networkidle0" }),
+            ]);
+            await page.evaluate(() => window.SuperTokens.redirectToAuth({ redirectBack: false }));
+            await page.waitForNavigation({ waitUntil: "networkidle0" });
+            let text = await getAuthPageHeaderText(page);
+            let { pathname: pathAfterRedirectToAuth, href: hrefAfterRedirectToAuth } = await page.evaluate(
+                () => window.location
+            );
+
+            const url = new URL(hrefAfterRedirectToAuth);
+            const redirectToPath = url.searchParams.get("redirectToPath");
+
+            assert.equal(pathAfterRedirectToAuth, "/auth/");
+            // Only the EmailPassword recipe has this header on the sign in page
+            assert.deepStrictEqual(text, "Sign In");
+            // Test that redirecToPath is null
+            assert.equal(redirectToPath, null);
         });
     });
 
@@ -294,23 +317,34 @@ describe("SuperTokens SignUp", function () {
             ]);
         });
 
-        it("Successful signup with query params kept", async function () {
+        it("Successful signup with redirectToPath (w/ leading slash) keeping query params", async function () {
             await Promise.all([
                 page.goto(`${TEST_CLIENT_BASE_URL}/auth?redirectToPath=%2Fredirect-here%3Ffoo%3Dbar`),
                 page.waitForNavigation({ waitUntil: "networkidle0" }),
             ]);
             await toggleSignInSignUp(page);
-            await setInputValues(page, [
-                { name: "email", value: "jack.doe@supertokens.io" },
-                { name: "password", value: "Str0ngP@ssw0rd" },
-                { name: "name", value: "John Doe" },
-                { name: "age", value: "20" },
-            ]);
+            const { fieldValues } = getDefaultSignUpFieldValues({ email: "jack.doe@supertokens.io" });
+            await setInputValues(page, fieldValues);
 
             await submitForm(page);
             await page.waitForNavigation({ waitUntil: "networkidle0" });
             let { pathname, search } = await page.evaluate(() => window.location);
             assert.deepStrictEqual(pathname + search, "/redirect-here?foo=bar");
+        });
+
+        it("Successful signup with redirectToPath (w/ leading slash) keeping query params", async function () {
+            await Promise.all([
+                page.goto(`${TEST_CLIENT_BASE_URL}/auth?redirectToPath=%3Ffoo%3Dbar`),
+                page.waitForNavigation({ waitUntil: "networkidle0" }),
+            ]);
+            await toggleSignInSignUp(page);
+            const { fieldValues } = getDefaultSignUpFieldValues({ email: "jack.doe2@supertokens.io" });
+            await setInputValues(page, fieldValues);
+
+            await submitForm(page);
+            await page.waitForNavigation({ waitUntil: "networkidle0" });
+            let { pathname, search } = await page.evaluate(() => window.location);
+            assert.deepStrictEqual(pathname + search, "/?foo=bar");
         });
 
         it("should show error message on sign up with duplicate email", async function () {

--- a/test/end-to-end/thirdparty.test.js
+++ b/test/end-to-end/thirdparty.test.js
@@ -136,7 +136,7 @@ export function getThirdPartyTestCases({ authRecipe, rid, logId, signInUpPageLoa
             ]);
         });
 
-        it("Successful sign in with Auth0 with query params kept", async function () {
+        it("Successful sign in with Auth0 with redirectToPath (w/ leading slash) keeping query params", async function () {
             await Promise.all([
                 page.goto(`${TEST_CLIENT_BASE_URL}/auth?redirectToPath=%2Fredirect-here%3Ffoo%3Dbar`),
                 page.waitForNavigation({ waitUntil: "networkidle0" }),
@@ -149,6 +149,21 @@ export function getThirdPartyTestCases({ authRecipe, rid, logId, signInUpPageLoa
             ]);
             const { pathname, search } = await page.evaluate(() => window.location);
             assert.deepStrictEqual(pathname + search, "/redirect-here?foo=bar");
+        });
+
+        it("Successful sign in with Auth0 with redirectToPath (w/o leading slash) keeping query params", async function () {
+            await Promise.all([
+                page.goto(`${TEST_CLIENT_BASE_URL}/auth?redirectToPath=%3Ffoo%3Dbar`),
+                page.waitForNavigation({ waitUntil: "networkidle0" }),
+            ]);
+            await assertProviders(page);
+            await clickOnProviderButton(page, "Auth0");
+            await Promise.all([
+                loginWithAuth0(page),
+                page.waitForResponse((response) => response.url() === SIGN_IN_UP_API && response.status() === 200),
+            ]);
+            const { pathname, search } = await page.evaluate(() => window.location);
+            assert.deepStrictEqual(pathname + search, "/?foo=bar");
         });
 
         it("Successful signin with Auth0 and email verification", async function () {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -600,6 +600,24 @@ export async function defaultSignUp(page, rid = "emailpassword") {
         rid
     );
 }
+
+export function getDefaultSignUpFieldValues({
+    name = "John Doe",
+    email = "john.doe@supertokens.io",
+    password = "Str0ngP@ssw0rd",
+    age = "20",
+} = {}) {
+    const fieldValues = [
+        { name: "email", value: email },
+        { name: "password", value: password },
+        { name: "name", value: name },
+        { name: "age", value: age },
+    ];
+    const postValues = `{"formFields":[{"id":"email","value":"${email}"},{"id":"password","value":"${password}"},{"id":"name","value":"${name}"},{"id":"age","value":"${age}"},{"id":"country","value":""}]}`;
+
+    return { fieldValues, postValues };
+}
+
 export async function signUp(page, fields, postValues = undefined, rid = "emailpassword") {
     // Set values.
     await setInputValues(page, fields);
@@ -879,7 +897,7 @@ export async function setGeneralErrorToLocalStorage(recipeName, action, page) {
     });
 }
 
-export async function getTestEmail() {
+export function getTestEmail() {
     return `john.doe+${Date.now()}@supertokens.io`;
 }
 


### PR DESCRIPTION
## Summary of change

Previously, when calling `redirectToAuth` with the `redirectBack` option, query parameters were stripped when redirecting back to the previous page after authentication. This issue has been fixed, and now query parameters are preserved as intended.


## Test Plan

Tested manually extensively. Also, updated an existing test case to verify query params are being preserved. 

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`

