### PR TITLE
feat: skip unnecessary updates in SessionAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.42.3] - 2024-07-19
+
+### Changes
+
+-   Now we only update the session context if the object changes by value. This optimization should help reduce unnecessary re-renders.
+
 ## [0.42.2] - 2024-05-29
 
 ### Changes

--- a/examples/for-tests-react-16/src/App.js
+++ b/examples/for-tests-react-16/src/App.js
@@ -418,6 +418,14 @@ export const DashboardNoAuthRequired = doNotUseReactRouterDom
 export function DashboardNoAuthRequiredHelper(props) {
     let sessionContext = useSessionContext();
 
+    useEffect(() => {
+        if (testContext.signoutOnSessionNotExists) {
+            if (!sessionContext.loading && !sessionContext.doesSessionExist) {
+                Session.signOut();
+            }
+        }
+    }, [sessionContext]);
+
     if (sessionContext.loading) {
         return null;
     }

--- a/examples/for-tests-react-16/src/testContext.js
+++ b/examples/for-tests-react-16/src/testContext.js
@@ -21,6 +21,7 @@ export function getTestContext() {
                 : undefined,
         enableMFA: localStorage.getItem("enableMFA") === "true",
         defaultToEmail: localStorage.getItem("defaultToEmail") !== "false",
+        signoutOnSessionNotExists: localStorage.getItem("signoutOnSessionNotExists") === "true",
         disableRedirectionAfterSuccessfulSignInUp:
             localStorage.getItem("disableRedirectionAfterSuccessfulSignInUp") === "true",
     };

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -590,6 +590,14 @@ export const DashboardNoAuthRequired = doNotUseReactRouterDom
 export function DashboardNoAuthRequiredHelper(props) {
     let sessionContext = useSessionContext();
 
+    useEffect(() => {
+        if (testContext.signoutOnSessionNotExists) {
+            if (!sessionContext.loading && !sessionContext.doesSessionExist) {
+                Session.signOut();
+            }
+        }
+    }, [sessionContext]);
+
     if (sessionContext.loading) {
         return null;
     }

--- a/examples/for-tests/src/testContext.js
+++ b/examples/for-tests/src/testContext.js
@@ -22,6 +22,7 @@ export function getTestContext() {
         },
         enableMFA: localStorage.getItem("enableMFA") === "true",
         defaultToEmail: localStorage.getItem("defaultToEmail") !== "false",
+        signoutOnSessionNotExists: localStorage.getItem("signoutOnSessionNotExists") === "true",
         disableRedirectionAfterSuccessfulSignInUp:
             localStorage.getItem("disableRedirectionAfterSuccessfulSignInUp") === "true",
     };

--- a/lib/build/genericComponentOverrideContext.js
+++ b/lib/build/genericComponentOverrideContext.js
@@ -265,7 +265,7 @@ var SSR_ERROR =
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var package_version = "0.42.2";
+var package_version = "0.42.3";
 
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *

--- a/lib/build/index2.js
+++ b/lib/build/index2.js
@@ -2057,6 +2057,22 @@ var SessionAuth = function (_a) {
     var _c = React.useState({ loading: true }),
         context = _c[0],
         setContext = _c[1];
+    var setContextIfChanged = React.useCallback(
+        function (newValue) {
+            setContext(function (oldValue) {
+                // We can't do this check before re-validation because there are be validators that depend on the current time
+                // Since the context is constructed by the same functions the property order should be stable, meaning that
+                // a simple JSON string check should be sufficient.
+                // Plus since this is just an optimization it is fine to have false positives,
+                // and this method won't have false negatives (where we'd miss an update).
+                if (JSON.stringify(oldValue) !== JSON.stringify(newValue)) {
+                    return newValue;
+                }
+                return oldValue;
+            });
+        },
+        [setContext]
+    );
     var session = React.useRef();
     // We store this here, to prevent the list of called hooks changing even if a navigate hook is added later to SuperTokens.
     var navigateHookRef = React.useRef(
@@ -2239,7 +2255,7 @@ var SessionAuth = function (_a) {
                                 )
                             )
                                 return [3 /*break*/, 3];
-                            setContext(toSetContext);
+                            setContextIfChanged(toSetContext);
                             return [2 /*return*/];
                         case 3:
                             return [
@@ -2268,7 +2284,7 @@ var SessionAuth = function (_a) {
                                 });
                                 return [
                                     2 /*return*/,
-                                    setContext(
+                                    setContextIfChanged(
                                         genericComponentOverrideContext.__assign(
                                             genericComponentOverrideContext.__assign({}, toSetContext),
                                             { accessDeniedValidatorError: failureRedirectInfo.failedClaim }
@@ -2278,7 +2294,7 @@ var SessionAuth = function (_a) {
                             }
                             _a.label = 8;
                         case 8:
-                            setContext(toSetContext);
+                            setContextIfChanged(toSetContext);
                             return [2 /*return*/];
                     }
                 });
@@ -2353,7 +2369,7 @@ var SessionAuth = function (_a) {
                                     )
                                 )
                                     return [3 /*break*/, 5];
-                                setContext(
+                                setContextIfChanged(
                                     genericComponentOverrideContext.__assign(
                                         genericComponentOverrideContext.__assign({}, event.sessionContext),
                                         { loading: false, invalidClaims: invalidClaims }
@@ -2387,7 +2403,7 @@ var SessionAuth = function (_a) {
                                     });
                                     return [
                                         2 /*return*/,
-                                        setContext(
+                                        setContextIfChanged(
                                             genericComponentOverrideContext.__assign(
                                                 genericComponentOverrideContext.__assign({}, event.sessionContext),
                                                 {
@@ -2401,7 +2417,7 @@ var SessionAuth = function (_a) {
                                 }
                                 _b.label = 10;
                             case 10:
-                                setContext(
+                                setContextIfChanged(
                                     genericComponentOverrideContext.__assign(
                                         genericComponentOverrideContext.__assign({}, event.sessionContext),
                                         { loading: false, invalidClaims: invalidClaims }
@@ -2409,7 +2425,7 @@ var SessionAuth = function (_a) {
                                 );
                                 return [2 /*return*/];
                             case 11:
-                                setContext(
+                                setContextIfChanged(
                                     genericComponentOverrideContext.__assign(
                                         genericComponentOverrideContext.__assign({}, event.sessionContext),
                                         { loading: false, invalidClaims: [] }
@@ -2417,7 +2433,7 @@ var SessionAuth = function (_a) {
                                 );
                                 return [2 /*return*/];
                             case 12:
-                                setContext(
+                                setContextIfChanged(
                                     genericComponentOverrideContext.__assign(
                                         genericComponentOverrideContext.__assign({}, event.sessionContext),
                                         { loading: false, invalidClaims: [] }
@@ -2446,7 +2462,7 @@ var SessionAuth = function (_a) {
             }
             return undefined;
         },
-        [props, setContext, context.loading, userContext, navigate, redirectToLogin]
+        [props, setContextIfChanged, context.loading, userContext, navigate, redirectToLogin]
     );
     if (props.requireAuth !== false && (context.loading || !context.doesSessionExist)) {
         return null;

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.42.2";
+export declare const package_version = "0.42.3";

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.42.2";
+export const package_version = "0.42.3";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.42.2",
+    "version": "0.42.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.42.2",
+            "version": "0.42.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "size-limit": [
         {
             "path": "lib/build/index.js",
-            "limit": "23kb"
+            "limit": "23.5kb"
         },
         {
             "path": "recipe/session/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.42.2",
+    "version": "0.42.3",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {


### PR DESCRIPTION
## Summary of change

skip unnecessary updates in SessionAuth

## Related issues

-   
## Test Plan

Added an extra test that replacates a case we've seen on a user call: running signout on context updates that have `doesSessionExist === false`. This used to trigger an infinite re-render loop.

## Documentation changes

None, this is a small optimization that people should not rely on.

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [x] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [x] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [x] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`
