### PR TITLE
fix: add missing types to OAuth2Provider recipe init

### DIFF
--- a/lib/build/recipe/oauth2provider/index.d.ts
+++ b/lib/build/recipe/oauth2provider/index.d.ts
@@ -4,7 +4,14 @@ import { UserInput, GetRedirectionURLContext, PreAPIHookContext, OnHandleEventCo
 import type { RecipeFunctionOptions, LoginInfo } from "supertokens-web-js/recipe/oauth2provider";
 import type { RecipeInterface } from "supertokens-web-js/recipe/oauth2provider";
 export default class Wrapper {
-    static init(config?: UserInput): import("../../types").RecipeInitResult<any, never, any, any>;
+    static init(
+        config?: UserInput
+    ): import("../../types").RecipeInitResult<
+        GetRedirectionURLContext,
+        import("./types").PreAndPostAPIHookAction,
+        OnHandleEventContext,
+        import("./types").NormalisedConfig
+    >;
     /**
      * Returns information about an OAuth login in progress
      *

--- a/lib/build/recipe/oauth2provider/recipe.d.ts
+++ b/lib/build/recipe/oauth2provider/recipe.d.ts
@@ -22,7 +22,9 @@ export default class OAuth2Provider extends RecipeModule<
         config: NormalisedConfigWithAppInfoAndRecipeID<NormalisedConfig>,
         webJSRecipe?: WebJSRecipeInterface<typeof OAuth2WebJS>
     );
-    static init(config?: UserInput): RecipeInitResult<any, never, any, any>;
+    static init(
+        config?: UserInput
+    ): RecipeInitResult<GetRedirectionURLContext, PreAndPostAPIHookAction, OnHandleEventContext, NormalisedConfig>;
     static getInstanceOrThrow(): OAuth2Provider;
     static getInstance(): OAuth2Provider | undefined;
     getDefaultRedirectionURL(ctx: GetRedirectionURLContext): Promise<string>;

--- a/lib/ts/recipe/oauth2provider/index.ts
+++ b/lib/ts/recipe/oauth2provider/index.ts
@@ -24,6 +24,7 @@ export default class Wrapper {
     static init(config?: UserInput) {
         return OAuth2Provider.init(config);
     }
+
     /**
      * Returns information about an OAuth login in progress
      *

--- a/lib/ts/recipe/oauth2provider/recipe.ts
+++ b/lib/ts/recipe/oauth2provider/recipe.ts
@@ -57,7 +57,9 @@ export default class OAuth2Provider extends RecipeModule<
         super(config);
     }
 
-    static init(config?: UserInput): RecipeInitResult<any, never, any, any> {
+    static init(
+        config?: UserInput
+    ): RecipeInitResult<GetRedirectionURLContext, PreAndPostAPIHookAction, OnHandleEventContext, NormalisedConfig> {
         const normalisedConfig = normaliseOAuth2Config(config);
         return {
             recipeID: OAuth2Provider.RECIPE_ID,


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [ ] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [ ] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
