### PR TITLE
feat: SessionAuth SSR support (initialSessionAuthContext)

### DIFF
--- a/lib/build/index2.js
+++ b/lib/build/index2.js
@@ -853,7 +853,7 @@ var SessionContext = React__default.default.createContext({
 });
 
 var SessionAuth = function (_a) {
-    var _b;
+    var _b, _c;
     var children = _a.children,
         props = genericComponentOverrideContext.__rest(_a, ["children"]);
     var requireAuth = React.useRef(props.requireAuth);
@@ -865,20 +865,20 @@ var SessionAuth = function (_a) {
     }
     // Reusing the parent context was removed because it caused a redirect loop in an edge case
     // because it'd also reuse the invalid claims part until it loaded.
-    var _c = React.useState({ loading: true }),
-        context = _c[0],
-        setContext = _c[1];
+    var _d = React.useState((_b = props.initialSessionAuthContext) !== null && _b !== void 0 ? _b : { loading: true }),
+        context = _d[0],
+        setContext = _d[1];
     var session = React.useRef();
     // We store this here, to prevent the list of called hooks changing even if a navigate hook is added later to SuperTokens.
     var navigateHookRef = React.useRef(
-        (_b = UI.getReactRouterDomWithCustomHistory()) === null || _b === void 0 ? void 0 : _b.useHistoryCustom
+        (_c = UI.getReactRouterDomWithCustomHistory()) === null || _c === void 0 ? void 0 : _c.useHistoryCustom
     );
     var navigate;
     try {
         if (navigateHookRef.current) {
             navigate = navigateHookRef.current();
         }
-    } catch (_d) {
+    } catch (_e) {
         // We catch and ignore errors here, because this is may throw if
         // the app is using react-router-dom but added a session auth outside of the router.
     }
@@ -912,6 +912,7 @@ var SessionAuth = function (_a) {
                             return [
                                 2 /*return*/,
                                 {
+                                    preloaded: false,
                                     loading: false,
                                     doesSessionExist: false,
                                     accessTokenPayload: {},
@@ -952,6 +953,7 @@ var SessionAuth = function (_a) {
                         return [
                             2 /*return*/,
                             {
+                                preloaded: false,
                                 loading: false,
                                 doesSessionExist: false,
                                 accessTokenPayload: {},
@@ -962,6 +964,7 @@ var SessionAuth = function (_a) {
                     case 6:
                         _b.trys.push([6, 9, , 11]);
                         _a = {
+                            preloaded: false,
                             loading: false,
                             doesSessionExist: true,
                             invalidClaims: invalidClaims,
@@ -999,6 +1002,7 @@ var SessionAuth = function (_a) {
                         return [
                             2 /*return*/,
                             {
+                                preloaded: false,
                                 loading: false,
                                 doesSessionExist: false,
                                 accessTokenPayload: {},
@@ -1138,7 +1142,7 @@ var SessionAuth = function (_a) {
                                 setContext(
                                     genericComponentOverrideContext.__assign(
                                         genericComponentOverrideContext.__assign({}, event.sessionContext),
-                                        { loading: false, invalidClaims: invalidClaims }
+                                        { preloaded: false, loading: false, invalidClaims: invalidClaims }
                                     )
                                 );
                                 return [
@@ -1165,6 +1169,7 @@ var SessionAuth = function (_a) {
                                             genericComponentOverrideContext.__assign(
                                                 genericComponentOverrideContext.__assign({}, event.sessionContext),
                                                 {
+                                                    preloaded: false,
                                                     loading: false,
                                                     invalidClaims: invalidClaims,
                                                     accessDeniedValidatorError: failureRedirectInfo.failedClaim,
@@ -1178,7 +1183,7 @@ var SessionAuth = function (_a) {
                                 setContext(
                                     genericComponentOverrideContext.__assign(
                                         genericComponentOverrideContext.__assign({}, event.sessionContext),
-                                        { loading: false, invalidClaims: invalidClaims }
+                                        { preloaded: false, loading: false, invalidClaims: invalidClaims }
                                     )
                                 );
                                 return [2 /*return*/];
@@ -1186,7 +1191,7 @@ var SessionAuth = function (_a) {
                                 setContext(
                                     genericComponentOverrideContext.__assign(
                                         genericComponentOverrideContext.__assign({}, event.sessionContext),
-                                        { loading: false, invalidClaims: [] }
+                                        { preloaded: false, loading: false, invalidClaims: [] }
                                     )
                                 );
                                 return [2 /*return*/];
@@ -1194,7 +1199,7 @@ var SessionAuth = function (_a) {
                                 setContext(
                                     genericComponentOverrideContext.__assign(
                                         genericComponentOverrideContext.__assign({}, event.sessionContext),
-                                        { loading: false, invalidClaims: [] }
+                                        { preloaded: false, loading: false, invalidClaims: [] }
                                     )
                                 );
                                 if (props.onSessionExpired !== undefined) {

--- a/lib/build/index2.js
+++ b/lib/build/index2.js
@@ -912,7 +912,7 @@ var SessionAuth = function (_a) {
                             return [
                                 2 /*return*/,
                                 {
-                                    preloaded: false,
+                                    isContextFromSSR: false,
                                     loading: false,
                                     doesSessionExist: false,
                                     accessTokenPayload: {},
@@ -953,7 +953,7 @@ var SessionAuth = function (_a) {
                         return [
                             2 /*return*/,
                             {
-                                preloaded: false,
+                                isContextFromSSR: false,
                                 loading: false,
                                 doesSessionExist: false,
                                 accessTokenPayload: {},
@@ -964,7 +964,7 @@ var SessionAuth = function (_a) {
                     case 6:
                         _b.trys.push([6, 9, , 11]);
                         _a = {
-                            preloaded: false,
+                            isContextFromSSR: false,
                             loading: false,
                             doesSessionExist: true,
                             invalidClaims: invalidClaims,
@@ -1002,7 +1002,7 @@ var SessionAuth = function (_a) {
                         return [
                             2 /*return*/,
                             {
-                                preloaded: false,
+                                isContextFromSSR: false,
                                 loading: false,
                                 doesSessionExist: false,
                                 accessTokenPayload: {},
@@ -1142,7 +1142,7 @@ var SessionAuth = function (_a) {
                                 setContext(
                                     genericComponentOverrideContext.__assign(
                                         genericComponentOverrideContext.__assign({}, event.sessionContext),
-                                        { preloaded: false, loading: false, invalidClaims: invalidClaims }
+                                        { isContextFromSSR: false, loading: false, invalidClaims: invalidClaims }
                                     )
                                 );
                                 return [
@@ -1169,7 +1169,7 @@ var SessionAuth = function (_a) {
                                             genericComponentOverrideContext.__assign(
                                                 genericComponentOverrideContext.__assign({}, event.sessionContext),
                                                 {
-                                                    preloaded: false,
+                                                    isContextFromSSR: false,
                                                     loading: false,
                                                     invalidClaims: invalidClaims,
                                                     accessDeniedValidatorError: failureRedirectInfo.failedClaim,
@@ -1183,7 +1183,7 @@ var SessionAuth = function (_a) {
                                 setContext(
                                     genericComponentOverrideContext.__assign(
                                         genericComponentOverrideContext.__assign({}, event.sessionContext),
-                                        { preloaded: false, loading: false, invalidClaims: invalidClaims }
+                                        { isContextFromSSR: false, loading: false, invalidClaims: invalidClaims }
                                     )
                                 );
                                 return [2 /*return*/];
@@ -1191,7 +1191,7 @@ var SessionAuth = function (_a) {
                                 setContext(
                                     genericComponentOverrideContext.__assign(
                                         genericComponentOverrideContext.__assign({}, event.sessionContext),
-                                        { preloaded: false, loading: false, invalidClaims: [] }
+                                        { isContextFromSSR: false, loading: false, invalidClaims: [] }
                                     )
                                 );
                                 return [2 /*return*/];
@@ -1199,7 +1199,7 @@ var SessionAuth = function (_a) {
                                 setContext(
                                     genericComponentOverrideContext.__assign(
                                         genericComponentOverrideContext.__assign({}, event.sessionContext),
-                                        { preloaded: false, loading: false, invalidClaims: [] }
+                                        { isContextFromSSR: false, loading: false, invalidClaims: [] }
                                     )
                                 );
                                 if (props.onSessionExpired !== undefined) {

--- a/lib/build/index2.js
+++ b/lib/build/index2.js
@@ -853,7 +853,7 @@ var SessionContext = React__default.default.createContext({
 });
 
 var SessionAuth = function (_a) {
-    var _b, _c;
+    var _b;
     var children = _a.children,
         props = genericComponentOverrideContext.__rest(_a, ["children"]);
     var requireAuth = React.useRef(props.requireAuth);
@@ -863,22 +863,28 @@ var SessionAuth = function (_a) {
             'requireAuth prop should not change. If you are seeing this, it probably means that you are using SessionAuth in multiple routes with different values for requireAuth. To solve this, try adding the "key" prop to all uses of SessionAuth like <SessionAuth key="someUniqueKeyPerRoute" requireAuth={...}>'
         );
     }
+    var initialContext = props.initialSessionAuthContext
+        ? genericComponentOverrideContext.__assign(
+              genericComponentOverrideContext.__assign({}, props.initialSessionAuthContext),
+              { invalidClaims: [] }
+          )
+        : { loading: true };
     // Reusing the parent context was removed because it caused a redirect loop in an edge case
     // because it'd also reuse the invalid claims part until it loaded.
-    var _d = React.useState((_b = props.initialSessionAuthContext) !== null && _b !== void 0 ? _b : { loading: true }),
-        context = _d[0],
-        setContext = _d[1];
+    var _c = React.useState(initialContext),
+        context = _c[0],
+        setContext = _c[1];
     var session = React.useRef();
     // We store this here, to prevent the list of called hooks changing even if a navigate hook is added later to SuperTokens.
     var navigateHookRef = React.useRef(
-        (_c = UI.getReactRouterDomWithCustomHistory()) === null || _c === void 0 ? void 0 : _c.useHistoryCustom
+        (_b = UI.getReactRouterDomWithCustomHistory()) === null || _b === void 0 ? void 0 : _b.useHistoryCustom
     );
     var navigate;
     try {
         if (navigateHookRef.current) {
             navigate = navigateHookRef.current();
         }
-    } catch (_e) {
+    } catch (_d) {
         // We catch and ignore errors here, because this is may throw if
         // the app is using react-router-dom but added a session auth outside of the router.
     }

--- a/lib/build/recipe/session/sessionAuth.d.ts
+++ b/lib/build/recipe/session/sessionAuth.d.ts
@@ -1,8 +1,13 @@
 import React from "react";
+import type { SessionContextType } from "./types";
 import type { Navigate, ReactComponentClass, SessionClaimValidator, UserContext } from "../../types";
 import type { PropsWithChildren } from "react";
 import type { ClaimValidationError } from "supertokens-web-js/recipe/session";
 export declare type SessionAuthProps = {
+    /**
+     * Initial context that is rendered on a server side (SSR).
+     */
+    initialSessionAuthContext?: SessionContextType;
     /**
      * For a detailed explanation please see https://github.com/supertokens/supertokens-auth-react/issues/570
      */

--- a/lib/build/recipe/session/sessionAuth.d.ts
+++ b/lib/build/recipe/session/sessionAuth.d.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import type { SessionContextType } from "./types";
+import type { SSRSessionContextType } from "./types";
 import type { Navigate, ReactComponentClass, SessionClaimValidator, UserContext } from "../../types";
 import type { PropsWithChildren } from "react";
 import type { ClaimValidationError } from "supertokens-web-js/recipe/session";
@@ -7,7 +7,7 @@ export declare type SessionAuthProps = {
     /**
      * Initial context that is rendered on a server side (SSR).
      */
-    initialSessionAuthContext?: SessionContextType;
+    initialSessionAuthContext?: SSRSessionContextType;
     /**
      * For a detailed explanation please see https://github.com/supertokens/supertokens-auth-react/issues/570
      */

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -41,6 +41,7 @@ export declare type SessionContextType =
     | {
           loading: true;
       };
+export declare type SSRSessionContextType = Omit<LoadedSessionContext, "invalidClaims" | "accessDeniedValidatorError">;
 export declare type AccessDeniedThemeProps = {
     recipe: Session;
     navigate: Navigate;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -31,6 +31,7 @@ export declare type SessionContextUpdate = {
     accessTokenPayload: any;
 };
 export declare type LoadedSessionContext = {
+    preloaded: boolean;
     loading: false;
     invalidClaims: ClaimValidationError[];
     accessDeniedValidatorError?: ClaimValidationError;

--- a/lib/build/recipe/session/types.d.ts
+++ b/lib/build/recipe/session/types.d.ts
@@ -31,7 +31,7 @@ export declare type SessionContextUpdate = {
     accessTokenPayload: any;
 };
 export declare type LoadedSessionContext = {
-    preloaded: boolean;
+    isContextFromSSR: boolean;
     loading: false;
     invalidClaims: ClaimValidationError[];
     accessDeniedValidatorError?: ClaimValidationError;

--- a/lib/ts/recipe/session/index.ts
+++ b/lib/ts/recipe/session/index.ts
@@ -25,7 +25,7 @@ import { RecipeComponentsOverrideContextProvider } from "./componentOverrideCont
 import Session from "./recipe";
 import SessionAuthWrapper from "./sessionAuth";
 import SessionContext from "./sessionContext";
-import { InputType, SessionContextType } from "./types";
+import { InputType, SessionContextType, SSRSessionContextType } from "./types";
 import { useClaimValue as useClaimValueFunc } from "./useClaimValue";
 import useSessionContextFunc from "./useSessionContext";
 
@@ -150,6 +150,7 @@ export {
     InputType,
     SessionContext,
     SessionContextType,
+    SSRSessionContextType,
     BooleanClaim,
     ClaimValidationError,
     ClaimValidationResult,

--- a/lib/ts/recipe/session/sessionAuth.tsx
+++ b/lib/ts/recipe/session/sessionAuth.tsx
@@ -28,7 +28,12 @@ import Session from "./recipe";
 import SessionContext from "./sessionContext";
 import { getFailureRedirectionInfo } from "./utils";
 
-import type { LoadedSessionContext, RecipeEventWithSessionContext, SessionContextType } from "./types";
+import type {
+    LoadedSessionContext,
+    RecipeEventWithSessionContext,
+    SessionContextType,
+    SSRSessionContextType,
+} from "./types";
 import type { Navigate, ReactComponentClass, SessionClaimValidator, UserContext } from "../../types";
 import type { PropsWithChildren } from "react";
 import type { ClaimValidationError } from "supertokens-web-js/recipe/session";
@@ -37,7 +42,7 @@ export type SessionAuthProps = {
     /**
      * Initial context that is rendered on a server side (SSR).
      */
-    initialSessionAuthContext?: SessionContextType;
+    initialSessionAuthContext?: SSRSessionContextType;
     /**
      * For a detailed explanation please see https://github.com/supertokens/supertokens-auth-react/issues/570
      */
@@ -69,9 +74,16 @@ const SessionAuth: React.FC<PropsWithChildren<SessionAuthProps>> = ({ children, 
         );
     }
 
+    const initialContext: SessionContextType = props.initialSessionAuthContext
+        ? {
+              ...props.initialSessionAuthContext,
+              invalidClaims: [], // invalidClaims is currently unsupported on server (SSR)
+          }
+        : { loading: true };
+
     // Reusing the parent context was removed because it caused a redirect loop in an edge case
     // because it'd also reuse the invalid claims part until it loaded.
-    const [context, setContext] = useState<SessionContextType>(props.initialSessionAuthContext ?? { loading: true });
+    const [context, setContext] = useState<SessionContextType>(initialContext);
 
     const session = useRef<Session>();
 

--- a/lib/ts/recipe/session/sessionAuth.tsx
+++ b/lib/ts/recipe/session/sessionAuth.tsx
@@ -105,7 +105,7 @@ const SessionAuth: React.FC<PropsWithChildren<SessionAuthProps>> = ({ children, 
 
         if (sessionExists === false) {
             return {
-                preloaded: false,
+                isContextFromSSR: false,
                 loading: false,
                 doesSessionExist: false,
                 accessTokenPayload: {},
@@ -133,7 +133,7 @@ const SessionAuth: React.FC<PropsWithChildren<SessionAuthProps>> = ({ children, 
                 throw err;
             }
             return {
-                preloaded: false,
+                isContextFromSSR: false,
                 loading: false,
                 doesSessionExist: false,
                 accessTokenPayload: {},
@@ -144,7 +144,7 @@ const SessionAuth: React.FC<PropsWithChildren<SessionAuthProps>> = ({ children, 
 
         try {
             return {
-                preloaded: false,
+                isContextFromSSR: false,
                 loading: false,
                 doesSessionExist: true,
                 invalidClaims,
@@ -166,7 +166,7 @@ const SessionAuth: React.FC<PropsWithChildren<SessionAuthProps>> = ({ children, 
             // This means that loading the access token or the userId failed
             // This may happen if the server cleared the error since the validation was done which should be extremely rare
             return {
-                preloaded: false,
+                isContextFromSSR: false,
                 loading: false,
                 doesSessionExist: false,
                 accessTokenPayload: {},
@@ -254,7 +254,12 @@ const SessionAuth: React.FC<PropsWithChildren<SessionAuthProps>> = ({ children, 
                             userContext,
                         });
                         if (failureRedirectInfo.redirectPath) {
-                            setContext({ ...event.sessionContext, preloaded: false, loading: false, invalidClaims });
+                            setContext({
+                                ...event.sessionContext,
+                                isContextFromSSR: false,
+                                loading: false,
+                                invalidClaims,
+                            });
                             return await SuperTokens.getInstanceOrThrow().redirectToUrl(
                                 failureRedirectInfo.redirectPath,
                                 navigate
@@ -267,22 +272,22 @@ const SessionAuth: React.FC<PropsWithChildren<SessionAuthProps>> = ({ children, 
                             });
                             return setContext({
                                 ...event.sessionContext,
-                                preloaded: false,
+                                isContextFromSSR: false,
                                 loading: false,
                                 invalidClaims,
                                 accessDeniedValidatorError: failureRedirectInfo.failedClaim,
                             });
                         }
                     }
-                    setContext({ ...event.sessionContext, preloaded: false, loading: false, invalidClaims });
+                    setContext({ ...event.sessionContext, isContextFromSSR: false, loading: false, invalidClaims });
 
                     return;
                 }
                 case "SIGN_OUT":
-                    setContext({ ...event.sessionContext, preloaded: false, loading: false, invalidClaims: [] });
+                    setContext({ ...event.sessionContext, isContextFromSSR: false, loading: false, invalidClaims: [] });
                     return;
                 case "UNAUTHORISED":
-                    setContext({ ...event.sessionContext, preloaded: false, loading: false, invalidClaims: [] });
+                    setContext({ ...event.sessionContext, isContextFromSSR: false, loading: false, invalidClaims: [] });
                     if (props.onSessionExpired !== undefined) {
                         props.onSessionExpired();
                     } else if (props.requireAuth !== false && props.doRedirection !== false) {

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -50,7 +50,7 @@ export type SessionContextUpdate = {
 };
 
 export type LoadedSessionContext = {
-    preloaded: boolean;
+    isContextFromSSR: boolean;
     loading: false;
     invalidClaims: ClaimValidationError[];
     accessDeniedValidatorError?: ClaimValidationError;

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -50,6 +50,7 @@ export type SessionContextUpdate = {
 };
 
 export type LoadedSessionContext = {
+    preloaded: boolean;
     loading: false;
     invalidClaims: ClaimValidationError[];
     accessDeniedValidatorError?: ClaimValidationError;

--- a/lib/ts/recipe/session/types.ts
+++ b/lib/ts/recipe/session/types.ts
@@ -62,6 +62,8 @@ export type SessionContextType =
           loading: true;
       };
 
+export type SSRSessionContextType = Omit<LoadedSessionContext, "invalidClaims" | "accessDeniedValidatorError">;
+
 export type AccessDeniedThemeProps = {
     recipe: Session;
     navigate: Navigate;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15917,9 +15917,9 @@
             }
         },
         "node_modules/supertokens-website": {
-            "version": "17.0.4",
-            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-17.0.4.tgz",
-            "integrity": "sha512-ayWhEFvspUe26YhM1bq11ssEpnFCZIsoHZtJwJHgHsoflfMUKdgrzOix/bboI0PWJeNTUphHyZebw0ApctaS1Q==",
+            "version": "17.0.5",
+            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-17.0.5.tgz",
+            "integrity": "sha512-NBOiKO3NV2VBAFgO+ZEmpOPVde2BwOjB6T0qjj2XaZX4jh+6yDGhrckJMwF5R0ucpTgOQXmBrpDnUJ5kFZlgiQ==",
             "peer": true,
             "dependencies": {
                 "browser-tabs-lock": "^1.3.0",
@@ -28941,9 +28941,9 @@
             }
         },
         "supertokens-website": {
-            "version": "17.0.4",
-            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-17.0.4.tgz",
-            "integrity": "sha512-ayWhEFvspUe26YhM1bq11ssEpnFCZIsoHZtJwJHgHsoflfMUKdgrzOix/bboI0PWJeNTUphHyZebw0ApctaS1Q==",
+            "version": "17.0.5",
+            "resolved": "https://registry.npmjs.org/supertokens-website/-/supertokens-website-17.0.5.tgz",
+            "integrity": "sha512-NBOiKO3NV2VBAFgO+ZEmpOPVde2BwOjB6T0qjj2XaZX4jh+6yDGhrckJMwF5R0ucpTgOQXmBrpDnUJ5kFZlgiQ==",
             "peer": true,
             "requires": {
                 "browser-tabs-lock": "^1.3.0",

--- a/recipe/session/index.js
+++ b/recipe/session/index.js
@@ -13,6 +13,7 @@
  * under the License.
  */
 "use strict";
+"use client"; // Important for NextJS support (SessionAuth is a client component)
 function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }

--- a/test/unit/componentOverrides.test.tsx
+++ b/test/unit/componentOverrides.test.tsx
@@ -214,6 +214,7 @@ describe("Components override per recipe provider", () => {
             ],
         });
         setMockResolvesSession({
+            isContextFromSSR: false,
             userId: "mock-user-id",
             accessTokenPayload: {},
             invalidClaims: [],

--- a/test/unit/recipe/emailpassword/signInUp.test.tsx
+++ b/test/unit/recipe/emailpassword/signInUp.test.tsx
@@ -56,6 +56,7 @@ describe("EmailPassword.SignInAndUp", () => {
         });
 
         setMockResolvesSession({
+            isContextFromSSR: false,
             userId: "mock-user-id",
             accessTokenPayload: {},
             invalidClaims: [],

--- a/test/unit/recipe/passwordless/signInUp.test.tsx
+++ b/test/unit/recipe/passwordless/signInUp.test.tsx
@@ -57,6 +57,7 @@ describe("Passwordless.SingInUp", () => {
         });
 
         setMockResolvesSession({
+            isContextFromSSR: false,
             userId: "mock-user-id",
             accessTokenPayload: {},
             invalidClaims: [],

--- a/test/unit/recipe/session/sessionAuth.test.tsx
+++ b/test/unit/recipe/session/sessionAuth.test.tsx
@@ -90,6 +90,7 @@ describe("SessionAuth", () => {
             doesSessionExist: true,
             invalidClaims: [],
             loading: false,
+            preloaded: false,
         });
     });
 
@@ -216,6 +217,7 @@ describe("SessionAuth", () => {
                     userId: "mock-id",
                     invalidClaims: [],
                     loading: false,
+                    preloaded: false,
                 });
 
                 // when
@@ -508,6 +510,7 @@ describe("SessionAuth", () => {
                 userId: "mock-id",
                 invalidClaims: [{ validatorId: "st-test-claim", reason: "test-reason" }],
                 loading: false,
+                preloaded: false,
             });
 
             await act(() =>
@@ -664,6 +667,7 @@ describe("SessionAuth", () => {
                 userId: "",
                 invalidClaims: [],
                 loading: false,
+                preloaded: false,
             });
 
             // when
@@ -692,6 +696,7 @@ describe("SessionAuth", () => {
                 userId: "",
                 invalidClaims: [],
                 loading: false,
+                preloaded: false,
             });
 
             // when

--- a/test/unit/recipe/session/sessionAuth.test.tsx
+++ b/test/unit/recipe/session/sessionAuth.test.tsx
@@ -5,7 +5,7 @@ import SuperTokens from "../../../../lib/ts/superTokens";
 import Session from "../../../../lib/ts/recipe/session/recipe";
 import SessionAuth from "../../../../lib/ts/recipe/session/sessionAuth";
 import SessionContext from "../../../../lib/ts/recipe/session/sessionContext";
-import { SessionContextType } from "../../../../lib/ts/recipe/session";
+import { SessionContextType, SSRSessionContextType } from "../../../../lib/ts/recipe/session";
 import { PrimitiveClaim, SessionClaim, useClaimValue } from "../../../../lib/ts/recipe/session";
 import * as utils from "supertokens-web-js/utils";
 
@@ -156,6 +156,34 @@ describe("SessionAuth", () => {
 
         result.unmount();
     });
+
+    test("set initial SSR context (initialSessionAuthContext)", async () => {
+        const initialSessionAuthContext: SSRSessionContextType = {
+            isContextFromSSR: true,
+            loading: false,
+            doesSessionExist: true,
+            accessTokenPayload: {
+                foo: "bar",
+            },
+            userId: "mock-ssr-user-id",
+        };
+
+        // when
+        const result = render(
+            <SessionAuth initialSessionAuthContext={initialSessionAuthContext}>
+                <MockSessionConsumer />
+            </SessionAuth>
+        );
+
+        // then
+        expect(await result.findByText(/^userId:/)).toHaveTextContent(`userId: mock-ssr-user-id`);
+        expect(await result.findByText(/^accessTokenPayload:/)).toHaveTextContent(
+            `accessTokenPayload: ${JSON.stringify({
+                foo: "bar",
+            })}`
+        );
+    });
+
     test("set initial context", async () => {
         // when
         const result = render(

--- a/test/unit/recipe/session/sessionAuth.test.tsx
+++ b/test/unit/recipe/session/sessionAuth.test.tsx
@@ -90,7 +90,7 @@ describe("SessionAuth", () => {
             doesSessionExist: true,
             invalidClaims: [],
             loading: false,
-            preloaded: false,
+            isContextFromSSR: false,
         });
     });
 
@@ -217,7 +217,7 @@ describe("SessionAuth", () => {
                     userId: "mock-id",
                     invalidClaims: [],
                     loading: false,
-                    preloaded: false,
+                    isContextFromSSR: false,
                 });
 
                 // when
@@ -510,7 +510,7 @@ describe("SessionAuth", () => {
                 userId: "mock-id",
                 invalidClaims: [{ validatorId: "st-test-claim", reason: "test-reason" }],
                 loading: false,
-                preloaded: false,
+                isContextFromSSR: false,
             });
 
             await act(() =>
@@ -667,7 +667,7 @@ describe("SessionAuth", () => {
                 userId: "",
                 invalidClaims: [],
                 loading: false,
-                preloaded: false,
+                isContextFromSSR: false,
             });
 
             // when
@@ -696,7 +696,7 @@ describe("SessionAuth", () => {
                 userId: "",
                 invalidClaims: [],
                 loading: false,
-                preloaded: false,
+                isContextFromSSR: false,
             });
 
             // when

--- a/test/unit/recipe/thirdparty/signInUp.test.tsx
+++ b/test/unit/recipe/thirdparty/signInUp.test.tsx
@@ -68,6 +68,7 @@ describe("ThirdParty.SignInAndUp", () => {
         });
 
         setMockResolvesSession({
+            isContextFromSSR: false,
             userId: "mock-user-id",
             accessTokenPayload: {},
             invalidClaims: [],

--- a/test/unit/recipe/thirdpartyemailpassword/signInUp.test.tsx
+++ b/test/unit/recipe/thirdpartyemailpassword/signInUp.test.tsx
@@ -56,6 +56,7 @@ describe("ThirdPartyEmailPassword.SignInAndUp", () => {
         });
 
         setMockResolvesSession({
+            isContextFromSSR: false,
             userId: "mock-user-id",
             accessTokenPayload: {},
             invalidClaims: [],

--- a/test/unit/recipe/thirdpartypasswordless/signInUp.test.tsx
+++ b/test/unit/recipe/thirdpartypasswordless/signInUp.test.tsx
@@ -57,6 +57,7 @@ describe("ThirdPartyPasswordless.SignInAndUp", () => {
         });
 
         setMockResolvesSession({
+            isContextFromSSR: false,
             userId: "mock-user-id",
             accessTokenPayload: {},
             invalidClaims: [],


### PR DESCRIPTION
## Summary of change

Adds `initialSessionAuthContext` support for `SessionAuth` component. `initialSessionAuthContext` is an initial state that Session provider uses to create a context.

- Added `initialSessionAuthContext` property to `SessionAuthProps`
- Added `isContextFromSSR` to `LoadedSessionContext` that signals if a session context is provided from a server or computed on the client.
   -  `isContextFromSSR: true`  when uses initial context preloaded from server (SSR). This means `invalidClaims[]` and `accessDeniedValidatorError` are not yet evaluated and the client should not trust the data (as discussed with @porcellus ) 
   -  `isContextFromSSR: false`  when uses a client generated context (ex: after client rerender)

## Related issues

-   https://github.com/supertokens/supertokens-auth-react/issues/790
-   https://github.com/supertokens/supertokens-auth-react/issues/263
-   https://github.com/supertokens/supertokens-node/pull/785

## Test Plan

Tested locally on a NextJS implementation using supertokens. Tested scenarios include:
- Tested `<SessionAuth />` rendering with children that consume context (userId) -> Renders on server side, no flash or hydration issues
- Tested with `requireAuth: false` on server component. ->  `<SessionAuth />`  provides an empty session context and renders children

## Documentation changes

TODO.

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`

## Remaining TODOs for this PR

-   [x] Add `getInitialSessionAuthContext` support to `supertokens-node`
-   [ ] Update documentation to include examples
