### PR TITLE
test: fix import errors in e2e tests

### DIFF
--- a/test/end-to-end/mfa.chooserscreen.test.js
+++ b/test/end-to-end/mfa.chooserscreen.test.js
@@ -32,6 +32,7 @@ import {
     getFactorChooserOptions,
     setAccountLinkingConfig,
     isMFASupported,
+    expectErrorThrown,
 } from "../helpers";
 import fetch from "isomorphic-fetch";
 import { CREATE_CODE_API, CREATE_TOTP_DEVICE_API, MFA_INFO_API } from "../constants";
@@ -53,7 +54,6 @@ import {
     setupUserWithAllFactors,
     goToFactorChooser,
     waitForAccessDenied,
-    expectErrorThrown,
     waitForLoadingScreen,
     waitForBlockedScreen,
 } from "./mfa.helpers";

--- a/test/end-to-end/mfa.default_reqs.test.js
+++ b/test/end-to-end/mfa.default_reqs.test.js
@@ -53,7 +53,6 @@ import {
     setupUserWithAllFactors,
     goToFactorChooser,
     waitForAccessDenied,
-    expectErrorThrown,
     waitForLoadingScreen,
     waitForBlockedScreen,
     addToRequiredSecondaryFactorsForUser,

--- a/test/end-to-end/mfa.factorscreen.otp.test.js
+++ b/test/end-to-end/mfa.factorscreen.otp.test.js
@@ -54,7 +54,6 @@ import {
     setupUserWithAllFactors,
     goToFactorChooser,
     waitForAccessDenied,
-    expectErrorThrown,
     waitForLoadingScreen,
     waitForBlockedScreen,
 } from "./mfa.helpers";

--- a/test/end-to-end/mfa.factorscreen.totp.test.js
+++ b/test/end-to-end/mfa.factorscreen.totp.test.js
@@ -54,7 +54,6 @@ import {
     setupUserWithAllFactors,
     goToFactorChooser,
     waitForAccessDenied,
-    expectErrorThrown,
     waitForLoadingScreen,
     waitForBlockedScreen,
 } from "./mfa.helpers";

--- a/test/end-to-end/mfa.requirement_handling.test.js
+++ b/test/end-to-end/mfa.requirement_handling.test.js
@@ -53,7 +53,6 @@ import {
     setupUserWithAllFactors,
     goToFactorChooser,
     waitForAccessDenied,
-    expectErrorThrown,
     waitForLoadingScreen,
     waitForBlockedScreen,
 } from "./mfa.helpers";

--- a/test/end-to-end/mfa.signin.test.js
+++ b/test/end-to-end/mfa.signin.test.js
@@ -31,6 +31,7 @@ import {
     waitFor,
     isMFASupported,
     setAccountLinkingConfig,
+    expectErrorThrown,
 } from "../helpers";
 import fetch from "isomorphic-fetch";
 import { CREATE_CODE_API, CREATE_TOTP_DEVICE_API, MFA_INFO_API } from "../constants";
@@ -52,7 +53,6 @@ import {
     setupUserWithAllFactors,
     goToFactorChooser,
     waitForAccessDenied,
-    expectErrorThrown,
     waitForLoadingScreen,
     waitForBlockedScreen,
 } from "./mfa.helpers";


### PR DESCRIPTION
## Summary of change

Fix import errors introduced by #813 (vscode moved and supposedly updated imports but it didn't actually happen)

## Related issues

-   [CI failures](https://app.circleci.com/pipelines/github/supertokens/supertokens-auth-react/4389/workflows/9795cc80-5f58-4e9f-8792-c21879253e23/jobs/2433)

## Test Plan

N/A test only change

## Documentation changes

N/A test only change

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [ ] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [ ] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`
