### PR TITLE
fix: inputComponents now get stable callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.40.2] - 2024-04-30
+
+### Fixes
+
+-   Custom `inputComponents` (in sign in/up form fields) now get reference-stable callbacks.
+
 ## [0.40.1] - 2024-04-29
 
 ### CI changes

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import "./App.css";
 
 import AppWithoutRouter from "./AppWithoutRouter";
@@ -289,21 +289,31 @@ const incorrectFormFields = [
     },
 ];
 
+const DropdownInputComponent = ({ value, name, onChange }) => {
+    const onChangeRef = useRef(onChange);
+
+    if (onChangeRef.current !== onChange) {
+        throw new Error("callbacks passed to inputComponents should be reference stable");
+    }
+
+    return (
+        <select value={value} name={name} onChange={(e) => onChange(e.target.value)}>
+            <option value="" disabled hidden>
+                Select an option
+            </option>
+            <option value="option 1">Option 1</option>
+            <option value="option 2">Option 2</option>
+            <option value="option 3">Option 3</option>
+        </select>
+    );
+};
+
 const customFields = [
     {
         id: "select-dropdown",
         label: "Select Dropdown",
         nonOptionalErrorMsg: "Select dropdown is not an optional",
-        inputComponent: ({ value, name, onChange }) => (
-            <select value={value} name={name} onChange={(e) => onChange(e.target.value)}>
-                <option value="" disabled hidden>
-                    Select an option
-                </option>
-                <option value="option 1">Option 1</option>
-                <option value="option 2">Option 2</option>
-                <option value="option 3">Option 3</option>
-            </select>
-        ),
+        inputComponent: DropdownInputComponent,
         optional: true,
     },
     {

--- a/lib/build/emailpassword-shared9.js
+++ b/lib/build/emailpassword-shared9.js
@@ -455,7 +455,7 @@ function InputComponentWrapper(props) {
                 value: value,
             });
         },
-        [onInputFocus, field]
+        [onInputFocus, field.id]
     );
     var useCallbackOnInputBlur = React.useCallback(
         function (value) {
@@ -464,7 +464,7 @@ function InputComponentWrapper(props) {
                 value: value,
             });
         },
-        [onInputBlur, field]
+        [onInputBlur, field.id]
     );
     var useCallbackOnInputChange = React.useCallback(
         function (value) {
@@ -473,7 +473,7 @@ function InputComponentWrapper(props) {
                 value: value,
             });
         },
-        [onInputChange, field]
+        [onInputChange, field.id]
     );
     return field.inputComponent !== undefined
         ? jsxRuntime.jsx(field.inputComponent, {

--- a/lib/build/genericComponentOverrideContext.js
+++ b/lib/build/genericComponentOverrideContext.js
@@ -265,7 +265,7 @@ var SSR_ERROR =
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var package_version = "0.40.1";
+var package_version = "0.40.2";
 
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.40.1";
+export declare const package_version = "0.40.2";

--- a/lib/ts/recipe/emailpassword/components/library/formBase.tsx
+++ b/lib/ts/recipe/emailpassword/components/library/formBase.tsx
@@ -66,7 +66,7 @@ function InputComponentWrapper(props: {
                 value,
             });
         },
-        [onInputFocus, field]
+        [onInputFocus, field.id]
     );
 
     const useCallbackOnInputBlur = useCallback<(value: string) => void>(
@@ -76,7 +76,7 @@ function InputComponentWrapper(props: {
                 value,
             });
         },
-        [onInputBlur, field]
+        [onInputBlur, field.id]
     );
 
     const useCallbackOnInputChange = useCallback(
@@ -86,7 +86,7 @@ function InputComponentWrapper(props: {
                 value,
             });
         },
-        [onInputChange, field]
+        [onInputChange, field.id]
     );
 
     return field.inputComponent !== undefined ? (

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.40.1";
+export const package_version = "0.40.2";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.40.1",
+    "version": "0.40.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.40.1",
+            "version": "0.40.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.40.1",
+    "version": "0.40.2",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {


### PR DESCRIPTION
## Summary of change

`inputComponents` now get stable callbacks, as it was intended originally.

## Related issues

-   

## Test Plan

Modified the test app, so existing tests also check this.

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [x] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [x] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [x] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`
