### PR TITLE
fix: only show continue with passwordless if email pwless is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.47.1] - 2024-09-18
+
+### Fixes
+
+-   Fixed an issue where we showed the "continue with passwordless" button during sign-in even if email-based passwordless was disabled by the tenant configuration.
+
 ## [0.47.0] - 2024-09-02
 
 ### Breaking changes

--- a/lib/build/genericComponentOverrideContext.js
+++ b/lib/build/genericComponentOverrideContext.js
@@ -265,7 +265,7 @@ var SSR_ERROR =
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var package_version = "0.47.0";
+var package_version = "0.47.1";
 
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *

--- a/lib/build/passwordlessprebuiltui.js
+++ b/lib/build/passwordlessprebuiltui.js
@@ -5901,6 +5901,11 @@ function useChildProps$1(recipe$2, factorIds, error, onError, clearError, rebuil
     return React.useMemo(
         function () {
             var _a;
+            var isPasswordlessEmailEnabled = [types.FactorIds.LINK_EMAIL, types.FactorIds.OTP_EMAIL].some(function (
+                id
+            ) {
+                return factorIds.includes(id);
+            });
             return {
                 isPhoneNumber: isPhoneNumber,
                 setIsPhoneNumber: function (isPhone) {
@@ -5937,7 +5942,7 @@ function useChildProps$1(recipe$2, factorIds, error, onError, clearError, rebuil
                                     }
                                 case 2:
                                     email = contactInfo;
-                                    if (recipe$2.config.contactMethod === "PHONE") {
+                                    if (recipe$2.config.contactMethod === "PHONE" || !isPasswordlessEmailEnabled) {
                                         setShowPasswordField(true);
                                         return [2 /*return*/, { status: "OK" }];
                                     }
@@ -5980,7 +5985,9 @@ function useChildProps$1(recipe$2, factorIds, error, onError, clearError, rebuil
                                     }
                                 case 6:
                                     setShowPasswordField(true);
-                                    setShowContinueWithPasswordlessLink(true);
+                                    if (isPasswordlessEmailEnabled) {
+                                        setShowContinueWithPasswordlessLink(true);
+                                    }
                                     return [2 /*return*/, { status: "OK" }];
                                 case 7:
                                     return [2 /*return*/];

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.47.0";
+export declare const package_version = "0.47.1";

--- a/lib/ts/recipe/passwordless/components/features/signInAndUpEPCombo/index.tsx
+++ b/lib/ts/recipe/passwordless/components/features/signInAndUpEPCombo/index.tsx
@@ -26,6 +26,7 @@ import { getRedirectToPathFromURL, useRethrowInRender, validateForm } from "../.
 import EmailPassword from "../../../../emailpassword/recipe";
 import { EmailVerificationClaim } from "../../../../emailverification";
 import EmailVerification from "../../../../emailverification/recipe";
+import { FactorIds } from "../../../../multifactorauth";
 import { getInvalidClaimsFromResponse } from "../../../../session";
 import SessionRecipe from "../../../../session/recipe";
 import Session from "../../../../session/recipe";
@@ -61,6 +62,10 @@ export function useChildProps(
     const rethrowInRender = useRethrowInRender();
 
     return useMemo(() => {
+        const isPasswordlessEmailEnabled = [FactorIds.LINK_EMAIL, FactorIds.OTP_EMAIL].some((id) =>
+            factorIds.includes(id)
+        );
+
         return {
             isPhoneNumber,
             setIsPhoneNumber: (isPhone) => {
@@ -85,7 +90,7 @@ export function useChildProps(
                     }
                 }
                 const email = contactInfo;
-                if (recipe.config.contactMethod === "PHONE") {
+                if (recipe.config.contactMethod === "PHONE" || !isPasswordlessEmailEnabled) {
                     setShowPasswordField(true);
                     return { status: "OK" };
                 }
@@ -114,7 +119,9 @@ export function useChildProps(
                     }
                 } else {
                     setShowPasswordField(true);
-                    setShowContinueWithPasswordlessLink(true);
+                    if (isPasswordlessEmailEnabled) {
+                        setShowContinueWithPasswordlessLink(true);
+                    }
                     return { status: "OK" };
                 }
             },

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.47.0";
+export const package_version = "0.47.1";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.47.0",
+    "version": "0.47.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.47.0",
+            "version": "0.47.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "intl-tel-input": "^17.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.47.0",
+    "version": "0.47.1",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {


### PR DESCRIPTION
## Summary of change

Fixed an issue where we showed the "continue with passwordless" button during sign-in even if email-based passwordless was disabled by the tenant configuration.

## Related issues

-   

## Test Plan



## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [ ] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [ ] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
