### PR TITLE
test: fix CI test failure

### DIFF
--- a/test/end-to-end/emailverification.test.js
+++ b/test/end-to-end/emailverification.test.js
@@ -371,7 +371,10 @@ describe("SuperTokens Email Verification", function () {
             assert.deepStrictEqual(generalSuccess, "Email resent");
 
             // Click on Logout should remove session and redirect to login page
-            await Promise.all([clickLinkWithRightArrow(page), page.waitForNavigation({ waitUntil: "networkidle0" })]);
+            await Promise.all([
+                logoutFromEmailVerification(page),
+                page.waitForNavigation({ waitUntil: "networkidle0" }),
+            ]);
             await waitForUrl(page, "/auth/");
             assert.deepStrictEqual(consoleLogs, [
                 "ST_LOGS SESSION OVERRIDE ADD_FETCH_INTERCEPTORS_AND_RETURN_MODIFIED_FETCH",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -368,7 +368,7 @@ export async function logoutFromEmailVerification(page) {
         ({ ST_ROOT_SELECTOR }) =>
             document
                 .querySelector(ST_ROOT_SELECTOR)
-                .shadowRoot.querySelector("[data-supertokens~='secondaryLinkWithArrow']")
+                .shadowRoot.querySelector("[data-supertokens~='buttonWithArrow']")
                 .click(),
         { ST_ROOT_SELECTOR }
     );


### PR DESCRIPTION
## Summary of change

Fixes the CI test failure

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan
- All failing tests(CI) now pass locally

<img width="1262" alt="Screenshot 2024-09-05 at 12 59 16" src="https://github.com/user-attachments/assets/9c7dc0af-3f54-4591-a999-6b2c6127e085">

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [ ] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [ ] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
