### PR TITLE
feat!: make passwordless link sent, otp input and mfa screens clear the login attempt info if it is missing some props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Breaking changes
+
+-   The prebuilt UI now clears the login attempt info if the stored data doesn't contain all the required properties. This should help migration from a custom UI to the prebuilt UI.
+
 ## [0.45.1] - 2024-08-09
 
 ### Changes

--- a/lib/build/passwordless-shared.js
+++ b/lib/build/passwordless-shared.js
@@ -401,6 +401,16 @@ function normalisePasswordlessBaseConfig(config) {
         style: style,
     });
 }
+function checkAdditionalLoginAttemptInfoProperties(loginAttemptInfo) {
+    if (
+        loginAttemptInfo.contactInfo === undefined ||
+        loginAttemptInfo.contactMethod === undefined ||
+        loginAttemptInfo.lastResend === undefined
+    ) {
+        return false;
+    }
+    return true;
+}
 
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *
@@ -532,6 +542,7 @@ var Passwordless = /** @class */ (function (_super) {
 
 exports.Passwordless = Passwordless;
 exports.Provider = Provider;
+exports.checkAdditionalLoginAttemptInfoProperties = checkAdditionalLoginAttemptInfoProperties;
 exports.defaultValidate = defaultValidate;
 exports.useContext = useContext;
 exports.userInputCodeValidate = userInputCodeValidate;

--- a/lib/build/passwordlessprebuiltui.js
+++ b/lib/build/passwordlessprebuiltui.js
@@ -4761,6 +4761,24 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                             loginAttemptInfo = undefined;
                             _b.label = 3;
                         case 3:
+                            if (
+                                !(
+                                    loginAttemptInfo !== undefined &&
+                                    !recipe$2.checkAdditionalLoginAttemptInfoProperties(loginAttemptInfo)
+                                )
+                            )
+                                return [3 /*break*/, 5];
+                            return [
+                                4 /*yield*/,
+                                recipeImplementation === null || recipeImplementation === void 0
+                                    ? void 0
+                                    : recipeImplementation.clearLoginAttemptInfo({ userContext: userContext }),
+                            ];
+                        case 4:
+                            _b.sent();
+                            loginAttemptInfo = undefined;
+                            _b.label = 5;
+                        case 5:
                             showBackButton =
                                 mfaInfo.factors.next.length === 0 ||
                                 recipe$3.getAvailableFactors(
@@ -4773,16 +4791,16 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                 (props.contactMethod === "EMAIL"
                                     ? mfaInfo.emails[factorId]
                                     : mfaInfo.phoneNumbers[factorId]) || [];
-                            if (!!loginAttemptInfo) return [3 /*break*/, 15];
-                            if (!(contactInfoList.length > 0 && doSetup !== "true")) return [3 /*break*/, 13];
+                            if (!!loginAttemptInfo) return [3 /*break*/, 17];
+                            if (!(contactInfoList.length > 0 && doSetup !== "true")) return [3 /*break*/, 15];
                             createCodeInfo =
                                 props.contactMethod === "EMAIL"
                                     ? { email: contactInfoList[0] }
                                     : { phoneNumber: contactInfoList[0] };
                             createResp = void 0;
-                            _b.label = 4;
-                        case 4:
-                            _b.trys.push([4, 6, , 12]);
+                            _b.label = 6;
+                        case 6:
+                            _b.trys.push([6, 8, , 14]);
                             dispatch({
                                 type: "load",
                                 showAccessDenied: false,
@@ -4801,11 +4819,11 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                     )
                                 ),
                             ];
-                        case 5:
+                        case 7:
                             // createCode also dispatches the event that marks this page fully loaded
                             createResp = _b.sent();
-                            return [3 /*break*/, 12];
-                        case 6:
+                            return [3 /*break*/, 14];
+                        case 8:
                             err_1 = _b.sent();
                             if (
                                 !(
@@ -4813,22 +4831,22 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                     err_1.status === types.Session.getInstanceOrThrow().config.invalidClaimStatusCode
                                 )
                             )
-                                return [3 /*break*/, 11];
+                                return [3 /*break*/, 13];
                             return [
                                 4 /*yield*/,
                                 session.getInvalidClaimsFromResponse({ response: err_1, userContext: userContext }),
                             ];
-                        case 7:
+                        case 9:
                             invalidClaims = _b.sent();
                             if (
                                 !invalidClaims.some(function (i) {
                                     return i.id === emailverification.EmailVerificationClaim.id;
                                 })
                             )
-                                return [3 /*break*/, 11];
-                            _b.label = 8;
-                        case 8:
-                            _b.trys.push([8, 10, , 11]);
+                                return [3 /*break*/, 13];
+                            _b.label = 10;
+                        case 10:
+                            _b.trys.push([10, 12, , 13]);
                             evInstance = recipe.EmailVerification.getInstanceOrThrow();
                             return [
                                 4 /*yield*/,
@@ -4841,13 +4859,13 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                     userContext
                                 ),
                             ];
-                        case 9:
+                        case 11:
                             _b.sent();
                             return [2 /*return*/];
-                        case 10:
+                        case 12:
                             _b.sent();
-                            return [3 /*break*/, 11];
-                        case 11:
+                            return [3 /*break*/, 13];
+                        case 13:
                             // If it isn't a 403 or if it is not an EV claim error, we show the error
                             dispatch({
                                 type: "setError",
@@ -4855,7 +4873,7 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                 error: "SOMETHING_WENT_WRONG_ERROR_RELOAD",
                             });
                             return [2 /*return*/];
-                        case 12:
+                        case 14:
                             if ((createResp === null || createResp === void 0 ? void 0 : createResp.status) !== "OK") {
                                 dispatch({
                                     type: "setError",
@@ -4866,8 +4884,8 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                             : "SOMETHING_WENT_WRONG_ERROR_RELOAD",
                                 });
                             }
-                            return [3 /*break*/, 14];
-                        case 13:
+                            return [3 /*break*/, 16];
+                        case 15:
                             // this will ask the user for the email/phone
                             dispatch({
                                 type: "load",
@@ -4878,10 +4896,10 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                 showBackButton: showBackButton,
                                 callingCreateCode: false,
                             });
-                            _b.label = 14;
-                        case 14:
-                            return [3 /*break*/, 16];
-                        case 15:
+                            _b.label = 16;
+                        case 16:
+                            return [3 /*break*/, 18];
+                        case 17:
                             // In this branch we already have a valid login attempt so we show the OTP screen
                             dispatch({
                                 type: "load",
@@ -4892,8 +4910,8 @@ function useOnLoad(props, recipeImplementation, dispatch, userContext) {
                                 showBackButton: showBackButton,
                                 callingCreateCode: false,
                             });
-                            _b.label = 16;
-                        case 16:
+                            _b.label = 18;
+                        case 18:
                             return [2 /*return*/];
                     }
                 });
@@ -6939,11 +6957,11 @@ var PasswordlessPreBuiltUI = /** @class */ (function (_super) {
                     {
                         type: "FULL_PAGE",
                         preloadInfoAndRunChecks: function (firstFactors, userContext) {
-                            var _b, _c;
+                            var _b, _c, _d;
                             return genericComponentOverrideContext.__awaiter(this, void 0, void 0, function () {
                                 var loginAttemptInfo;
-                                return genericComponentOverrideContext.__generator(this, function (_d) {
-                                    switch (_d.label) {
+                                return genericComponentOverrideContext.__generator(this, function (_e) {
+                                    switch (_e.label) {
                                         case 0:
                                             return [
                                                 4 /*yield*/,
@@ -6954,8 +6972,8 @@ var PasswordlessPreBuiltUI = /** @class */ (function (_super) {
                                                 ),
                                             ];
                                         case 1:
-                                            loginAttemptInfo = _d.sent();
-                                            if (!(loginAttemptInfo !== undefined)) return [3 /*break*/, 5];
+                                            loginAttemptInfo = _e.sent();
+                                            if (!(loginAttemptInfo !== undefined)) return [3 /*break*/, 7];
                                             if (
                                                 !(
                                                     loginAttemptInfo.contactMethod === "PHONE" &&
@@ -6972,9 +6990,9 @@ var PasswordlessPreBuiltUI = /** @class */ (function (_super) {
                                                     : _b.clearLoginAttemptInfo({ userContext: userContext }),
                                             ];
                                         case 2:
-                                            _d.sent();
+                                            _e.sent();
                                             loginAttemptInfo = undefined;
-                                            return [3 /*break*/, 5];
+                                            return [3 /*break*/, 7];
                                         case 3:
                                             if (
                                                 !(
@@ -6992,10 +7010,32 @@ var PasswordlessPreBuiltUI = /** @class */ (function (_super) {
                                                     : _c.clearLoginAttemptInfo({ userContext: userContext }),
                                             ];
                                         case 4:
-                                            _d.sent();
+                                            _e.sent();
                                             loginAttemptInfo = undefined;
-                                            _d.label = 5;
+                                            return [3 /*break*/, 7];
                                         case 5:
+                                            if (!!recipe$2.checkAdditionalLoginAttemptInfoProperties(loginAttemptInfo))
+                                                return [3 /*break*/, 7];
+                                            // If these properties are not set, it means that the user likely started logging in
+                                            // using a custom UI and then switched to the pre-built UI. In that case, we should clear
+                                            // the login attempt info so that the user is prompted to login again, since the pre-built UI
+                                            // requires these properties to be set in order to show the correct UI.
+                                            return [
+                                                4 /*yield*/,
+                                                (_d = recipe$2.Passwordless.getInstanceOrThrow().webJSRecipe) ===
+                                                    null || _d === void 0
+                                                    ? void 0
+                                                    : _d.clearLoginAttemptInfo({ userContext: userContext }),
+                                            ];
+                                        case 6:
+                                            // If these properties are not set, it means that the user likely started logging in
+                                            // using a custom UI and then switched to the pre-built UI. In that case, we should clear
+                                            // the login attempt info so that the user is prompted to login again, since the pre-built UI
+                                            // requires these properties to be set in order to show the correct UI.
+                                            _e.sent();
+                                            loginAttemptInfo = undefined;
+                                            _e.label = 7;
+                                        case 7:
                                             if (
                                                 loginAttemptInfo === undefined ||
                                                 loginAttemptInfo.flowType !== "MAGIC_LINK"
@@ -7035,11 +7075,11 @@ var PasswordlessPreBuiltUI = /** @class */ (function (_super) {
                     {
                         type: "FULL_PAGE",
                         preloadInfoAndRunChecks: function (firstFactors, userContext) {
-                            var _b, _c;
+                            var _b, _c, _d;
                             return genericComponentOverrideContext.__awaiter(this, void 0, void 0, function () {
                                 var loginAttemptInfo;
-                                return genericComponentOverrideContext.__generator(this, function (_d) {
-                                    switch (_d.label) {
+                                return genericComponentOverrideContext.__generator(this, function (_e) {
+                                    switch (_e.label) {
                                         case 0:
                                             return [
                                                 4 /*yield*/,
@@ -7050,8 +7090,8 @@ var PasswordlessPreBuiltUI = /** @class */ (function (_super) {
                                                 ),
                                             ];
                                         case 1:
-                                            loginAttemptInfo = _d.sent();
-                                            if (!(loginAttemptInfo !== undefined)) return [3 /*break*/, 5];
+                                            loginAttemptInfo = _e.sent();
+                                            if (!(loginAttemptInfo !== undefined)) return [3 /*break*/, 7];
                                             if (
                                                 !(
                                                     loginAttemptInfo.contactMethod === "PHONE" &&
@@ -7068,9 +7108,9 @@ var PasswordlessPreBuiltUI = /** @class */ (function (_super) {
                                                     : _b.clearLoginAttemptInfo({ userContext: userContext }),
                                             ];
                                         case 2:
-                                            _d.sent();
+                                            _e.sent();
                                             loginAttemptInfo = undefined;
-                                            return [3 /*break*/, 5];
+                                            return [3 /*break*/, 7];
                                         case 3:
                                             if (
                                                 !(
@@ -7088,10 +7128,32 @@ var PasswordlessPreBuiltUI = /** @class */ (function (_super) {
                                                     : _c.clearLoginAttemptInfo({ userContext: userContext }),
                                             ];
                                         case 4:
-                                            _d.sent();
+                                            _e.sent();
                                             loginAttemptInfo = undefined;
-                                            _d.label = 5;
+                                            return [3 /*break*/, 7];
                                         case 5:
+                                            if (!!recipe$2.checkAdditionalLoginAttemptInfoProperties(loginAttemptInfo))
+                                                return [3 /*break*/, 7];
+                                            // If these properties are not set, it means that the user likely started logging in
+                                            // using a custom UI and then switched to the pre-built UI. In that case, we should clear
+                                            // the login attempt info so that the user is prompted to login again, since the pre-built UI
+                                            // requires these properties to be set in order to show the correct UI.
+                                            return [
+                                                4 /*yield*/,
+                                                (_d = recipe$2.Passwordless.getInstanceOrThrow().webJSRecipe) ===
+                                                    null || _d === void 0
+                                                    ? void 0
+                                                    : _d.clearLoginAttemptInfo({ userContext: userContext }),
+                                            ];
+                                        case 6:
+                                            // If these properties are not set, it means that the user likely started logging in
+                                            // using a custom UI and then switched to the pre-built UI. In that case, we should clear
+                                            // the login attempt info so that the user is prompted to login again, since the pre-built UI
+                                            // requires these properties to be set in order to show the correct UI.
+                                            _e.sent();
+                                            loginAttemptInfo = undefined;
+                                            _e.label = 7;
+                                        case 7:
                                             if (
                                                 loginAttemptInfo === undefined ||
                                                 loginAttemptInfo.flowType === "MAGIC_LINK"

--- a/lib/build/recipe/passwordless/utils.d.ts
+++ b/lib/build/recipe/passwordless/utils.d.ts
@@ -1,2 +1,3 @@
-import type { Config, NormalisedConfig } from "./types";
+import type { Config, LoginAttemptInfo, NormalisedConfig } from "./types";
 export declare function normalisePasswordlessConfig(config: Config): NormalisedConfig;
+export declare function checkAdditionalLoginAttemptInfoProperties(loginAttemptInfo: LoginAttemptInfo): boolean;

--- a/lib/ts/recipe/passwordless/components/features/mfa/index.tsx
+++ b/lib/ts/recipe/passwordless/components/features/mfa/index.tsx
@@ -43,6 +43,7 @@ import SessionRecipe from "../../../../session/recipe";
 import Session from "../../../../session/recipe";
 import { defaultPhoneNumberValidator } from "../../../defaultPhoneNumberValidator";
 import { getPhoneNumberUtils } from "../../../phoneNumberUtils";
+import { checkAdditionalLoginAttemptInfoProperties } from "../../../utils";
 import MFAThemeWrapper from "../../themes/mfa";
 import { defaultTranslationsPasswordless } from "../../themes/translations";
 
@@ -315,6 +316,11 @@ function useOnLoad(
             const factorId = props.contactMethod === "EMAIL" ? FactorIds.OTP_EMAIL : FactorIds.OTP_PHONE;
 
             if (loginAttemptInfo && props.contactMethod !== loginAttemptInfo.contactMethod) {
+                await recipeImplementation?.clearLoginAttemptInfo({ userContext });
+                loginAttemptInfo = undefined;
+            }
+
+            if (loginAttemptInfo !== undefined && !checkAdditionalLoginAttemptInfoProperties(loginAttemptInfo)) {
                 await recipeImplementation?.clearLoginAttemptInfo({ userContext });
                 loginAttemptInfo = undefined;
             }

--- a/lib/ts/recipe/passwordless/prebuiltui.tsx
+++ b/lib/ts/recipe/passwordless/prebuiltui.tsx
@@ -18,6 +18,7 @@ import UserInputCodeFeature from "./components/features/userInputCode";
 import MFAThemeWrapper from "./components/themes/mfa";
 import { defaultTranslationsPasswordless } from "./components/themes/translations";
 import Passwordless from "./recipe";
+import { checkAdditionalLoginAttemptInfoProperties } from "./utils";
 
 import type { AdditionalLoginAttemptInfoProperties, LoginAttemptInfo } from "./types";
 import type { GenericComponentOverrideMap } from "../../components/componentOverride/componentOverrideContext";
@@ -187,6 +188,13 @@ export class PasswordlessPreBuiltUI extends RecipeRouter {
                         ) {
                             await Passwordless.getInstanceOrThrow().webJSRecipe?.clearLoginAttemptInfo({ userContext });
                             loginAttemptInfo = undefined;
+                        } else if (!checkAdditionalLoginAttemptInfoProperties(loginAttemptInfo)) {
+                            // If these properties are not set, it means that the user likely started logging in
+                            // using a custom UI and then switched to the pre-built UI. In that case, we should clear
+                            // the login attempt info so that the user is prompted to login again, since the pre-built UI
+                            // requires these properties to be set in order to show the correct UI.
+                            await Passwordless.getInstanceOrThrow().webJSRecipe?.clearLoginAttemptInfo({ userContext });
+                            loginAttemptInfo = undefined;
                         }
                     }
 
@@ -232,6 +240,13 @@ export class PasswordlessPreBuiltUI extends RecipeRouter {
                             !firstFactors.includes(FactorIds.OTP_EMAIL) &&
                             !firstFactors.includes(FactorIds.LINK_EMAIL)
                         ) {
+                            await Passwordless.getInstanceOrThrow().webJSRecipe?.clearLoginAttemptInfo({ userContext });
+                            loginAttemptInfo = undefined;
+                        } else if (!checkAdditionalLoginAttemptInfoProperties(loginAttemptInfo)) {
+                            // If these properties are not set, it means that the user likely started logging in
+                            // using a custom UI and then switched to the pre-built UI. In that case, we should clear
+                            // the login attempt info so that the user is prompted to login again, since the pre-built UI
+                            // requires these properties to be set in order to show the correct UI.
                             await Passwordless.getInstanceOrThrow().webJSRecipe?.clearLoginAttemptInfo({ userContext });
                             loginAttemptInfo = undefined;
                         }

--- a/lib/ts/recipe/passwordless/utils.ts
+++ b/lib/ts/recipe/passwordless/utils.ts
@@ -17,7 +17,7 @@ import { normaliseAuthRecipe } from "../authRecipe/utils";
 
 import { defaultEmailValidator } from "./validators";
 
-import type { Config, NormalisedConfig, SignInUpFeatureConfigInput } from "./types";
+import type { Config, LoginAttemptInfo, NormalisedConfig, SignInUpFeatureConfigInput } from "./types";
 import type { FeatureBaseConfig, NormalisedBaseConfig } from "../../types";
 import type { RecipeInterface } from "supertokens-web-js/recipe/passwordless";
 
@@ -114,4 +114,15 @@ function normalisePasswordlessBaseConfig<T>(config?: T & FeatureBaseConfig): T &
         ...(config as T),
         style,
     };
+}
+
+export function checkAdditionalLoginAttemptInfoProperties(loginAttemptInfo: LoginAttemptInfo) {
+    if (
+        loginAttemptInfo.contactInfo === undefined ||
+        loginAttemptInfo.contactMethod === undefined ||
+        loginAttemptInfo.lastResend === undefined
+    ) {
+        return false;
+    }
+    return true;
 }


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

This is a convenience thing for people migrating from custom UI to prebuilt UI which we do not test for

## Documentation changes

N/A

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [x] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [x] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [x] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`