### PR TITLE
 feat!: make the mfa screens do success redirection if the next array is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+-   Changed `redirectToFactor` to accept an object instead of multiple arguments.
+-   Changed `redirectToFactorChooser` to accept an object instead of multiple arguments.
 -   Made MFA related screens do a success redirection if MFA is already completed and the `stepUp` query param is not set to `true`.
+    -   `redirectToFactorChooser` now accepts a `stepUp` option to set the `stepUp` query param.
+    -   `redirectToFactor` now accepts a `stepUp` option to set the `stepUp` query param.
 
 ## [0.45.1] - 2024-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Breaking changes
+
+-   Made MFA related screens do a success redirection if MFA is already completed and the `stepUp` query param is not set to `true`.
+
 ## [0.45.1] - 2024-08-09
 
 ### Changes

--- a/examples/for-tests-react-16/src/App.js
+++ b/examples/for-tests-react-16/src/App.js
@@ -514,9 +514,13 @@ export function DashboardHelper({ redirectOnLogout, ...props } = {}) {
             <a
                 className="goToFactorChooser"
                 onClick={() => {
-                    return MultiFactorAuth.redirectToFactorChooser(true, undefined, props.history);
+                    return MultiFactorAuth.redirectToFactorChooser({
+                        redirectBack: true,
+                        stepUp: true,
+                        navigate: props.history,
+                    });
                 }}>
-                MFA chooser
+                MFA chooser (step up)
             </a>
         </div>
     );

--- a/examples/for-tests/src/App.js
+++ b/examples/for-tests/src/App.js
@@ -686,9 +686,13 @@ export function DashboardHelper({ redirectOnLogout, ...props } = {}) {
             <a
                 className="goToFactorChooser"
                 onClick={() => {
-                    return MultiFactorAuth.redirectToFactorChooser(true, undefined, props.history);
+                    return MultiFactorAuth.redirectToFactorChooser({
+                        redirectBack: true,
+                        stepUp: true,
+                        navigate: props.history,
+                    });
                 }}>
-                MFA chooser
+                MFA chooser (step up)
             </a>
         </div>
     );

--- a/examples/with-multifactorauth-phone-chooser/frontend/package.json
+++ b/examples/with-multifactorauth-phone-chooser/frontend/package.json
@@ -15,7 +15,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.2.1",
         "react-scripts": "5.0.1",
-        "supertokens-auth-react": "latest",
+        "supertokens-auth-react": "github:supertokens/supertokens-auth-react#feat/mfa_redirect",
         "supertokens-web-js": "latest",
         "typescript": "^4.8.2",
         "web-vitals": "^2.1.4"

--- a/examples/with-multifactorauth-phone-chooser/frontend/src/Home/CallAPIView.tsx
+++ b/examples/with-multifactorauth-phone-chooser/frontend/src/Home/CallAPIView.tsx
@@ -15,7 +15,7 @@ export default function CallAPIView() {
     async function goToPhoneSetup() {
         await MultiFactorAuth.redirectToFactor({
             factorId: MultiFactorAuth.FactorIds.OTP_PHONE,
-            setup: true,
+            forceSetup: true,
             redirectBack: true,
             navigate,
         });

--- a/examples/with-multifactorauth-phone-chooser/frontend/src/Home/CallAPIView.tsx
+++ b/examples/with-multifactorauth-phone-chooser/frontend/src/Home/CallAPIView.tsx
@@ -13,7 +13,12 @@ export default function CallAPIView() {
     }
 
     async function goToPhoneSetup() {
-        await MultiFactorAuth.redirectToFactor(MultiFactorAuth.FactorIds.OTP_PHONE, true, true, navigate);
+        await MultiFactorAuth.redirectToFactor({
+            factorId: MultiFactorAuth.FactorIds.OTP_PHONE,
+            setup: true,
+            redirectBack: true,
+            navigate,
+        });
     }
 
     return (

--- a/examples/with-multifactorauth-phone-chooser/frontend/src/SelectPhone/index.tsx
+++ b/examples/with-multifactorauth-phone-chooser/frontend/src/SelectPhone/index.tsx
@@ -16,10 +16,19 @@ export default function SelectPhone() {
             if (res.status === 200) {
                 const loadedInfo = await res.clone().json();
                 if (loadedInfo.user.phoneNumbers.length === 0) {
-                    await MultiFactorAuth.redirectToFactor(MultiFactorAuth.FactorIds.OTP_PHONE, true, false, nav);
+                    await MultiFactorAuth.redirectToFactor({
+                        factorId: MultiFactorAuth.FactorIds.OTP_PHONE,
+                        setup: true,
+                        redirectBack: false,
+                        navigate,
+                    });
                 } else if (loadedInfo.user.phoneNumbers.length === 1) {
                     await Passwordless.createCode({ phoneNumber: loadedInfo.user.phoneNumbers[0] });
-                    await MultiFactorAuth.redirectToFactor(MultiFactorAuth.FactorIds.OTP_PHONE, false, false, nav);
+                    await MultiFactorAuth.redirectToFactor({
+                        factorId: MultiFactorAuth.FactorIds.OTP_PHONE,
+                        redirectBack: false,
+                        navigate,
+                    });
                 } else {
                     setUserInfo(loadedInfo);
                 }
@@ -65,12 +74,11 @@ export default function SelectPhone() {
                                                 hasOtherPhoneNumbers: true,
                                             },
                                         });
-                                        return MultiFactorAuth.redirectToFactor(
-                                            MultiFactorAuth.FactorIds.OTP_PHONE,
-                                            false,
-                                            false,
-                                            nav
-                                        );
+                                        return MultiFactorAuth.redirectToFactor({
+                                            factorId: MultiFactorAuth.FactorIds.OTP_PHONE,
+                                            redirectBack: false,
+                                            navigate: nav,
+                                        });
                                     }
                                 })
                                 .catch(setError);

--- a/examples/with-multifactorauth-phone-chooser/frontend/src/SelectPhone/index.tsx
+++ b/examples/with-multifactorauth-phone-chooser/frontend/src/SelectPhone/index.tsx
@@ -18,16 +18,16 @@ export default function SelectPhone() {
                 if (loadedInfo.user.phoneNumbers.length === 0) {
                     await MultiFactorAuth.redirectToFactor({
                         factorId: MultiFactorAuth.FactorIds.OTP_PHONE,
-                        setup: true,
+                        forceSetup: true,
                         redirectBack: false,
-                        navigate,
+                        navigate: nav,
                     });
                 } else if (loadedInfo.user.phoneNumbers.length === 1) {
                     await Passwordless.createCode({ phoneNumber: loadedInfo.user.phoneNumbers[0] });
                     await MultiFactorAuth.redirectToFactor({
                         factorId: MultiFactorAuth.FactorIds.OTP_PHONE,
                         redirectBack: false,
-                        navigate,
+                        navigate: nav,
                     });
                 } else {
                     setUserInfo(loadedInfo);

--- a/examples/with-multifactorauth-recovery-codes/frontend/src/RecoveryCode/index.tsx
+++ b/examples/with-multifactorauth-recovery-codes/frontend/src/RecoveryCode/index.tsx
@@ -17,7 +17,12 @@ export default function RecoveryCode() {
         if (reset.data.status !== "OK") {
             setError("Recovery code not found");
         } else {
-            await MultiFactorAuth.redirectToFactor("totp", true, false, nav);
+            await MultiFactorAuth.redirectToFactor({
+                factorId: "totp",
+                forceSetup: true,
+                redirectBack: false,
+                navigate: nav,
+            });
         }
     }
 

--- a/lib/build/genericComponentOverrideContext.js
+++ b/lib/build/genericComponentOverrideContext.js
@@ -265,7 +265,7 @@ var SSR_ERROR =
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var package_version = "0.45.1";
+var package_version = "0.46.0";
 
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *

--- a/lib/build/multifactorauth-shared2.js
+++ b/lib/build/multifactorauth-shared2.js
@@ -389,13 +389,20 @@ var MultiFactorAuth = /** @class */ (function (_super) {
         _this.secondaryFactors = [];
         _this.getDefaultRedirectionURL = function (context, userContext) {
             return genericComponentOverrideContext.__awaiter(_this, void 0, void 0, function () {
-                var chooserPath, url, redirectInfo, url;
+                var chooserPath, url, queryParams, redirectInfo, url, queryParams;
                 return genericComponentOverrideContext.__generator(this, function (_b) {
                     if (context.action === "FACTOR_CHOOSER") {
                         chooserPath = new NormalisedURLPath__default.default(DEFAULT_FACTOR_CHOOSER_PATH);
                         url = this.config.appInfo.websiteBasePath.appendPath(chooserPath).getAsStringDangerous();
+                        queryParams = new URLSearchParams();
                         if (context.nextFactorOptions && context.nextFactorOptions.length > 0) {
-                            url += "?n=".concat(context.nextFactorOptions.join(","));
+                            queryParams.set("n", context.nextFactorOptions.join(","));
+                        }
+                        if (context.stepUp) {
+                            queryParams.set("stepUp", "true");
+                        }
+                        if (queryParams.toString() !== "") {
+                            url += "?" + queryParams.toString();
                         }
                         return [2 /*return*/, url];
                     } else if (context.action === "GO_TO_FACTOR") {
@@ -406,8 +413,15 @@ var MultiFactorAuth = /** @class */ (function (_super) {
                             url = this.config.appInfo.websiteBasePath
                                 .appendPath(new NormalisedURLPath__default.default(redirectInfo.path))
                                 .getAsStringDangerous();
+                            queryParams = new URLSearchParams();
                             if (context.forceSetup) {
-                                url += "?setup=true";
+                                queryParams.set("setup", "true");
+                            }
+                            if (context.stepUp) {
+                                queryParams.set("stepUp", "true");
+                            }
+                            if (queryParams.toString() !== "") {
+                                url += "?" + queryParams.toString();
                             }
                             return [2 /*return*/, url];
                         }
@@ -497,27 +511,27 @@ var MultiFactorAuth = /** @class */ (function (_super) {
     MultiFactorAuth.prototype.getSecondaryFactors = function (userContext) {
         return this.config.getSecondaryFactorInfo(this.secondaryFactors, userContext);
     };
-    MultiFactorAuth.prototype.redirectToFactor = function (factorId, forceSetup, redirectBack, navigate, userContext) {
-        if (forceSetup === void 0) {
-            forceSetup = false;
-        }
-        if (redirectBack === void 0) {
-            redirectBack = false;
-        }
+    MultiFactorAuth.prototype.redirectToFactor = function (_b) {
+        var factorId = _b.factorId,
+            forceSetup = _b.forceSetup,
+            stepUp = _b.stepUp,
+            redirectBack = _b.redirectBack,
+            navigate = _b.navigate,
+            userContext = _b.userContext;
         return genericComponentOverrideContext.__awaiter(this, void 0, void 0, function () {
             var url, redirectUrl, redirectUrl;
-            return genericComponentOverrideContext.__generator(this, function (_b) {
-                switch (_b.label) {
+            return genericComponentOverrideContext.__generator(this, function (_c) {
+                switch (_c.label) {
                     case 0:
                         return [
                             4 /*yield*/,
                             this.getRedirectUrl(
-                                { action: "GO_TO_FACTOR", forceSetup: forceSetup, factorId: factorId },
+                                { action: "GO_TO_FACTOR", forceSetup: forceSetup, stepUp: stepUp, factorId: factorId },
                                 utils.getNormalisedUserContext(userContext)
                             ),
                         ];
                     case 1:
-                        url = _b.sent();
+                        url = _c.sent();
                         if (url === null) {
                             return [2 /*return*/];
                         }
@@ -557,32 +571,28 @@ var MultiFactorAuth = /** @class */ (function (_super) {
             });
         });
     };
-    MultiFactorAuth.prototype.redirectToFactorChooser = function (
-        redirectBack,
-        nextFactorOptions,
-        navigate,
-        userContext
-    ) {
-        if (redirectBack === void 0) {
-            redirectBack = false;
-        }
-        if (nextFactorOptions === void 0) {
-            nextFactorOptions = [];
-        }
+    MultiFactorAuth.prototype.redirectToFactorChooser = function (_b) {
+        var _c = _b.redirectBack,
+            redirectBack = _c === void 0 ? false : _c,
+            _d = _b.nextFactorOptions,
+            nextFactorOptions = _d === void 0 ? [] : _d,
+            stepUp = _b.stepUp,
+            navigate = _b.navigate,
+            userContext = _b.userContext;
         return genericComponentOverrideContext.__awaiter(this, void 0, void 0, function () {
             var url, redirectUrl, redirectUrl;
-            return genericComponentOverrideContext.__generator(this, function (_b) {
-                switch (_b.label) {
+            return genericComponentOverrideContext.__generator(this, function (_e) {
+                switch (_e.label) {
                     case 0:
                         return [
                             4 /*yield*/,
                             this.getRedirectUrl(
-                                { action: "FACTOR_CHOOSER", nextFactorOptions: nextFactorOptions },
+                                { action: "FACTOR_CHOOSER", nextFactorOptions: nextFactorOptions, stepUp: stepUp },
                                 utils.getNormalisedUserContext(userContext)
                             ),
                         ];
                     case 1:
-                        url = _b.sent();
+                        url = _e.sent();
                         if (url === null) {
                             return [2 /*return*/];
                         }

--- a/lib/build/multifactorauth.js
+++ b/lib/build/multifactorauth.js
@@ -49,34 +49,26 @@ var Wrapper = /** @class */ (function () {
             })
         );
     };
-    Wrapper.redirectToFactor = function (factorId, forceSetup, redirectBack, navigate, userContext) {
-        if (forceSetup === void 0) {
-            forceSetup = false;
-        }
-        if (redirectBack === void 0) {
-            redirectBack = true;
-        }
-        return recipe.MultiFactorAuth.getInstanceOrThrow().redirectToFactor(
-            factorId,
-            forceSetup,
-            redirectBack,
-            navigate,
-            userContext
-        );
+    Wrapper.redirectToFactor = function (input) {
+        var _a, _b, _c;
+        return recipe.MultiFactorAuth.getInstanceOrThrow().redirectToFactor({
+            factorId: input.factorId,
+            forceSetup: (_a = input.forceSetup) !== null && _a !== void 0 ? _a : false,
+            redirectBack: (_b = input.redirectBack) !== null && _b !== void 0 ? _b : true,
+            stepUp: (_c = input.stepUp) !== null && _c !== void 0 ? _c : false,
+            navigate: input.navigate,
+            userContext: genericComponentOverrideContext.getNormalisedUserContext(input.userContext),
+        });
     };
-    Wrapper.redirectToFactorChooser = function (redirectBack, nextFactorOptions, navigate, userContext) {
-        if (redirectBack === void 0) {
-            redirectBack = true;
-        }
-        if (nextFactorOptions === void 0) {
-            nextFactorOptions = [];
-        }
-        return recipe.MultiFactorAuth.getInstanceOrThrow().redirectToFactorChooser(
-            redirectBack,
-            nextFactorOptions,
-            navigate,
-            userContext
-        );
+    Wrapper.redirectToFactorChooser = function (input) {
+        var _a, _b, _c;
+        return recipe.MultiFactorAuth.getInstanceOrThrow().redirectToFactorChooser({
+            nextFactorOptions: (_a = input.nextFactorOptions) !== null && _a !== void 0 ? _a : [],
+            redirectBack: (_b = input.redirectBack) !== null && _b !== void 0 ? _b : true,
+            stepUp: (_c = input.stepUp) !== null && _c !== void 0 ? _c : false,
+            navigate: input.navigate,
+            userContext: genericComponentOverrideContext.getNormalisedUserContext(input.userContext),
+        });
     };
     Wrapper.MultiFactorAuthClaim = recipe.MultiFactorAuth.MultiFactorAuthClaim;
     Wrapper.FactorIds = types.FactorIds;

--- a/lib/build/multifactorauthprebuiltui.js
+++ b/lib/build/multifactorauthprebuiltui.js
@@ -302,6 +302,7 @@ var FactorChooser$1 = function (props) {
     var recipeComponentOverrides = props.useComponentOverrides();
     var nextQueryParam =
         (_a = genericComponentOverrideContext.getQueryParams("n")) !== null && _a !== void 0 ? _a : undefined;
+    var stepUpQueryParam = genericComponentOverrideContext.getQueryParams("stepUp");
     var redirectToAuthWithHistory = React.useCallback(
         function () {
             return genericComponentOverrideContext.__awaiter(void 0, void 0, void 0, function () {
@@ -338,7 +339,7 @@ var FactorChooser$1 = function (props) {
         function (mfaInfo) {
             return genericComponentOverrideContext.__awaiter(void 0, void 0, void 0, function () {
                 return genericComponentOverrideContext.__generator(this, function (_a) {
-                    if (mfaInfo.factors.next.length === 0) {
+                    if (mfaInfo.factors.next.length === 0 && stepUpQueryParam !== "true") {
                         void types.Session.getInstanceOrThrow()
                             .validateGlobalClaimsAndHandleSuccessRedirection(
                                 undefined,
@@ -399,7 +400,14 @@ var FactorChooser$1 = function (props) {
                 action: "FACTOR_CHOOSEN",
                 factorId: factorId,
             });
-            return props.recipe.redirectToFactor(factorId, false, false, props.navigate);
+            return props.recipe.redirectToFactor({
+                factorId: factorId,
+                forceSetup: false,
+                stepUp: stepUpQueryParam === "true",
+                redirectBack: false,
+                navigate: props.navigate,
+                userContext: props.userContext,
+            });
         },
         [props.recipe]
     );

--- a/lib/build/multifactorauthprebuiltui.js
+++ b/lib/build/multifactorauthprebuiltui.js
@@ -291,6 +291,7 @@ var defaultTranslationsMultiFactorAuth = {
 var FactorChooser$1 = function (props) {
     var _a;
     var sessionContext = React.useContext(uiEntry.SessionContext);
+    var rethrowInRender = genericComponentOverrideContext.useRethrowInRender();
     var _b = React.useState(undefined),
         mfaInfo = _b[0],
         setMFAInfo = _b[1];
@@ -337,11 +338,23 @@ var FactorChooser$1 = function (props) {
         function (mfaInfo) {
             return genericComponentOverrideContext.__awaiter(void 0, void 0, void 0, function () {
                 return genericComponentOverrideContext.__generator(this, function (_a) {
-                    setMFAInfo({
-                        factors: mfaInfo.factors,
-                        phoneNumbers: mfaInfo.phoneNumbers,
-                        emails: mfaInfo.emails,
-                    });
+                    if (mfaInfo.factors.next.length === 0) {
+                        void types.Session.getInstanceOrThrow()
+                            .validateGlobalClaimsAndHandleSuccessRedirection(
+                                undefined,
+                                recipe.MultiFactorAuth.RECIPE_ID,
+                                genericComponentOverrideContext.getRedirectToPathFromURL(),
+                                userContext,
+                                props.navigate
+                            )
+                            .catch(rethrowInRender);
+                    } else {
+                        setMFAInfo({
+                            factors: mfaInfo.factors,
+                            phoneNumbers: mfaInfo.phoneNumbers,
+                            emails: mfaInfo.emails,
+                        });
+                    }
                     return [2 /*return*/];
                 });
             });

--- a/lib/build/passwordlessprebuiltui.js
+++ b/lib/build/passwordlessprebuiltui.js
@@ -4720,8 +4720,10 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                 var error,
                     errorQueryParam,
                     doSetup,
+                    stepUp,
                     loginAttemptInfo,
                     factorId,
+                    redirectToPath,
                     showBackButton,
                     contactInfoList,
                     createCodeInfo,
@@ -4729,12 +4731,13 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                     err_1,
                     invalidClaims,
                     evInstance;
-                return genericComponentOverrideContext.__generator(this, function (_b) {
-                    switch (_b.label) {
+                return genericComponentOverrideContext.__generator(this, function (_c) {
+                    switch (_c.label) {
                         case 0:
                             error = undefined;
                             errorQueryParam = genericComponentOverrideContext.getQueryParams("error");
                             doSetup = genericComponentOverrideContext.getQueryParams("setup");
+                            stepUp = genericComponentOverrideContext.getQueryParams("stepUp");
                             if (errorQueryParam !== null) {
                                 error = "SOMETHING_WENT_WRONG_ERROR";
                             }
@@ -4745,7 +4748,7 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                 }),
                             ];
                         case 1:
-                            loginAttemptInfo = _b.sent();
+                            loginAttemptInfo = _c.sent();
                             factorId =
                                 props.contactMethod === "EMAIL" ? types.FactorIds.OTP_EMAIL : types.FactorIds.OTP_PHONE;
                             if (!(loginAttemptInfo && props.contactMethod !== loginAttemptInfo.contactMethod))
@@ -4757,10 +4760,39 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                     : recipeImplementation.clearLoginAttemptInfo({ userContext: userContext }),
                             ];
                         case 2:
-                            _b.sent();
+                            _c.sent();
                             loginAttemptInfo = undefined;
-                            _b.label = 3;
+                            _c.label = 3;
                         case 3:
+                            if (!(mfaInfo.factors.next.length === 0 && stepUp !== "true")) return [3 /*break*/, 7];
+                            redirectToPath = genericComponentOverrideContext.getRedirectToPathFromURL();
+                            _c.label = 4;
+                        case 4:
+                            _c.trys.push([4, 6, , 7]);
+                            return [
+                                4 /*yield*/,
+                                types.Session.getInstanceOrThrow().validateGlobalClaimsAndHandleSuccessRedirection(
+                                    undefined,
+                                    props.recipe.recipeID,
+                                    redirectToPath,
+                                    userContext,
+                                    props.navigate
+                                ),
+                            ];
+                        case 5:
+                            _c.sent();
+                            return [3 /*break*/, 7];
+                        case 6:
+                            _c.sent();
+                            // If we couldn't redirect to EV (or an unknown claim validation failed or somehow the redirection threw an error)
+                            // we fall back to showing the something went wrong error
+                            dispatch({
+                                type: "setError",
+                                showAccessDenied: true,
+                                error: "SOMETHING_WENT_WRONG_ERROR_RELOAD",
+                            });
+                            return [3 /*break*/, 7];
+                        case 7:
                             showBackButton =
                                 mfaInfo.factors.next.length === 0 ||
                                 recipe$3.getAvailableFactors(
@@ -4773,16 +4805,16 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                 (props.contactMethod === "EMAIL"
                                     ? mfaInfo.emails[factorId]
                                     : mfaInfo.phoneNumbers[factorId]) || [];
-                            if (!!loginAttemptInfo) return [3 /*break*/, 15];
-                            if (!(contactInfoList.length > 0 && doSetup !== "true")) return [3 /*break*/, 13];
+                            if (!!loginAttemptInfo) return [3 /*break*/, 19];
+                            if (!(contactInfoList.length > 0 && doSetup !== "true")) return [3 /*break*/, 17];
                             createCodeInfo =
                                 props.contactMethod === "EMAIL"
                                     ? { email: contactInfoList[0] }
                                     : { phoneNumber: contactInfoList[0] };
                             createResp = void 0;
-                            _b.label = 4;
-                        case 4:
-                            _b.trys.push([4, 6, , 12]);
+                            _c.label = 8;
+                        case 8:
+                            _c.trys.push([8, 10, , 16]);
                             dispatch({
                                 type: "load",
                                 showAccessDenied: false,
@@ -4801,34 +4833,34 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                     )
                                 ),
                             ];
-                        case 5:
+                        case 9:
                             // createCode also dispatches the event that marks this page fully loaded
-                            createResp = _b.sent();
-                            return [3 /*break*/, 12];
-                        case 6:
-                            err_1 = _b.sent();
+                            createResp = _c.sent();
+                            return [3 /*break*/, 16];
+                        case 10:
+                            err_1 = _c.sent();
                             if (
                                 !(
                                     "status" in err_1 &&
                                     err_1.status === types.Session.getInstanceOrThrow().config.invalidClaimStatusCode
                                 )
                             )
-                                return [3 /*break*/, 11];
+                                return [3 /*break*/, 15];
                             return [
                                 4 /*yield*/,
                                 session.getInvalidClaimsFromResponse({ response: err_1, userContext: userContext }),
                             ];
-                        case 7:
-                            invalidClaims = _b.sent();
+                        case 11:
+                            invalidClaims = _c.sent();
                             if (
                                 !invalidClaims.some(function (i) {
                                     return i.id === emailverification.EmailVerificationClaim.id;
                                 })
                             )
-                                return [3 /*break*/, 11];
-                            _b.label = 8;
-                        case 8:
-                            _b.trys.push([8, 10, , 11]);
+                                return [3 /*break*/, 15];
+                            _c.label = 12;
+                        case 12:
+                            _c.trys.push([12, 14, , 15]);
                             evInstance = recipe.EmailVerification.getInstanceOrThrow();
                             return [
                                 4 /*yield*/,
@@ -4841,13 +4873,13 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                     userContext
                                 ),
                             ];
-                        case 9:
-                            _b.sent();
+                        case 13:
+                            _c.sent();
                             return [2 /*return*/];
-                        case 10:
-                            _b.sent();
-                            return [3 /*break*/, 11];
-                        case 11:
+                        case 14:
+                            _c.sent();
+                            return [3 /*break*/, 15];
+                        case 15:
                             // If it isn't a 403 or if it is not an EV claim error, we show the error
                             dispatch({
                                 type: "setError",
@@ -4855,7 +4887,7 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                 error: "SOMETHING_WENT_WRONG_ERROR_RELOAD",
                             });
                             return [2 /*return*/];
-                        case 12:
+                        case 16:
                             if ((createResp === null || createResp === void 0 ? void 0 : createResp.status) !== "OK") {
                                 dispatch({
                                     type: "setError",
@@ -4866,8 +4898,8 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                             : "SOMETHING_WENT_WRONG_ERROR_RELOAD",
                                 });
                             }
-                            return [3 /*break*/, 14];
-                        case 13:
+                            return [3 /*break*/, 18];
+                        case 17:
                             // this will ask the user for the email/phone
                             dispatch({
                                 type: "load",
@@ -4878,10 +4910,10 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                 showBackButton: showBackButton,
                                 callingCreateCode: false,
                             });
-                            _b.label = 14;
-                        case 14:
-                            return [3 /*break*/, 16];
-                        case 15:
+                            _c.label = 18;
+                        case 18:
+                            return [3 /*break*/, 20];
+                        case 19:
                             // In this branch we already have a valid login attempt so we show the OTP screen
                             dispatch({
                                 type: "load",
@@ -4892,8 +4924,8 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                 showBackButton: showBackButton,
                                 callingCreateCode: false,
                             });
-                            _b.label = 16;
-                        case 16:
+                            _c.label = 20;
+                        case 20:
                             return [2 /*return*/];
                     }
                 });

--- a/lib/build/passwordlessprebuiltui.js
+++ b/lib/build/passwordlessprebuiltui.js
@@ -4764,7 +4764,8 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                             loginAttemptInfo = undefined;
                             _c.label = 3;
                         case 3:
-                            if (!(mfaInfo.factors.next.length === 0 && stepUp !== "true")) return [3 /*break*/, 7];
+                            if (!(mfaInfo.factors.next.length === 0 && stepUp !== "true" && doSetup !== "true"))
+                                return [3 /*break*/, 7];
                             redirectToPath = genericComponentOverrideContext.getRedirectToPathFromURL();
                             _c.label = 4;
                         case 4:

--- a/lib/build/recipe/multifactorauth/index.d.ts
+++ b/lib/build/recipe/multifactorauth/index.d.ts
@@ -34,19 +34,21 @@ export default class Wrapper {
         phoneNumbers: Record<string, string[] | undefined>;
         fetchResponse: Response;
     }>;
-    static redirectToFactor(
-        factorId: string,
-        forceSetup?: boolean,
-        redirectBack?: boolean,
-        navigate?: Navigate,
-        userContext?: UserContext
-    ): Promise<void>;
-    static redirectToFactorChooser(
-        redirectBack?: boolean,
-        nextFactorOptions?: string[],
-        navigate?: Navigate,
-        userContext?: UserContext
-    ): Promise<void>;
+    static redirectToFactor(input: {
+        factorId: string;
+        forceSetup?: boolean;
+        stepUp?: boolean;
+        redirectBack?: boolean;
+        navigate?: Navigate;
+        userContext?: UserContext;
+    }): Promise<void>;
+    static redirectToFactorChooser(input: {
+        redirectBack?: boolean;
+        nextFactorOptions?: string[];
+        stepUp?: boolean;
+        navigate?: Navigate;
+        userContext?: UserContext;
+    }): Promise<void>;
     static ComponentsOverrideProvider: import("react").FC<
         import("react").PropsWithChildren<{
             components: import("./types").ComponentOverrideMap;

--- a/lib/build/recipe/multifactorauth/recipe.d.ts
+++ b/lib/build/recipe/multifactorauth/recipe.d.ts
@@ -41,18 +41,33 @@ export default class MultiFactorAuth extends RecipeModule<
     addMFAFactors(secondaryFactors: SecondaryFactorRedirectionInfo[]): void;
     isFirstFactorEnabledOnClient(factorId: string): boolean;
     getSecondaryFactors(userContext: UserContext): SecondaryFactorRedirectionInfo[];
-    redirectToFactor(
-        factorId: string,
-        forceSetup?: boolean,
-        redirectBack?: boolean,
-        navigate?: Navigate,
-        userContext?: UserContext
-    ): Promise<void>;
-    redirectToFactorChooser(
-        redirectBack?: boolean,
-        nextFactorOptions?: string[],
-        navigate?: Navigate,
-        userContext?: UserContext
-    ): Promise<void>;
+    redirectToFactor({
+        factorId,
+        forceSetup,
+        stepUp,
+        redirectBack,
+        navigate,
+        userContext,
+    }: {
+        factorId: string;
+        forceSetup: boolean | undefined;
+        stepUp: boolean | undefined;
+        redirectBack: boolean | undefined;
+        navigate: Navigate | undefined;
+        userContext: UserContext | undefined;
+    }): Promise<void>;
+    redirectToFactorChooser({
+        redirectBack,
+        nextFactorOptions,
+        stepUp,
+        navigate,
+        userContext,
+    }: {
+        redirectBack: boolean | undefined;
+        nextFactorOptions: string[] | undefined;
+        stepUp: boolean | undefined;
+        navigate: Navigate | undefined;
+        userContext: UserContext | undefined;
+    }): Promise<void>;
     static reset(): void;
 }

--- a/lib/build/recipe/multifactorauth/types.d.ts
+++ b/lib/build/recipe/multifactorauth/types.d.ts
@@ -55,11 +55,13 @@ export declare type GetRedirectionURLContext =
     | {
           action: "FACTOR_CHOOSER";
           nextFactorOptions?: string[];
+          stepUp?: boolean;
       }
     | {
           action: "GO_TO_FACTOR";
           factorId: string;
           forceSetup?: boolean;
+          stepUp?: boolean;
       };
 export declare type PreAndPostAPIHookAction = "GET_MFA_INFO";
 export declare type PreAPIHookContext = {

--- a/lib/build/totpprebuiltui.js
+++ b/lib/build/totpprebuiltui.js
@@ -3744,7 +3744,7 @@ var useFeatureReducer = function () {
         }
     );
 };
-function useOnLoad(recipeImpl, dispatch, userContext) {
+function useOnLoad(recipeImpl, dispatch, navigate, userContext) {
     var _this = this;
     var fetchMFAInfo = React__namespace.useCallback(
         function () {
@@ -3770,16 +3770,54 @@ function useOnLoad(recipeImpl, dispatch, userContext) {
     var onLoad = React__namespace.useCallback(
         function (mfaInfo) {
             return genericComponentOverrideContext.__awaiter(_this, void 0, void 0, function () {
-                var error, errorQueryParam, doSetup, alreadySetup, showBackButton, deviceInfo, createResp;
-                return genericComponentOverrideContext.__generator(this, function (_b) {
-                    switch (_b.label) {
+                var error,
+                    errorQueryParam,
+                    doSetup,
+                    stepUp,
+                    redirectToPath,
+                    alreadySetup,
+                    showBackButton,
+                    deviceInfo,
+                    createResp;
+                return genericComponentOverrideContext.__generator(this, function (_c) {
+                    switch (_c.label) {
                         case 0:
                             error = undefined;
                             errorQueryParam = genericComponentOverrideContext.getQueryParams("error");
                             doSetup = genericComponentOverrideContext.getQueryParams("setup");
+                            stepUp = genericComponentOverrideContext.getQueryParams("stepUp");
                             if (errorQueryParam !== null) {
                                 error = "SOMETHING_WENT_WRONG_ERROR";
                             }
+                            if (!(mfaInfo.factors.next.length === 0 && stepUp !== "true")) return [3 /*break*/, 4];
+                            redirectToPath = genericComponentOverrideContext.getRedirectToPathFromURL();
+                            _c.label = 1;
+                        case 1:
+                            _c.trys.push([1, 3, , 4]);
+                            return [
+                                4 /*yield*/,
+                                types.Session.getInstanceOrThrow().validateGlobalClaimsAndHandleSuccessRedirection(
+                                    undefined,
+                                    recipe.TOTP.RECIPE_ID,
+                                    redirectToPath,
+                                    userContext,
+                                    navigate
+                                ),
+                            ];
+                        case 2:
+                            _c.sent();
+                            return [3 /*break*/, 4];
+                        case 3:
+                            _c.sent();
+                            // If we couldn't redirect to EV (or an unknown claim validation failed or somehow the redirection threw an error)
+                            // we fall back to showing the something went wrong error
+                            dispatch({
+                                type: "setError",
+                                showAccessDenied: true,
+                                error: "SOMETHING_WENT_WRONG_ERROR_RELOAD",
+                            });
+                            return [3 /*break*/, 4];
+                        case 4:
                             alreadySetup = mfaInfo.factors.alreadySetup.includes(types.FactorIds.TOTP);
                             showBackButton =
                                 mfaInfo.factors.next.length === 0 ||
@@ -3789,11 +3827,11 @@ function useOnLoad(recipeImpl, dispatch, userContext) {
                                     recipe$1.MultiFactorAuth.getInstanceOrThrow(),
                                     userContext
                                 ).length !== 1;
-                            if (!(doSetup || !alreadySetup)) return [3 /*break*/, 5];
+                            if (!(doSetup || !alreadySetup)) return [3 /*break*/, 9];
                             createResp = void 0;
-                            _b.label = 1;
-                        case 1:
-                            _b.trys.push([1, 3, , 4]);
+                            _c.label = 5;
+                        case 5:
+                            _c.trys.push([5, 7, , 8]);
                             dispatch({
                                 type: "load",
                                 deviceInfo: undefined,
@@ -3803,18 +3841,18 @@ function useOnLoad(recipeImpl, dispatch, userContext) {
                                 callingCreateDevice: true,
                             });
                             return [4 /*yield*/, recipeImpl.createDevice({ userContext: userContext })];
-                        case 2:
-                            createResp = _b.sent();
-                            return [3 /*break*/, 4];
-                        case 3:
-                            _b.sent();
+                        case 6:
+                            createResp = _c.sent();
+                            return [3 /*break*/, 8];
+                        case 7:
+                            _c.sent();
                             dispatch({
                                 type: "setError",
                                 showAccessDenied: true,
                                 error: "SOMETHING_WENT_WRONG_ERROR_RELOAD",
                             });
                             return [2 /*return*/];
-                        case 4:
+                        case 8:
                             if (createResp.status !== "OK") {
                                 dispatch({
                                     type: "setError",
@@ -3825,8 +3863,8 @@ function useOnLoad(recipeImpl, dispatch, userContext) {
                             }
                             deviceInfo = genericComponentOverrideContext.__assign({}, createResp);
                             delete deviceInfo.status;
-                            _b.label = 5;
-                        case 5:
+                            _c.label = 9;
+                        case 9:
                             // No need to check if the component is unmounting, since this has no effect then.
                             dispatch({
                                 type: "load",
@@ -3959,7 +3997,7 @@ var SignInUpFeature = function (props) {
         [props.recipe]
     );
     var childProps = useChildProps(props.recipe, recipeImplementation, state, dispatch, userContext, props.navigate);
-    useOnLoad(recipeImplementation, dispatch, userContext);
+    useOnLoad(recipeImplementation, dispatch, props.navigate, userContext);
     return jsxRuntime.jsx(
         uiEntry.ComponentOverrideContext.Provider,
         genericComponentOverrideContext.__assign(

--- a/lib/build/totpprebuiltui.js
+++ b/lib/build/totpprebuiltui.js
@@ -3789,7 +3789,8 @@ function useOnLoad(recipeImpl, dispatch, navigate, userContext) {
                             if (errorQueryParam !== null) {
                                 error = "SOMETHING_WENT_WRONG_ERROR";
                             }
-                            if (!(mfaInfo.factors.next.length === 0 && stepUp !== "true")) return [3 /*break*/, 4];
+                            if (!(mfaInfo.factors.next.length === 0 && stepUp !== "true" && doSetup !== "true"))
+                                return [3 /*break*/, 4];
                             redirectToPath = genericComponentOverrideContext.getRedirectToPathFromURL();
                             _c.label = 1;
                         case 1:

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.45.1";
+export declare const package_version = "0.46.0";

--- a/lib/ts/recipe/multifactorauth/components/features/factorChooser/index.tsx
+++ b/lib/ts/recipe/multifactorauth/components/features/factorChooser/index.tsx
@@ -56,6 +56,7 @@ export const FactorChooser: React.FC<Prop> = (props) => {
     const recipeComponentOverrides = props.useComponentOverrides();
 
     const nextQueryParam = getQueryParams("n") ?? undefined;
+    const stepUpQueryParam = getQueryParams("stepUp");
 
     const redirectToAuthWithHistory = useCallback(async () => {
         await redirectToAuth({ redirectBack: false, navigate: props.navigate });
@@ -68,7 +69,7 @@ export const FactorChooser: React.FC<Prop> = (props) => {
 
     const checkMFAInfo = useCallback(
         async (mfaInfo: Awaited<ReturnType<typeof fetchMFAInfo>>): Promise<void> => {
-            if (mfaInfo.factors.next.length === 0) {
+            if (mfaInfo.factors.next.length === 0 && stepUpQueryParam !== "true") {
                 void Session.getInstanceOrThrow()
                     .validateGlobalClaimsAndHandleSuccessRedirection(
                         undefined,
@@ -108,7 +109,14 @@ export const FactorChooser: React.FC<Prop> = (props) => {
                 action: "FACTOR_CHOOSEN",
                 factorId,
             });
-            return props.recipe.redirectToFactor(factorId, false, false, props.navigate);
+            return props.recipe.redirectToFactor({
+                factorId,
+                forceSetup: false,
+                stepUp: stepUpQueryParam === "true",
+                redirectBack: false,
+                navigate: props.navigate,
+                userContext: props.userContext,
+            });
         },
         [props.recipe]
     );

--- a/lib/ts/recipe/multifactorauth/index.ts
+++ b/lib/ts/recipe/multifactorauth/index.ts
@@ -53,34 +53,38 @@ export default class Wrapper {
         });
     }
 
-    static redirectToFactor(
-        factorId: string,
-        forceSetup = false,
-        redirectBack = true,
-        navigate?: Navigate,
-        userContext?: UserContext
-    ) {
-        return MultiFactorAuthRecipe.getInstanceOrThrow().redirectToFactor(
-            factorId,
-            forceSetup,
-            redirectBack,
-            navigate,
-            userContext
-        );
+    static redirectToFactor(input: {
+        factorId: string;
+        forceSetup?: boolean;
+        stepUp?: boolean;
+        redirectBack?: boolean;
+        navigate?: Navigate;
+        userContext?: UserContext;
+    }) {
+        return MultiFactorAuthRecipe.getInstanceOrThrow().redirectToFactor({
+            factorId: input.factorId,
+            forceSetup: input.forceSetup ?? false,
+            redirectBack: input.redirectBack ?? true,
+            stepUp: input.stepUp ?? false,
+            navigate: input.navigate,
+            userContext: getNormalisedUserContext(input.userContext),
+        });
     }
 
-    static redirectToFactorChooser(
-        redirectBack = true,
-        nextFactorOptions: string[] = [],
-        navigate?: Navigate,
-        userContext?: UserContext
-    ) {
-        return MultiFactorAuthRecipe.getInstanceOrThrow().redirectToFactorChooser(
-            redirectBack,
-            nextFactorOptions,
-            navigate,
-            userContext
-        );
+    static redirectToFactorChooser(input: {
+        redirectBack?: boolean;
+        nextFactorOptions?: string[];
+        stepUp?: boolean;
+        navigate?: Navigate;
+        userContext?: UserContext;
+    }) {
+        return MultiFactorAuthRecipe.getInstanceOrThrow().redirectToFactorChooser({
+            nextFactorOptions: input.nextFactorOptions ?? [],
+            redirectBack: input.redirectBack ?? true,
+            stepUp: input.stepUp ?? false,
+            navigate: input.navigate,
+            userContext: getNormalisedUserContext(input.userContext),
+        });
     }
 
     static ComponentsOverrideProvider = RecipeComponentsOverrideContextProvider;

--- a/lib/ts/recipe/multifactorauth/recipe.tsx
+++ b/lib/ts/recipe/multifactorauth/recipe.tsx
@@ -151,8 +151,15 @@ export default class MultiFactorAuth extends RecipeModule<
         if (context.action === "FACTOR_CHOOSER") {
             const chooserPath = new NormalisedURLPath(DEFAULT_FACTOR_CHOOSER_PATH);
             let url = this.config.appInfo.websiteBasePath.appendPath(chooserPath).getAsStringDangerous();
+            const queryParams = new URLSearchParams();
             if (context.nextFactorOptions && context.nextFactorOptions.length > 0) {
-                url += `?n=${context.nextFactorOptions.join(",")}`;
+                queryParams.set("n", context.nextFactorOptions.join(","));
+            }
+            if (context.stepUp) {
+                queryParams.set("stepUp", "true");
+            }
+            if (queryParams.toString() !== "") {
+                url += "?" + queryParams.toString();
             }
             return url;
         } else if (context.action === "GO_TO_FACTOR") {
@@ -161,8 +168,15 @@ export default class MultiFactorAuth extends RecipeModule<
                 let url = this.config.appInfo.websiteBasePath
                     .appendPath(new NormalisedURLPath(redirectInfo.path))
                     .getAsStringDangerous();
+                const queryParams = new URLSearchParams();
                 if (context.forceSetup) {
-                    url += "?setup=true";
+                    queryParams.set("setup", "true");
+                }
+                if (context.stepUp) {
+                    queryParams.set("stepUp", "true");
+                }
+                if (queryParams.toString() !== "") {
+                    url += "?" + queryParams.toString();
                 }
                 return url;
             }
@@ -189,15 +203,23 @@ export default class MultiFactorAuth extends RecipeModule<
         return this.config.getSecondaryFactorInfo(this.secondaryFactors, userContext);
     }
 
-    async redirectToFactor(
-        factorId: string,
-        forceSetup = false,
-        redirectBack = false,
-        navigate?: Navigate,
-        userContext?: UserContext
-    ) {
+    async redirectToFactor({
+        factorId,
+        forceSetup,
+        stepUp,
+        redirectBack,
+        navigate,
+        userContext,
+    }: {
+        factorId: string;
+        forceSetup: boolean | undefined;
+        stepUp: boolean | undefined;
+        redirectBack: boolean | undefined;
+        navigate: Navigate | undefined;
+        userContext: UserContext | undefined;
+    }) {
         let url = await this.getRedirectUrl(
-            { action: "GO_TO_FACTOR", forceSetup, factorId },
+            { action: "GO_TO_FACTOR", forceSetup, stepUp, factorId },
             getNormalisedUserContext(userContext)
         );
         if (url === null) {
@@ -226,14 +248,21 @@ export default class MultiFactorAuth extends RecipeModule<
         return SuperTokens.getInstanceOrThrow().redirectToUrl(url, navigate);
     }
 
-    async redirectToFactorChooser(
+    async redirectToFactorChooser({
         redirectBack = false,
-        nextFactorOptions: string[] = [],
-        navigate?: Navigate,
-        userContext?: UserContext
-    ) {
+        nextFactorOptions = [],
+        stepUp,
+        navigate,
+        userContext,
+    }: {
+        redirectBack: boolean | undefined;
+        nextFactorOptions: string[] | undefined;
+        stepUp: boolean | undefined;
+        navigate: Navigate | undefined;
+        userContext: UserContext | undefined;
+    }) {
         let url = await this.getRedirectUrl(
-            { action: "FACTOR_CHOOSER", nextFactorOptions },
+            { action: "FACTOR_CHOOSER", nextFactorOptions, stepUp },
             getNormalisedUserContext(userContext)
         );
 

--- a/lib/ts/recipe/multifactorauth/types.ts
+++ b/lib/ts/recipe/multifactorauth/types.ts
@@ -79,11 +79,13 @@ export type GetRedirectionURLContext =
     | {
           action: "FACTOR_CHOOSER";
           nextFactorOptions?: string[];
+          stepUp?: boolean;
       }
     | {
           action: "GO_TO_FACTOR";
           factorId: string;
           forceSetup?: boolean;
+          stepUp?: boolean;
       };
 
 export type PreAndPostAPIHookAction = "GET_MFA_INFO";

--- a/lib/ts/recipe/passwordless/components/features/mfa/index.tsx
+++ b/lib/ts/recipe/passwordless/components/features/mfa/index.tsx
@@ -320,7 +320,7 @@ function useOnLoad(
                 loginAttemptInfo = undefined;
             }
 
-            if (mfaInfo.factors.next.length === 0 && stepUp !== "true") {
+            if (mfaInfo.factors.next.length === 0 && stepUp !== "true" && doSetup !== "true") {
                 const redirectToPath = getRedirectToPathFromURL();
                 try {
                     await SessionRecipe.getInstanceOrThrow().validateGlobalClaimsAndHandleSuccessRedirection(

--- a/lib/ts/recipe/passwordless/components/features/mfa/index.tsx
+++ b/lib/ts/recipe/passwordless/components/features/mfa/index.tsx
@@ -303,6 +303,7 @@ function useOnLoad(
             let error: string | undefined = undefined;
             const errorQueryParam = getQueryParams("error");
             const doSetup = getQueryParams("setup");
+            const stepUp = getQueryParams("stepUp");
             if (errorQueryParam !== null) {
                 error = "SOMETHING_WENT_WRONG_ERROR";
             }
@@ -317,6 +318,27 @@ function useOnLoad(
             if (loginAttemptInfo && props.contactMethod !== loginAttemptInfo.contactMethod) {
                 await recipeImplementation?.clearLoginAttemptInfo({ userContext });
                 loginAttemptInfo = undefined;
+            }
+
+            if (mfaInfo.factors.next.length === 0 && stepUp !== "true") {
+                const redirectToPath = getRedirectToPathFromURL();
+                try {
+                    await SessionRecipe.getInstanceOrThrow().validateGlobalClaimsAndHandleSuccessRedirection(
+                        undefined,
+                        props.recipe.recipeID,
+                        redirectToPath,
+                        userContext,
+                        props.navigate
+                    );
+                } catch {
+                    // If we couldn't redirect to EV (or an unknown claim validation failed or somehow the redirection threw an error)
+                    // we fall back to showing the something went wrong error
+                    dispatch({
+                        type: "setError",
+                        showAccessDenied: true,
+                        error: "SOMETHING_WENT_WRONG_ERROR_RELOAD",
+                    });
+                }
             }
 
             // If the next array only has a single option, it means the we were redirected here

--- a/lib/ts/recipe/totp/components/features/mfa/index.tsx
+++ b/lib/ts/recipe/totp/components/features/mfa/index.tsx
@@ -30,6 +30,7 @@ import MultiFactorAuth from "../../../../multifactorauth/recipe";
 import { FactorIds } from "../../../../multifactorauth/types";
 import { getAvailableFactors } from "../../../../multifactorauth/utils";
 import SessionRecipe from "../../../../session/recipe";
+import TOTP from "../../../recipe";
 import MFATOTPThemeWrapper from "../../themes/mfa";
 import { defaultTranslationsTOTP } from "../../themes/translations";
 
@@ -124,7 +125,12 @@ export const useFeatureReducer = (): [TOTPMFAState, React.Dispatch<TOTPMFAAction
     );
 };
 
-function useOnLoad(recipeImpl: RecipeInterface, dispatch: React.Dispatch<TOTPMFAAction>, userContext: UserContext) {
+function useOnLoad(
+    recipeImpl: RecipeInterface,
+    dispatch: React.Dispatch<TOTPMFAAction>,
+    navigate: Navigate | undefined,
+    userContext: UserContext
+) {
     const fetchMFAInfo = React.useCallback(
         async () => MultiFactorAuth.getInstanceOrThrow().webJSRecipe.resyncSessionAndFetchMFAInfo({ userContext }),
         [userContext]
@@ -139,9 +145,32 @@ function useOnLoad(recipeImpl: RecipeInterface, dispatch: React.Dispatch<TOTPMFA
             let error: string | undefined = undefined;
             const errorQueryParam = getQueryParams("error");
             const doSetup = getQueryParams("setup");
+            const stepUp = getQueryParams("stepUp");
             if (errorQueryParam !== null) {
                 error = "SOMETHING_WENT_WRONG_ERROR";
             }
+
+            if (mfaInfo.factors.next.length === 0 && stepUp !== "true") {
+                const redirectToPath = getRedirectToPathFromURL();
+                try {
+                    await SessionRecipe.getInstanceOrThrow().validateGlobalClaimsAndHandleSuccessRedirection(
+                        undefined,
+                        TOTP.RECIPE_ID,
+                        redirectToPath,
+                        userContext,
+                        navigate
+                    );
+                } catch {
+                    // If we couldn't redirect to EV (or an unknown claim validation failed or somehow the redirection threw an error)
+                    // we fall back to showing the something went wrong error
+                    dispatch({
+                        type: "setError",
+                        showAccessDenied: true,
+                        error: "SOMETHING_WENT_WRONG_ERROR_RELOAD",
+                    });
+                }
+            }
+
             const alreadySetup = mfaInfo.factors.alreadySetup.includes(FactorIds.TOTP);
 
             // If the next array only has a single option, it means the we were redirected here
@@ -280,7 +309,7 @@ export const SignInUpFeature: React.FC<
         [props.recipe]
     );
     const childProps = useChildProps(props.recipe, recipeImplementation, state, dispatch, userContext, props.navigate)!;
-    useOnLoad(recipeImplementation, dispatch, userContext);
+    useOnLoad(recipeImplementation, dispatch, props.navigate, userContext);
 
     return (
         <ComponentOverrideContext.Provider value={recipeComponentOverrides}>

--- a/lib/ts/recipe/totp/components/features/mfa/index.tsx
+++ b/lib/ts/recipe/totp/components/features/mfa/index.tsx
@@ -150,7 +150,7 @@ function useOnLoad(
                 error = "SOMETHING_WENT_WRONG_ERROR";
             }
 
-            if (mfaInfo.factors.next.length === 0 && stepUp !== "true") {
+            if (mfaInfo.factors.next.length === 0 && stepUp !== "true" && doSetup !== "true") {
                 const redirectToPath = getRedirectToPathFromURL();
                 try {
                     await SessionRecipe.getInstanceOrThrow().validateGlobalClaimsAndHandleSuccessRedirection(

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.45.1";
+export const package_version = "0.46.0";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.45.1",
+    "version": "0.46.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.45.1",
+            "version": "0.46.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.45.1",
+    "version": "0.46.0",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {
@@ -141,7 +141,7 @@
         },
         {
             "path": "recipe/session/index.js",
-            "limit": "24kb"
+            "limit": "24.5kb"
         },
         {
             "path": "recipe/session/prebuiltui.js",

--- a/test/end-to-end/mfa.factorscreen.otp.test.js
+++ b/test/end-to-end/mfa.factorscreen.otp.test.js
@@ -449,7 +449,7 @@ describe("SuperTokens SignIn w/ MFA", function () {
                     await completeOTP(page);
                 });
 
-                it("should show a link redirecting back if visited after sign in - setup", async () => {
+                it("should show a link redirecting back if visited after sign in without stepUp param", async () => {
                     await setMFAInfo({
                         requirements: [],
                         alreadySetup: [factorId],
@@ -462,11 +462,27 @@ describe("SuperTokens SignIn w/ MFA", function () {
                         page.goto(`${TEST_CLIENT_BASE_URL}/auth/mfa/${factorId}`),
                         page.waitForNavigation({ waitUntil: "networkidle0" }),
                     ]);
+                    await waitForDashboard(page);
+                });
+
+                it("should show a link redirecting back if visited after sign in - force setup", async () => {
+                    await setMFAInfo({
+                        requirements: [],
+                        alreadySetup: [factorId],
+                        allowedToSetup: [factorId],
+                    });
+
+                    await tryEmailPasswordSignIn(page, email);
+
+                    await Promise.all([
+                        page.goto(`${TEST_CLIENT_BASE_URL}/auth/mfa/${factorId}?setup=true`),
+                        page.waitForNavigation({ waitUntil: "networkidle0" }),
+                    ]);
                     const backBtn = await waitForSTElement(page, "[data-supertokens~=backButton]");
                     await backBtn.click();
                     await waitForDashboard(page);
                 });
-                it("should show a link redirecting back if visited after sign in - verification", async () => {
+                it("should show a link redirecting back if visited after sign in - setup in stepUp", async () => {
                     await setMFAInfo({
                         requirements: [],
                         alreadySetup: [],
@@ -476,7 +492,25 @@ describe("SuperTokens SignIn w/ MFA", function () {
                     await tryEmailPasswordSignIn(page, email);
 
                     await Promise.all([
-                        page.goto(`${TEST_CLIENT_BASE_URL}/auth/mfa/${factorId}`),
+                        page.goto(`${TEST_CLIENT_BASE_URL}/auth/mfa/${factorId}?stepUp=true`),
+                        page.waitForNavigation({ waitUntil: "networkidle0" }),
+                    ]);
+                    const backBtn = await waitForSTElement(page, "[data-supertokens~=backButton]");
+                    await backBtn.click();
+                    await waitForDashboard(page);
+                });
+
+                it("should show a link redirecting back if visited after sign in - verification in stepUp", async () => {
+                    await setMFAInfo({
+                        requirements: [],
+                        alreadySetup: [factorId],
+                        allowedToSetup: [],
+                    });
+
+                    await tryEmailPasswordSignIn(page, email);
+
+                    await Promise.all([
+                        page.goto(`${TEST_CLIENT_BASE_URL}/auth/mfa/${factorId}?stepUp=true`),
                         page.waitForNavigation({ waitUntil: "networkidle0" }),
                     ]);
                     const backBtn = await waitForSTElement(page, "[data-supertokens~=backButton]");

--- a/test/end-to-end/mfa.factorscreen.totp.test.js
+++ b/test/end-to-end/mfa.factorscreen.totp.test.js
@@ -331,7 +331,7 @@ describe("SuperTokens SignIn w/ MFA", function () {
                 }
             });
 
-            it("should show a link redirecting back if visited after sign in - setup", async () => {
+            it("should redirect back if visited after sign in without stepUp param", async () => {
                 await setMFAInfo({
                     requirements: [],
                     alreadySetup: [factorId],
@@ -344,12 +344,28 @@ describe("SuperTokens SignIn w/ MFA", function () {
                     page.goto(`${TEST_CLIENT_BASE_URL}/auth/mfa/${factorId}`),
                     page.waitForNavigation({ waitUntil: "networkidle0" }),
                 ]);
+                await waitForDashboard(page);
+            });
+
+            it("should show a link redirecting back if visited after sign in - force setup", async () => {
+                await setMFAInfo({
+                    requirements: [],
+                    alreadySetup: [factorId],
+                    allowedToSetup: [factorId],
+                });
+
+                await tryEmailPasswordSignIn(page, email);
+
+                await Promise.all([
+                    page.goto(`${TEST_CLIENT_BASE_URL}/auth/mfa/${factorId}?setup=true`),
+                    page.waitForNavigation({ waitUntil: "networkidle0" }),
+                ]);
                 const backBtn = await waitForSTElement(page, "[data-supertokens~=backButton]");
                 await backBtn.click();
                 await waitForDashboard(page);
             });
 
-            it("should show a link redirecting back if visited after sign in - verification", async () => {
+            it("should show a link redirecting back if visited after sign in - setup in stepUp", async () => {
                 await setMFAInfo({
                     requirements: [],
                     alreadySetup: [],
@@ -359,7 +375,25 @@ describe("SuperTokens SignIn w/ MFA", function () {
                 await tryEmailPasswordSignIn(page, email);
 
                 await Promise.all([
-                    page.goto(`${TEST_CLIENT_BASE_URL}/auth/mfa/${factorId}`),
+                    page.goto(`${TEST_CLIENT_BASE_URL}/auth/mfa/${factorId}?stepUp=true`),
+                    page.waitForNavigation({ waitUntil: "networkidle0" }),
+                ]);
+                const backBtn = await waitForSTElement(page, "[data-supertokens~=backButton]");
+                await backBtn.click();
+                await waitForDashboard(page);
+            });
+
+            it("should show a link redirecting back if visited after sign in - verification in stepUp", async () => {
+                await setMFAInfo({
+                    requirements: [],
+                    alreadySetup: [factorId],
+                    allowedToSetup: [],
+                });
+
+                await tryEmailPasswordSignIn(page, email);
+
+                await Promise.all([
+                    page.goto(`${TEST_CLIENT_BASE_URL}/auth/mfa/${factorId}?stepUp=true`),
                     page.waitForNavigation({ waitUntil: "networkidle0" }),
                 ]);
                 const backBtn = await waitForSTElement(page, "[data-supertokens~=backButton]");


### PR DESCRIPTION
## Summary of change

-   Changed `redirectToFactor` to accept an object instead of multiple arguments.
-   Changed `redirectToFactorChooser` to accept an object instead of multiple arguments.
-   Made MFA related screens do a success redirection if MFA is already completed and the `stepUp` query param is not set to `true`.
    -   `redirectToFactorChooser` now accepts a `stepUp` option to set the `stepUp` query param.
    -   `redirectToFactor` now accepts a `stepUp` option to set the `stepUp` query param.

## Related issues

-   

## Test Plan

Updated existing tests/the test app to use the stepUp query param by default
Added new tests that check the redirection happens if the new query param is not added

## Documentation changes

Docs [PR](https://github.com/supertokens/docs/pull/836)

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [x] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [x] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [x] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`
