### PR TITLE
feat: add dateProvider config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Exporting the `DateProvider` from supertokens-web-js, that both built-in and custom validators can use instead of `Date.now` to get an estimate of the server clock.
 -   Added the `dateProvider` prop to the configuration that can be used to customize the built-in `DateProvider`.
--   Added `getClockSkewInMillis` as an overrideable function to the Session recipe that estimates the time difference between the backend and the client.
+-   Added `calculateClockSkewInMillis` as an overrideable function to the Session recipe that estimates the time difference between the backend and the client.
 
 ## [0.36.1] - 2023-12-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
--   Add `dateProvider` as a config option aimed at resolving clock skew issues.
+-    Exporting the `DateProvider` from supertokens-web-js, that both built-in and custom validators can use instead of `Date.now` to get an estimate of the server clock.
+-    Added the `dateProvider` prop to the configuration that can be used to customize the built-in `DateProvider`.
+-    Added `getClockSkewInMillis` as an overrideable function to the Session recipe that estimates the time difference between the backend and the client.
 
 ## [0.36.1] - 2023-12-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## [0.36.2] - 2024-01-15
+## [0.37.0] - 2024-01-15
+
+## Breaking Changes
+
+-   The default `DateProvider` implementation relies on `localStorage`. If your environment lacks support for `localStorage`, you must provide custom implementations for either the `DateProvider` or `localStorage`.
 
 ### Changes
 
--    Exporting the `DateProvider` from supertokens-web-js, that both built-in and custom validators can use instead of `Date.now` to get an estimate of the server clock.
--    Added the `dateProvider` prop to the configuration that can be used to customize the built-in `DateProvider`.
--    Added `getClockSkewInMillis` as an overrideable function to the Session recipe that estimates the time difference between the backend and the client.
+-   Exporting the `DateProvider` from supertokens-web-js, that both built-in and custom validators can use instead of `Date.now` to get an estimate of the server clock.
+-   Added the `dateProvider` prop to the configuration that can be used to customize the built-in `DateProvider`.
+-   Added `getClockSkewInMillis` as an overrideable function to the Session recipe that estimates the time difference between the backend and the client.
 
 ## [0.36.1] - 2023-12-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.36.2] - 2024-01-15
+
+### Changes
+
+-   Add `dateProvider` as a config option aimed at resolving clock skew issues.
+
 ## [0.36.1] - 2023-12-20
 
 ### Fixes

--- a/lib/build/dateProvider/index.d.ts
+++ b/lib/build/dateProvider/index.d.ts
@@ -1,0 +1,1 @@
+export { DateProviderReference } from "supertokens-web-js/utils/dateProvider";

--- a/lib/build/dateProvider/types.d.ts
+++ b/lib/build/dateProvider/types.d.ts
@@ -1,0 +1,1 @@
+export { DateProviderInput, DateProviderInterface } from "supertokens-web-js/utils/dateProvider/types";

--- a/lib/build/genericComponentOverrideContext.js
+++ b/lib/build/genericComponentOverrideContext.js
@@ -265,7 +265,7 @@ var SSR_ERROR =
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var package_version = "0.36.2";
+var package_version = "0.37.0";
 
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *

--- a/lib/build/genericComponentOverrideContext.js
+++ b/lib/build/genericComponentOverrideContext.js
@@ -265,7 +265,7 @@ var SSR_ERROR =
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var package_version = "0.36.1";
+var package_version = "0.36.2";
 
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *

--- a/lib/build/types.d.ts
+++ b/lib/build/types.d.ts
@@ -1,3 +1,4 @@
+import type { DateProviderInput } from "./dateProvider/types";
 import type { BaseRecipeModule } from "./recipe/recipeModule/baseRecipeModule";
 import type { NormalisedConfig as NormalisedRecipeModuleConfig } from "./recipe/recipeModule/types";
 import type { TranslationFunc, TranslationStore } from "./translation/translationHelpers";
@@ -38,6 +39,7 @@ export declare type SuperTokensConfig = {
     }[];
     cookieHandler?: CookieHandlerInput;
     windowHandler?: WindowHandlerInput;
+    dateProvider?: DateProviderInput;
     usesDynamicLoginMethods?: boolean;
     languageTranslations?: {
         defaultLanguage?: string;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.36.1";
+export declare const package_version = "0.36.2";

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.36.2";
+export declare const package_version = "0.37.0";

--- a/lib/ts/dateProvider/index.ts
+++ b/lib/ts/dateProvider/index.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+/* Copyright (c) 2024, VRAI Labs and/or its affiliates. All rights reserved.
  *
  * This software is licensed under the Apache License, Version 2.0 (the
  * "License") as published by the Apache Software Foundation.
@@ -12,4 +12,5 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.36.2";
+
+export { DateProviderReference } from "supertokens-web-js/utils/dateProvider";

--- a/lib/ts/dateProvider/types.ts
+++ b/lib/ts/dateProvider/types.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+/* Copyright (c) 2024, VRAI Labs and/or its affiliates. All rights reserved.
  *
  * This software is licensed under the Apache License, Version 2.0 (the
  * "License") as published by the Apache Software Foundation.
@@ -12,4 +12,5 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.36.2";
+
+export { DateProviderInput, DateProviderInterface } from "supertokens-web-js/utils/dateProvider/types";

--- a/lib/ts/types.ts
+++ b/lib/ts/types.ts
@@ -13,6 +13,7 @@
  * under the License.
  */
 
+import type { DateProviderInput } from "./dateProvider/types";
 import type { BaseRecipeModule } from "./recipe/recipeModule/baseRecipeModule";
 import type { NormalisedConfig as NormalisedRecipeModuleConfig } from "./recipe/recipeModule/types";
 import type { TranslationFunc, TranslationStore } from "./translation/translationHelpers";
@@ -71,6 +72,8 @@ export type SuperTokensConfig = {
     cookieHandler?: CookieHandlerInput;
 
     windowHandler?: WindowHandlerInput;
+
+    dateProvider?: DateProviderInput;
 
     usesDynamicLoginMethods?: boolean;
 

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.36.2";
+export const package_version = "0.37.0";

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
             "peerDependencies": {
                 "react": ">=16.8.0",
                 "react-dom": ">=16.8.0",
-                "supertokens-web-js": "^0.8.0"
+                "supertokens-web-js": "^0.9.0"
             }
         },
         "eslint": {
@@ -15907,19 +15907,19 @@
             "integrity": "sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg=="
         },
         "node_modules/supertokens-web-js": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/supertokens-web-js/-/supertokens-web-js-0.8.0.tgz",
-            "integrity": "sha512-kkvuPbdy1I0e7nejVJAhpPJhR5h7EUHdn7Fh1YqfSjZfSJh46J3JU2qWGCgSDVZuD1hSuUKb6skF9CQnltHWrQ==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/supertokens-web-js/-/supertokens-web-js-0.9.0.tgz",
+            "integrity": "sha512-7DucVUWxImrcjckza0oW6tkPfMzScj8V/qiQNZeUT/EfCqIbslNSO8holBHc9Eykc0vG/CC0d9ne5TRhAmRcxg==",
             "peer": true,
             "dependencies": {
                 "supertokens-js-override": "0.0.4",
-                "supertokens-website": "^17.0.3"
+                "supertokens-website": "^18.0.0"
             }
         },
         "node_modules/supertokens-website": {
-            "version": "17.0.4",
-            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-17.0.4.tgz",
-            "integrity": "sha512-ayWhEFvspUe26YhM1bq11ssEpnFCZIsoHZtJwJHgHsoflfMUKdgrzOix/bboI0PWJeNTUphHyZebw0ApctaS1Q==",
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-18.0.0.tgz",
+            "integrity": "sha512-4MQA14JAtFJWMK6p62BJbjY/i3UkvGgecyvdbl2dUetfIGsydTh709Bvwn6puVbUQa9XsmJ8DaVN9mZLTl/Bqw==",
             "peer": true,
             "dependencies": {
                 "browser-tabs-lock": "^1.3.0",
@@ -28931,19 +28931,19 @@
             "integrity": "sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg=="
         },
         "supertokens-web-js": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/supertokens-web-js/-/supertokens-web-js-0.8.0.tgz",
-            "integrity": "sha512-kkvuPbdy1I0e7nejVJAhpPJhR5h7EUHdn7Fh1YqfSjZfSJh46J3JU2qWGCgSDVZuD1hSuUKb6skF9CQnltHWrQ==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/supertokens-web-js/-/supertokens-web-js-0.9.0.tgz",
+            "integrity": "sha512-7DucVUWxImrcjckza0oW6tkPfMzScj8V/qiQNZeUT/EfCqIbslNSO8holBHc9Eykc0vG/CC0d9ne5TRhAmRcxg==",
             "peer": true,
             "requires": {
                 "supertokens-js-override": "0.0.4",
-                "supertokens-website": "^17.0.3"
+                "supertokens-website": "^18.0.0"
             }
         },
         "supertokens-website": {
-            "version": "17.0.4",
-            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-17.0.4.tgz",
-            "integrity": "sha512-ayWhEFvspUe26YhM1bq11ssEpnFCZIsoHZtJwJHgHsoflfMUKdgrzOix/bboI0PWJeNTUphHyZebw0ApctaS1Q==",
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-18.0.0.tgz",
+            "integrity": "sha512-4MQA14JAtFJWMK6p62BJbjY/i3UkvGgecyvdbl2dUetfIGsydTh709Bvwn6puVbUQa9XsmJ8DaVN9mZLTl/Bqw==",
             "peer": true,
             "requires": {
                 "browser-tabs-lock": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.36.2",
+    "version": "0.37.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.36.2",
+            "version": "0.37.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.36.1",
+    "version": "0.36.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.36.1",
+            "version": "0.36.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.36.1",
+    "version": "0.36.2",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {
@@ -109,7 +109,7 @@
         "build-pretty": "npm run build && npm run pretty && npm run pretty",
         "lint": "node other/checkTranslationKeys.js && cd lib && eslint ./ts --ext .ts,.tsx",
         "lint-fix": "cd lib && npx eslint ./ts --ext .ts,.tsx --fix",
-        "prune": "cd lib && ts-prune | grep -vE 'used in module| - default$| - package_version$|getSuperTokensRoutesForReactRouterDom$|supertokens-web-js|supertokens-website' && exit 1 || exit 0",
+        "prune": "cd lib && ts-prune | grep -vE 'used in module| - default$| - package_version$|getSuperTokensRoutesForReactRouterDom$|supertokens-web-js|supertokens-website|dateProvider' && exit 1 || exit 0",
         "pretty-check": "npx pretty-quick --staged --check .",
         "set-up-hooks": "cp hooks/pre-commit.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit",
         "build-docs": "rm -rf ./docs && npx typedoc --out ./docs --tsconfig ./lib/tsconfig.json ./lib/ts/index.ts ./lib/ts/**/index.ts ./lib/ts/**/*/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.36.2",
+    "version": "0.37.0",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
-        "supertokens-web-js": "^0.8.0"
+        "supertokens-web-js": "^0.9.0"
     },
     "scripts": {
         "init": "bash ./init.sh",

--- a/test/unit/dateProvider.test.ts
+++ b/test/unit/dateProvider.test.ts
@@ -1,0 +1,55 @@
+/* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { BooleanClaim } from "../../recipe/session";
+import EmailPassword from "../../recipe/emailpassword";
+import SuperTokens from "../../lib/ts/superTokens";
+import assert from "assert";
+
+describe("Date Provider test", function () {
+    let storageLogs: string[] = [];
+
+    beforeEach(function () {
+        SuperTokens.reset();
+        storageLogs = [];
+    });
+
+    it("should use custom date provider when calling init", async function () {
+        SuperTokens.init({
+            appInfo: {
+                appName: "SuperTokens",
+                websiteDomain: "supertokens.io",
+                apiDomain: "api.supertokens.io",
+            },
+            dateProvider: function (original) {
+                return {
+                    ...original,
+                    now: function () {
+                        storageLogs.push("ST_LOGS DATE_PROVIDER_NOW");
+                        return original.now();
+                    },
+                };
+            },
+            recipeList: [EmailPassword.init()],
+        });
+
+        // Calling the shouldRefresh method on a SessionClaimValidator should call the DateProvider now method
+        const claim = new BooleanClaim({ id: "test-claim", defaultMaxAgeInSeconds: 1000, refresh: async () => {} });
+        const validator = claim.validators.isTrue();
+        await validator.shouldRefresh({ "test-claim": { v: true, t: Date.now() } }, {});
+
+        assert.deepStrictEqual(storageLogs, ["ST_LOGS DATE_PROVIDER_NOW"]);
+    });
+});

--- a/test/unit/dateProvider.test.ts
+++ b/test/unit/dateProvider.test.ts
@@ -46,6 +46,10 @@ describe("Date Provider test", function () {
                         storageLogs.push("ST_LOGS DATE_PROVIDER_GET_THRESHOLD");
                         return 7;
                     },
+                    setThresholdInSeconds() {
+                        storageLogs.push("ST_LOGS DATE_PROVIDER_SET_THRESHOLD");
+                        return;
+                    },
                     now() {
                         storageLogs.push("ST_LOGS DATE_PROVIDER_NOW");
                         return Date.now();

--- a/test/unit/dateProvider.test.ts
+++ b/test/unit/dateProvider.test.ts
@@ -33,12 +33,22 @@ describe("Date Provider test", function () {
                 websiteDomain: "supertokens.io",
                 apiDomain: "api.supertokens.io",
             },
-            dateProvider: function (original) {
+            dateProvider: function () {
                 return {
-                    ...original,
-                    now: function () {
+                    getClientClockSkewInMillis() {
+                        storageLogs.push("ST_LOGS DATE_PROVIDER_GET_CLIENT_CLOCK_SKEW");
+                        return 0;
+                    },
+                    setClientClockSkewInMillis() {
+                        storageLogs.push("ST_LOGS DATE_PROVIDER_SET_CLIENT_CLOCK_SKEW");
+                    },
+                    getThresholdInSeconds() {
+                        storageLogs.push("ST_LOGS DATE_PROVIDER_GET_THRESHOLD");
+                        return 7;
+                    },
+                    now() {
                         storageLogs.push("ST_LOGS DATE_PROVIDER_NOW");
-                        return original.now();
+                        return Date.now();
                     },
                 };
             },
@@ -50,6 +60,6 @@ describe("Date Provider test", function () {
         const validator = claim.validators.isTrue();
         await validator.shouldRefresh({ "test-claim": { v: true, t: Date.now() } }, {});
 
-        assert.deepStrictEqual(storageLogs, ["ST_LOGS DATE_PROVIDER_NOW"]);
+        assert.deepStrictEqual(storageLogs, ["ST_LOGS DATE_PROVIDER_GET_THRESHOLD", "ST_LOGS DATE_PROVIDER_NOW"]);
     });
 });

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -100,6 +100,7 @@ const rid = window.localStorage.getItem("rid") || "emailpassword";
 const recipeList = getRecipeList();
 
 const dateProviderImplementation: DateProviderInterface = {
+    getThresholdInSeconds: () => 0,
     getClientClockSkewInMillis: () => 0,
     setClientClockSkewInMillis: () => {},
     now: () => Date.now(),

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -57,7 +57,8 @@ import {
     PasswordlessLinkClicked as TPPasswordlessPasswordlessLinkClicked,
 } from "../../../recipe/thirdpartypasswordless/prebuiltui";
 import EmailVerification from "../../../recipe/emailverification";
-
+import { DateProviderReference } from "../../../utils/dateProvider";
+import { DateProviderInput, DateProviderInterface } from "../../../utils/dateProvider/types";
 /*
  * This application is used with the purpose of illustrating Supertokens with typescript.
  * It is also used internally for deploy previews, hence a lot of code you will see
@@ -98,6 +99,14 @@ const rid = window.localStorage.getItem("rid") || "emailpassword";
 
 const recipeList = getRecipeList();
 
+const dateProviderImplementation: DateProviderInterface = {
+    getClientClockSkewInMillis: () => 0,
+    setClientClockSkewInMillis: () => {},
+    now: () => Date.now(),
+};
+
+const dateProviderInput: DateProviderInput = () => dateProviderImplementation;
+
 SuperTokens.init({
     appInfo: {
         appName: "SuperTokens Demo App",
@@ -111,6 +120,7 @@ SuperTokens.init({
         return undefined;
     },
     recipeList,
+    dateProvider: dateProviderInput,
 });
 
 function App() {
@@ -338,6 +348,9 @@ function getRecipeList() {
                         },
                         shouldDoInterceptionBasedOnUrl: (...input) => {
                             return oI.shouldDoInterceptionBasedOnUrl(...input);
+                        },
+                        getClockSkewInMillis: (...input) => {
+                            return oI.getClockSkewInMillis(...input);
                         },
                     };
                 },

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -101,6 +101,7 @@ const recipeList = getRecipeList();
 
 const dateProviderImplementation: DateProviderInterface = {
     getThresholdInSeconds: () => 0,
+    setThresholdInSeconds: () => {},
     getClientClockSkewInMillis: () => 0,
     setClientClockSkewInMillis: () => {},
     now: () => Date.now(),
@@ -350,8 +351,8 @@ function getRecipeList() {
                         shouldDoInterceptionBasedOnUrl: (...input) => {
                             return oI.shouldDoInterceptionBasedOnUrl(...input);
                         },
-                        getClockSkewInMillis: (...input) => {
-                            return oI.getClockSkewInMillis(...input);
+                        calculateClockSkewInMillis: (...input) => {
+                            return oI.calculateClockSkewInMillis(...input);
                         },
                     };
                 },

--- a/utils/dateProvider/index.d.ts
+++ b/utils/dateProvider/index.d.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+/* Copyright (c) 2024, VRAI Labs and/or its affiliates. All rights reserved.
  *
  * This software is licensed under the Apache License, Version 2.0 (the
  * "License") as published by the Apache Software Foundation.
@@ -12,4 +12,13 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.36.2";
+export * from "../../lib/build/dateProvider";
+/**
+ * 'export *' does not re-export a default.
+ * import DateProvider from "supertokens-auth-react/utils/dateProvider";
+ * the above import statement won't be possible unless either
+ * - user add "esModuleInterop": true in their tsconfig.json file
+ * - we do the following change:
+ */
+import * as _default from "../../lib/build/dateProvider";
+export default _default;

--- a/utils/dateProvider/index.js
+++ b/utils/dateProvider/index.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+/* Copyright (c) 2024, VRAI Labs and/or its affiliates. All rights reserved.
  *
  * This software is licensed under the Apache License, Version 2.0 (the
  * "License") as published by the Apache Software Foundation.
@@ -12,4 +12,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.36.2";
+"use strict";
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+exports.__esModule = true;
+__export(require("../../lib/build/dateProvider"));

--- a/utils/dateProvider/types.d.ts
+++ b/utils/dateProvider/types.d.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+/* Copyright (c) 2024, VRAI Labs and/or its affiliates. All rights reserved.
  *
  * This software is licensed under the Apache License, Version 2.0 (the
  * "License") as published by the Apache Software Foundation.
@@ -12,4 +12,13 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.36.2";
+export * from "../../lib/build/dateProvider/types";
+/**
+ * 'export *' does not re-export a default.
+ * import DateProvider from "supertokens-auth-react/utils/dateProvider/types";
+ * the above import statement won't be possible unless either
+ * - user add "esModuleInterop": true in their tsconfig.json file
+ * - we do the following change:
+ */
+import * as _default from "../../lib/build/dateProvider/types";
+export default _default;

--- a/utils/dateProvider/types.js
+++ b/utils/dateProvider/types.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+/* Copyright (c) 2024, VRAI Labs and/or its affiliates. All rights reserved.
  *
  * This software is licensed under the Apache License, Version 2.0 (the
  * "License") as published by the Apache Software Foundation.
@@ -12,4 +12,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.36.2";
+"use strict";
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+exports.__esModule = true;
+__export(require("../../lib/build/dateProvider/types"));


### PR DESCRIPTION
## Summary of change

This PR adds `dateProvider` as a config  that is used to fix clock skew issues between server and client.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`

