### PR TITLE
fix: missing branding from OTP screen

### DIFF
--- a/lib/build/passwordlessprebuiltui.js
+++ b/lib/build/passwordlessprebuiltui.js
@@ -3794,28 +3794,34 @@ var UserInputCodeFormHeader = uiEntry.withOverride(
 );
 
 var UserInputCodeFormScreen = function (props) {
-    return jsxRuntime.jsx(
+    return jsxRuntime.jsxs(
         "div",
         genericComponentOverrideContext.__assign(
             { "data-supertokens": "container" },
             {
-                children: jsxRuntime.jsxs(
-                    "div",
-                    genericComponentOverrideContext.__assign(
-                        { "data-supertokens": "row" },
-                        {
-                            children: [
-                                jsxRuntime.jsx(
-                                    UserInputCodeFormHeader,
-                                    genericComponentOverrideContext.__assign({}, props)
-                                ),
-                                props.error !== undefined &&
-                                    jsxRuntime.jsx(uiEntry.GeneralError, { error: props.error }),
-                                jsxRuntime.jsx(UserInputCodeForm, genericComponentOverrideContext.__assign({}, props)),
-                            ],
-                        }
-                    )
-                ),
+                children: [
+                    jsxRuntime.jsxs(
+                        "div",
+                        genericComponentOverrideContext.__assign(
+                            { "data-supertokens": "row" },
+                            {
+                                children: [
+                                    jsxRuntime.jsx(
+                                        UserInputCodeFormHeader,
+                                        genericComponentOverrideContext.__assign({}, props)
+                                    ),
+                                    props.error !== undefined &&
+                                        jsxRuntime.jsx(uiEntry.GeneralError, { error: props.error }),
+                                    jsxRuntime.jsx(
+                                        UserInputCodeForm,
+                                        genericComponentOverrideContext.__assign({}, props)
+                                    ),
+                                ],
+                            }
+                        )
+                    ),
+                    jsxRuntime.jsx(uiEntry.SuperTokensBranding, {}),
+                ],
             }
         )
     );

--- a/lib/ts/recipe/passwordless/components/themes/userInputCodeForm/userInputCodeFormScreen.tsx
+++ b/lib/ts/recipe/passwordless/components/themes/userInputCodeForm/userInputCodeFormScreen.tsx
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useState } from "react";
 import STGeneralError from "supertokens-web-js/utils/error";
 
 import { withOverride } from "../../../../../components/componentOverride/withOverride";
+import { SuperTokensBranding } from "../../../../../components/SuperTokensBranding";
 import { hasFontDefined } from "../../../../../styles/styles";
 import SuperTokens from "../../../../../superTokens";
 import { useTranslation } from "../../../../../translation/translationContext";
@@ -47,6 +48,7 @@ export const UserInputCodeFormScreen: React.FC<
                 {props.error !== undefined && <GeneralError error={props.error} />}
                 <UserInputCodeForm {...props} />
             </div>
+            <SuperTokensBranding />
         </div>
     );
 };

--- a/stories/emailverification.stories.tsx
+++ b/stories/emailverification.stories.tsx
@@ -51,7 +51,7 @@ export default {
             for (const ui of prebuiltUIs) {
                 ui.reset();
             }
-            resetAndInitST(recipeList, args.usesDynamicLoginMethods, undefined, {
+            resetAndInitST(recipeList, args.usesDynamicLoginMethods, undefined, undefined, {
                 path: args.path,
                 query: args.query,
                 hash: args.hash,
@@ -77,7 +77,7 @@ export default {
 };
 
 export const SentEmail: Story = {};
-export const LinkCliked: Story = {
+export const LinkClicked: Story = {
     args: {
         path: "/auth/verify-email",
         query: "token=asdf",

--- a/test/end-to-end/mfa.helpers.js
+++ b/test/end-to-end/mfa.helpers.js
@@ -33,6 +33,9 @@ export async function setupUserWithAllFactors(page) {
     const latestURLWithToken = await getLatestURLWithToken();
     await Promise.all([page.waitForNavigation({ waitUntil: "networkidle0" }), page.goto(latestURLWithToken)]);
 
+    // wait until all the handlers are set up
+    await waitFor(250);
+
     // click on the continue button
     await Promise.all([submitForm(page), page.waitForNavigation({ waitUntil: "networkidle0" })]);
 

--- a/test/end-to-end/passwordless.allrecipes.email.test.js
+++ b/test/end-to-end/passwordless.allrecipes.email.test.js
@@ -1,0 +1,24 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { getPasswordlessTestCases } from "./passwordless.test_gen";
+
+describe("SuperTokens Passwordless w/ all recipes enabled", function () {
+    getPasswordlessTestCases({
+        authRecipe: "all",
+        logId: "PASSWORDLESS",
+        generalErrorRecipeName: "PASSWORDLESS",
+        contactMethod: "EMAIL",
+    });
+});

--- a/test/end-to-end/passwordless.allrecipes.email_or_phone.test.js
+++ b/test/end-to-end/passwordless.allrecipes.email_or_phone.test.js
@@ -1,0 +1,24 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { getPasswordlessTestCases } from "./passwordless.test_gen";
+
+describe("SuperTokens Passwordless w/ all recipes enabled", function () {
+    getPasswordlessTestCases({
+        authRecipe: "all",
+        logId: "PASSWORDLESS",
+        generalErrorRecipeName: "PASSWORDLESS",
+        contactMethod: "EMAIL_OR_PHONE",
+    });
+});

--- a/test/end-to-end/passwordless.allrecipes.phone.test.js
+++ b/test/end-to-end/passwordless.allrecipes.phone.test.js
@@ -1,0 +1,24 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { getPasswordlessTestCases } from "./passwordless.test_gen";
+
+describe("SuperTokens Passwordless w/ all recipes enabled", function () {
+    getPasswordlessTestCases({
+        authRecipe: "all",
+        logId: "PASSWORDLESS",
+        generalErrorRecipeName: "PASSWORDLESS",
+        contactMethod: "PHONE",
+    });
+});

--- a/test/end-to-end/passwordless.email.test.js
+++ b/test/end-to-end/passwordless.email.test.js
@@ -1,0 +1,13 @@
+import { getPasswordlessTestCases } from "./passwordless.test_gen";
+
+/*
+ * Tests.
+ */
+describe("SuperTokens Passwordless", function () {
+    getPasswordlessTestCases({
+        authRecipe: "passwordless",
+        logId: "PASSWORDLESS",
+        generalErrorRecipeName: "PASSWORDLESS",
+        contactMethod: "EMAIL",
+    });
+});

--- a/test/end-to-end/passwordless.email_or_phone.test.js
+++ b/test/end-to-end/passwordless.email_or_phone.test.js
@@ -1,0 +1,13 @@
+import { getPasswordlessTestCases } from "./passwordless.test_gen";
+
+/*
+ * Tests.
+ */
+describe("SuperTokens Passwordless", function () {
+    getPasswordlessTestCases({
+        authRecipe: "passwordless",
+        logId: "PASSWORDLESS",
+        generalErrorRecipeName: "PASSWORDLESS",
+        contactMethod: "EMAIL_OR_PHONE",
+    });
+});

--- a/test/end-to-end/passwordless.phone.test.js
+++ b/test/end-to-end/passwordless.phone.test.js
@@ -1,0 +1,13 @@
+import { getPasswordlessTestCases } from "./passwordless.test_gen";
+
+/*
+ * Tests.
+ */
+describe("SuperTokens Passwordless", function () {
+    getPasswordlessTestCases({
+        authRecipe: "passwordless",
+        logId: "PASSWORDLESS",
+        generalErrorRecipeName: "PASSWORDLESS",
+        contactMethod: "PHONE",
+    });
+});

--- a/test/end-to-end/thirdpartypasswordless.pwless.email.test.js
+++ b/test/end-to-end/thirdpartypasswordless.pwless.email.test.js
@@ -1,0 +1,42 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Imports
+ */
+
+import { getFeatureFlags } from "../helpers";
+import { getPasswordlessTestCases } from "./passwordless.test_gen";
+
+/*
+ * Tests.
+ */
+describe("SuperTokens Third Party Passwordless", function () {
+    before(async function () {
+        const features = await getFeatureFlags();
+        if (!features.includes("thirdpartypasswordless")) {
+            this.skip();
+        }
+    });
+
+    describe("Passwordless specific", function () {
+        getPasswordlessTestCases({
+            authRecipe: "thirdpartypasswordless",
+            logId: "PASSWORDLESS",
+            generalErrorRecipeName: "THIRD_PARTY_PASSWORDLESS",
+            contactMethod: "EMAIL",
+        });
+    });
+});

--- a/test/end-to-end/thirdpartypasswordless.pwless.email_or_phone.test.js
+++ b/test/end-to-end/thirdpartypasswordless.pwless.email_or_phone.test.js
@@ -17,30 +17,8 @@
  * Imports
  */
 
-import assert from "assert";
-import puppeteer from "puppeteer";
-import {
-    clearBrowserCookiesWithoutAffectingConsole,
-    clickOnProviderButton,
-    getUserIdWithFetch,
-    getLogoutButton,
-    loginWithAuth0,
-    setInputValues,
-    submitForm,
-    waitForSTElement,
-    getPasswordlessDevice,
-    setPasswordlessFlowType,
-    getFeatureFlags,
-    isReact16,
-    assertProviders,
-    setEnabledRecipes,
-    clickOnProviderButtonWithoutWaiting,
-    getGeneralError,
-    backendBeforeEach,
-} from "../helpers";
-import { TEST_CLIENT_BASE_URL, TEST_SERVER_BASE_URL, SIGN_IN_UP_API, GET_AUTH_URL_API } from "../constants";
-import { getThirdPartyTestCases } from "./thirdparty.test";
-import { getPasswordlessTestCases } from "./passwordless.test";
+import { getFeatureFlags } from "../helpers";
+import { getPasswordlessTestCases } from "./passwordless.test_gen";
 
 /*
  * Tests.
@@ -58,6 +36,7 @@ describe("SuperTokens Third Party Passwordless", function () {
             authRecipe: "thirdpartypasswordless",
             logId: "PASSWORDLESS",
             generalErrorRecipeName: "THIRD_PARTY_PASSWORDLESS",
+            contactMethod: "EMAIL_OR_PHONE",
         });
     });
 });

--- a/test/end-to-end/thirdpartypasswordless.pwless.phone.test.js
+++ b/test/end-to-end/thirdpartypasswordless.pwless.phone.test.js
@@ -1,0 +1,42 @@
+/* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Imports
+ */
+
+import { getFeatureFlags } from "../helpers";
+import { getPasswordlessTestCases } from "./passwordless.test_gen";
+
+/*
+ * Tests.
+ */
+describe("SuperTokens Third Party Passwordless", function () {
+    before(async function () {
+        const features = await getFeatureFlags();
+        if (!features.includes("thirdpartypasswordless")) {
+            this.skip();
+        }
+    });
+
+    describe("Passwordless specific", function () {
+        getPasswordlessTestCases({
+            authRecipe: "thirdpartypasswordless",
+            logId: "PASSWORDLESS",
+            generalErrorRecipeName: "THIRD_PARTY_PASSWORDLESS",
+            contactMethod: "PHONE",
+        });
+    });
+});


### PR DESCRIPTION
## Summary of change

fix: missing branding from OTP screen
test parallelization&stability improvements
storybooks fix

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [ ] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [ ] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
