### PR TITLE
fix: use navigate fn to redirect to reset pw page in ep+pwless combo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.48.0] - 2024-10-07
 
+### Fixes
+
+-   Fixed an issue where the `AuthPage` was using full-page redirects to navigate to the password reset page if both emailpassword and passwordless were enabled.
+
 ### Changes
 
 -   Added the `OAuth2Provider` recipe

--- a/lib/build/passwordlessprebuiltui.js
+++ b/lib/build/passwordlessprebuiltui.js
@@ -5603,11 +5603,14 @@ var EPComboEmailForm = uiEntry.withOverride(
                                     genericComponentOverrideContext.__assign(
                                         {
                                             onClick: function () {
-                                                return recipe$1.EmailPassword.getInstanceOrThrow().redirect({
-                                                    action: "RESET_PASSWORD",
-                                                    tenantIdFromQueryParams:
-                                                        genericComponentOverrideContext.getTenantIdFromQueryParams(),
-                                                });
+                                                return recipe$1.EmailPassword.getInstanceOrThrow().redirect(
+                                                    {
+                                                        action: "RESET_PASSWORD",
+                                                        tenantIdFromQueryParams:
+                                                            genericComponentOverrideContext.getTenantIdFromQueryParams(),
+                                                    },
+                                                    props.navigate
+                                                );
                                             },
                                             "data-supertokens": "link linkButton formLabelLinkBtn forgotPasswordLink",
                                         },
@@ -5786,11 +5789,14 @@ var EPComboEmailOrPhoneForm = uiEntry.withOverride(
                                     genericComponentOverrideContext.__assign(
                                         {
                                             onClick: function () {
-                                                return recipe$1.EmailPassword.getInstanceOrThrow().redirect({
-                                                    action: "RESET_PASSWORD",
-                                                    tenantIdFromQueryParams:
-                                                        genericComponentOverrideContext.getTenantIdFromQueryParams(),
-                                                });
+                                                return recipe$1.EmailPassword.getInstanceOrThrow().redirect(
+                                                    {
+                                                        action: "RESET_PASSWORD",
+                                                        tenantIdFromQueryParams:
+                                                            genericComponentOverrideContext.getTenantIdFromQueryParams(),
+                                                    },
+                                                    props.navigate
+                                                );
                                             },
                                             "data-supertokens": "link linkButton formLabelLinkBtn forgotPasswordLink",
                                         },
@@ -6257,6 +6263,7 @@ function useChildProps$1(
                     (_a = recipe$2.config.validatePhoneNumber) !== null && _a !== void 0
                         ? _a
                         : defaultPhoneNumberValidator,
+                navigate: navigate,
             };
         },
         [
@@ -6267,6 +6274,7 @@ function useChildProps$1(
             isPhoneNumber,
             showPasswordField,
             showContinueWithPasswordlessLink,
+            navigate,
         ]
     );
 }

--- a/lib/build/recipe/passwordless/types.d.ts
+++ b/lib/build/recipe/passwordless/types.d.ts
@@ -18,6 +18,7 @@ import type { ComponentOverride } from "../../components/componentOverride/compo
 import type {
     APIFormField,
     FeatureBaseConfig,
+    Navigate,
     NormalisedBaseConfig,
     UserContext,
     WebJSRecipeInterface,
@@ -250,6 +251,7 @@ export declare type SignInUpEPComboEmailOrPhoneFormProps = {
     recipeImplementation: RecipeImplementation;
     config: NormalisedConfig;
     validatePhoneNumber: (phoneNumber: string) => Promise<string | undefined> | string | undefined;
+    navigate: Navigate | undefined;
 };
 export declare type SignInUpEPComboEmailFormProps = {
     showPasswordField: boolean;
@@ -277,6 +279,7 @@ export declare type SignInUpEPComboEmailFormProps = {
     recipeImplementation: RecipeImplementation;
     validatePhoneNumber: (phoneNumber: string) => Promise<string | undefined> | string | undefined;
     config: NormalisedConfig;
+    navigate: Navigate | undefined;
 };
 export declare type MFAAction =
     | {
@@ -336,6 +339,7 @@ export declare type SignInUpEPComboChildProps = Omit<SignInUpProps, "onSuccess">
               }
     ) => void;
     validatePhoneNumber: (phoneNumber: string) => Promise<string | undefined> | string | undefined;
+    navigate: Navigate | undefined;
 };
 export declare type LinkSentChildProps = LinkSentThemeProps;
 export declare type MFAChildProps = Omit<MFAProps, "featureState" | "dispatch">;

--- a/lib/build/recipe/recipeModule/index.d.ts
+++ b/lib/build/recipe/recipeModule/index.d.ts
@@ -9,7 +9,7 @@ export default abstract class RecipeModule<
 > extends BaseRecipeModule<GetRedirectionURLContextType, Action, OnHandleEventContextType, N> {
     redirect: (
         context: NormalisedGetRedirectionURLContext<GetRedirectionURLContextType>,
-        navigate?: Navigate,
+        navigate: Navigate | undefined,
         queryParams?: Record<string, string>,
         userContext?: UserContext
     ) => Promise<void>;

--- a/lib/ts/recipe/passwordless/components/features/signInAndUpEPCombo/index.tsx
+++ b/lib/ts/recipe/passwordless/components/features/signInAndUpEPCombo/index.tsx
@@ -233,6 +233,7 @@ export function useChildProps(
             recipeImplementation: recipeImplementation,
             config: recipe.config,
             validatePhoneNumber: recipe.config.validatePhoneNumber ?? defaultPhoneNumberValidator,
+            navigate,
         };
     }, [
         error,
@@ -242,6 +243,7 @@ export function useChildProps(
         isPhoneNumber,
         showPasswordField,
         showContinueWithPasswordlessLink,
+        navigate,
     ]);
 }
 

--- a/lib/ts/recipe/passwordless/components/themes/signInUpEPCombo/emailForm.tsx
+++ b/lib/ts/recipe/passwordless/components/themes/signInUpEPCombo/emailForm.tsx
@@ -59,10 +59,13 @@ export const EPComboEmailForm = withOverride(
                         <Label value={"PWLESS_COMBO_PASSWORD_LABEL"} data-supertokens="passwordInputLabel" />
                         <a
                             onClick={() =>
-                                EmailPassword.getInstanceOrThrow().redirect({
-                                    action: "RESET_PASSWORD",
-                                    tenantIdFromQueryParams: getTenantIdFromQueryParams(),
-                                })
+                                EmailPassword.getInstanceOrThrow().redirect(
+                                    {
+                                        action: "RESET_PASSWORD",
+                                        tenantIdFromQueryParams: getTenantIdFromQueryParams(),
+                                    },
+                                    props.navigate
+                                )
                             }
                             data-supertokens="link linkButton formLabelLinkBtn forgotPasswordLink">
                             {t("PWLESS_COMBO_FORGOT_PW_LINK")}

--- a/lib/ts/recipe/passwordless/components/themes/signInUpEPCombo/emailOrPhoneForm.tsx
+++ b/lib/ts/recipe/passwordless/components/themes/signInUpEPCombo/emailOrPhoneForm.tsx
@@ -109,10 +109,13 @@ export const EPComboEmailOrPhoneForm = withOverride(
                         <Label value={"PWLESS_COMBO_PASSWORD_LABEL"} data-supertokens="passwordInputLabel" />
                         <a
                             onClick={() =>
-                                EmailPassword.getInstanceOrThrow().redirect({
-                                    action: "RESET_PASSWORD",
-                                    tenantIdFromQueryParams: getTenantIdFromQueryParams(),
-                                })
+                                EmailPassword.getInstanceOrThrow().redirect(
+                                    {
+                                        action: "RESET_PASSWORD",
+                                        tenantIdFromQueryParams: getTenantIdFromQueryParams(),
+                                    },
+                                    props.navigate
+                                )
                             }
                             data-supertokens="link linkButton formLabelLinkBtn forgotPasswordLink">
                             {t("PWLESS_COMBO_FORGOT_PW_LINK")}

--- a/lib/ts/recipe/passwordless/types.ts
+++ b/lib/ts/recipe/passwordless/types.ts
@@ -33,6 +33,7 @@ import type { ComponentOverride } from "../../components/componentOverride/compo
 import type {
     APIFormField,
     FeatureBaseConfig,
+    Navigate,
     NormalisedBaseConfig,
     UserContext,
     WebJSRecipeInterface,
@@ -307,6 +308,7 @@ export type SignInUpEPComboEmailOrPhoneFormProps = {
     recipeImplementation: RecipeImplementation;
     config: NormalisedConfig;
     validatePhoneNumber: (phoneNumber: string) => Promise<string | undefined> | string | undefined;
+    navigate: Navigate | undefined;
 };
 
 export type SignInUpEPComboEmailFormProps = {
@@ -327,6 +329,7 @@ export type SignInUpEPComboEmailFormProps = {
     recipeImplementation: RecipeImplementation;
     validatePhoneNumber: (phoneNumber: string) => Promise<string | undefined> | string | undefined;
     config: NormalisedConfig;
+    navigate: Navigate | undefined;
 };
 
 export type MFAAction =
@@ -381,6 +384,7 @@ export type SignInUpEPComboChildProps = Omit<SignInUpProps, "onSuccess"> & {
             | { status: "OK"; isEmailPassword: false | undefined }
     ) => void;
     validatePhoneNumber: (phoneNumber: string) => Promise<string | undefined> | string | undefined;
+    navigate: Navigate | undefined;
 };
 export type LinkSentChildProps = LinkSentThemeProps;
 export type MFAChildProps = Omit<MFAProps, "featureState" | "dispatch">;

--- a/lib/ts/recipe/recipeModule/index.ts
+++ b/lib/ts/recipe/recipeModule/index.ts
@@ -30,7 +30,7 @@ export default abstract class RecipeModule<
 > extends BaseRecipeModule<GetRedirectionURLContextType, Action, OnHandleEventContextType, N> {
     redirect = async (
         context: NormalisedGetRedirectionURLContext<GetRedirectionURLContextType>,
-        navigate?: Navigate,
+        navigate: Navigate | undefined,
         queryParams?: Record<string, string>,
         userContext?: UserContext
     ): Promise<void> => {


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [ ] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [ ] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
