### PR TITLE
fix: add SessionPreBuiltUI into PreBuiltRecipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixes
+
+-   Fixed an issue where the `Session` recipe was not allowed in the pre-built UI list (it's still a no-op, but it shouldn't be a type issue)
+
 ## [0.45.1] - 2024-08-09
 
 ### Changes

--- a/lib/build/ui/types.d.ts
+++ b/lib/build/ui/types.d.ts
@@ -2,6 +2,7 @@ import type { EmailPasswordPreBuiltUI } from "../recipe/emailpassword/prebuiltui
 import type { EmailVerificationPreBuiltUI } from "../recipe/emailverification/prebuiltui";
 import type { MultiFactorAuthPreBuiltUI } from "../recipe/multifactorauth/prebuiltui";
 import type { PasswordlessPreBuiltUI } from "../recipe/passwordless/prebuiltui";
+import type { SessionPreBuiltUI } from "../recipe/session/prebuiltui";
 import type { ThirdPartyPreBuiltUI } from "../recipe/thirdparty/prebuiltui";
 import type { TOTPPreBuiltUI } from "../recipe/totp/prebuiltui";
 export declare type ReactRouterDomWithCustomHistory = {
@@ -18,4 +19,5 @@ export declare type PreBuiltRecipes = (
     | typeof EmailVerificationPreBuiltUI
     | typeof MultiFactorAuthPreBuiltUI
     | typeof TOTPPreBuiltUI
+    | typeof SessionPreBuiltUI
 )[];

--- a/lib/ts/ui/types.ts
+++ b/lib/ts/ui/types.ts
@@ -2,6 +2,7 @@ import type { EmailPasswordPreBuiltUI } from "../recipe/emailpassword/prebuiltui
 import type { EmailVerificationPreBuiltUI } from "../recipe/emailverification/prebuiltui";
 import type { MultiFactorAuthPreBuiltUI } from "../recipe/multifactorauth/prebuiltui";
 import type { PasswordlessPreBuiltUI } from "../recipe/passwordless/prebuiltui";
+import type { SessionPreBuiltUI } from "../recipe/session/prebuiltui";
 import type { ThirdPartyPreBuiltUI } from "../recipe/thirdparty/prebuiltui";
 import type { TOTPPreBuiltUI } from "../recipe/totp/prebuiltui";
 
@@ -18,4 +19,5 @@ export type PreBuiltRecipes = (
     | typeof EmailVerificationPreBuiltUI
     | typeof MultiFactorAuthPreBuiltUI
     | typeof TOTPPreBuiltUI
+    | typeof SessionPreBuiltUI
 )[];

--- a/test/with-typescript/src/App.tsx
+++ b/test/with-typescript/src/App.tsx
@@ -33,7 +33,7 @@ import {
     EmailPasswordPreBuiltUI,
     ResetPasswordUsingToken as EmailPasswordResetPasswordUsingToken,
 } from "../../../recipe/emailpassword/prebuiltui";
-import { AccessDeniedScreen } from "../../../recipe/session/prebuiltui";
+import { SessionPreBuiltUI, AccessDeniedScreen } from "../../../recipe/session/prebuiltui";
 import { LinkClicked as PasswordlessLinkClicked } from "../../../recipe/passwordless/prebuiltui";
 import EmailVerification from "../../../recipe/emailverification";
 import MultiFactorAuth from "../../../recipe/multifactorauth";
@@ -1105,7 +1105,7 @@ function testAuthPagePropTypes() {
         // @ts-expect-error This has to be a valid first factor
         <AuthPage preBuiltUIList={[ThirdPartyPreBuiltUI]} factors={["totp"]} />,
         <AuthPage
-            preBuiltUIList={[ThirdPartyPreBuiltUI]}
+            preBuiltUIList={[ThirdPartyPreBuiltUI, SessionPreBuiltUI]}
             factors={["thirdparty", "emailpassword", "link-email", "link-phone", "otp-email", "otp-phone"]}
         />,
     ];


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [x] Changelog has been updated
-   [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [x] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [x] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [x] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [x] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [x] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [x] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`
