### PR TITLE
fix: Webauthn test updates due to changes

### DIFF
--- a/lib/build/webauthnprebuiltui.js
+++ b/lib/build/webauthnprebuiltui.js
@@ -1680,8 +1680,8 @@ var SignInFeatureInner = function (props) {
         props.clearError,
         props.resetFactorList,
         props.onSignInUpSwitcherClick,
-        isPasskeySupported,
-        props.showBackButton
+        props.showBackButton,
+        isPasskeySupported
     );
     return jsxRuntime.jsxs(React__namespace.Fragment, {
         children: [

--- a/lib/ts/recipe/webauthn/components/features/signIn/index.tsx
+++ b/lib/ts/recipe/webauthn/components/features/signIn/index.tsx
@@ -127,8 +127,8 @@ const SignInFeatureInner: React.FC<
         props.clearError,
         props.resetFactorList,
         props.onSignInUpSwitcherClick,
-        isPasskeySupported,
-        props.showBackButton
+        props.showBackButton,
+        isPasskeySupported
     )!;
 
     return (

--- a/test/end-to-end/webauthn.recover_account.test.js
+++ b/test/end-to-end/webauthn.recover_account.test.js
@@ -167,10 +167,7 @@ describe("SuperTokens Webauthn Recover Account", () => {
             // Use the token to recover the account
             await openRecoveryWithToken(page, "test");
 
-            const errorTextContainer = await waitForSTElement(
-                page,
-                "[data-supertokens~='passkeyRecoverableErrorContainer']"
-            );
+            const errorTextContainer = await waitForSTElement(page, "[data-supertokens~='generalError']");
             const errorText = await errorTextContainer.evaluate((el) => el.textContent);
             assert.strictEqual(
                 errorText,
@@ -215,10 +212,7 @@ describe("SuperTokens Webauthn Recover Account", () => {
             // Use the token to recover the account
             await openRecoveryWithToken(page, "test");
 
-            const errorTextContainer = await waitForSTElement(
-                page,
-                "[data-supertokens~='passkeyRecoverableErrorContainer']"
-            );
+            const errorTextContainer = await waitForSTElement(page, "[data-supertokens~='generalError']");
             const errorText = await errorTextContainer.evaluate((el) => el.textContent);
             assert.strictEqual(errorText, "Something went wrong, please refresh the page or reach out to support.");
 
@@ -240,10 +234,7 @@ describe("SuperTokens Webauthn Recover Account", () => {
 
             await submitFormUnsafe(page);
 
-            const errorTextContainer = await waitForSTElement(
-                page,
-                "[data-supertokens~='passkeyRecoverableErrorContainer']"
-            );
+            const errorTextContainer = await waitForSTElement(page, "[data-supertokens~='generalError']");
             const errorText = await errorTextContainer.evaluate((el) => el.textContent);
             assert.strictEqual(errorText, "Failed to recover account, please try again.");
 
@@ -265,10 +256,7 @@ describe("SuperTokens Webauthn Recover Account", () => {
 
             await submitFormUnsafe(page);
 
-            const errorTextContainer = await waitForSTElement(
-                page,
-                "[data-supertokens~='passkeyRecoverableErrorContainer']"
-            );
+            const errorTextContainer = await waitForSTElement(page, "[data-supertokens~='generalError']");
             const errorText = await errorTextContainer.evaluate((el) => el.textContent);
             assert.strictEqual(
                 errorText,
@@ -293,10 +281,7 @@ describe("SuperTokens Webauthn Recover Account", () => {
 
             await submitFormUnsafe(page);
 
-            const errorTextContainer = await waitForSTElement(
-                page,
-                "[data-supertokens~='passkeyRecoverableErrorContainer']"
-            );
+            const errorTextContainer = await waitForSTElement(page, "[data-supertokens~='generalError']");
             const errorText = await errorTextContainer.evaluate((el) => el.textContent);
             assert.strictEqual(errorText, "Failed to recover account, please try again.");
 
@@ -318,10 +303,7 @@ describe("SuperTokens Webauthn Recover Account", () => {
 
             await submitFormUnsafe(page);
 
-            const errorTextContainer = await waitForSTElement(
-                page,
-                "[data-supertokens~='passkeyRecoverableErrorContainer']"
-            );
+            const errorTextContainer = await waitForSTElement(page, "[data-supertokens~='generalError']");
             const errorText = await errorTextContainer.evaluate((el) => el.textContent);
             assert.strictEqual(errorText, "Invalid authenticator, please try again.");
 
@@ -344,10 +326,7 @@ describe("SuperTokens Webauthn Recover Account", () => {
             await submitFormUnsafe(page);
             await new Promise((res) => setTimeout(res, 1000));
 
-            const errorTextContainer = await waitForSTElement(
-                page,
-                "[data-supertokens~='passkeyRecoverableErrorContainer']"
-            );
+            const errorTextContainer = await waitForSTElement(page, "[data-supertokens~='generalError']");
             const errorText = await errorTextContainer.evaluate((el) => el.textContent);
             assert.strictEqual(
                 errorText,

--- a/test/end-to-end/webauthn.recovery_email.test.js
+++ b/test/end-to-end/webauthn.recovery_email.test.js
@@ -139,10 +139,7 @@ describe("SuperTokens Webauthn Recovery Email", () => {
             const email = await getTestEmail();
             await openRecoveryAccountPage(page, email, true);
 
-            const errorTextContainer = await waitForSTElement(
-                page,
-                "[data-supertokens~='passkeyRecoverableErrorContainer']"
-            );
+            const errorTextContainer = await waitForSTElement(page, "[data-supertokens~='generalError']");
             const errorText = await errorTextContainer.evaluate((el) => el.textContent);
             assert.strictEqual(errorText, "Account Recovery is not allowed, please contact support.");
 
@@ -157,10 +154,7 @@ describe("SuperTokens Webauthn Recovery Email", () => {
             });
             const email = await getTestEmail();
             await openRecoveryAccountPage(page, email, true);
-            const errorTextContainer = await waitForSTElement(
-                page,
-                "[data-supertokens~='passkeyRecoverableErrorContainer']"
-            );
+            const errorTextContainer = await waitForSTElement(page, "[data-supertokens~='generalError']");
             const errorText = await errorTextContainer.evaluate((el) => el.textContent);
             assert.strictEqual(
                 errorText,

--- a/test/end-to-end/webauthn.signin.test.js
+++ b/test/end-to-end/webauthn.signin.test.js
@@ -60,7 +60,13 @@ describe("SuperTokens Webauthn SignIn", () => {
 
     describe("SignIn test", () => {
         it("signup with passkey", async () => {
+            // Override to enable webauthn support
+            await page.evaluateOnNewDocument(() => {
+                localStorage.setItem("overrideWebauthnSupport", "true");
+            });
+
             await tryWebauthnSignIn(page);
+            await page.waitForTimeout(3000);
 
             // Most of the sign-in mock is defined in the override for the web
             // test server.
@@ -91,7 +97,7 @@ describe("SuperTokens Webauthn SignIn", () => {
                 localStorage.setItem("webauthnErrorStatus", "FAILED_TO_AUTHENTICATE_USER");
             });
             await tryWebauthnSignIn(page);
-            await waitForSTElement(page, "[data-supertokens~='passkeyRecoverableErrorContainer']");
+            await waitForSTElement(page, "[data-supertokens~='generalError']");
 
             // Remove the error and retry
             await page.evaluateOnNewDocument(() => {
@@ -112,7 +118,7 @@ describe("SuperTokens Webauthn SignIn", () => {
                 localStorage.setItem("webauthnErrorStatus", "FAILED_TO_AUTHENTICATE_USER");
             });
             await tryWebauthnSignIn(page);
-            await waitForSTElement(page, "[data-supertokens~='passkeyRecoverableErrorContainer']");
+            await waitForSTElement(page, "[data-supertokens~='generalError']");
 
             await page.evaluateOnNewDocument(() => {
                 localStorage.removeItem("webauthnErrorStatus");
@@ -124,10 +130,7 @@ describe("SuperTokens Webauthn SignIn", () => {
                 localStorage.setItem("webauthnErrorStatus", "WEBAUTHN_NOT_SUPPORTED");
             });
             await tryWebauthnSignIn(page);
-            const errorTextContainer = await waitForSTElement(
-                page,
-                "[data-supertokens~='passkeyRecoverableErrorContainer']"
-            );
+            const errorTextContainer = await waitForSTElement(page, "[data-supertokens~='generalError']");
             const errorText = await errorTextContainer.evaluate((el) => el.textContent);
             assert.strictEqual(
                 errorText,
@@ -144,10 +147,7 @@ describe("SuperTokens Webauthn SignIn", () => {
                 localStorage.setItem("webauthnErrorStatus", "INVALID_OPTIONS_ERROR");
             });
             await tryWebauthnSignIn(page);
-            const errorTextContainer = await waitForSTElement(
-                page,
-                "[data-supertokens~='passkeyRecoverableErrorContainer']"
-            );
+            const errorTextContainer = await waitForSTElement(page, "[data-supertokens~='generalError']");
             const errorText = await errorTextContainer.evaluate((el) => el.textContent);
             assert.strictEqual(
                 errorText,
@@ -164,7 +164,7 @@ describe("SuperTokens Webauthn SignIn", () => {
                 localStorage.setItem("throwWebauthnError", "true");
             });
             await tryWebauthnSignIn(page);
-            await waitForSTElement(page, "[data-supertokens~='passkeyRecoverableErrorContainer']");
+            await waitForSTElement(page, "[data-supertokens~='generalError']");
 
             await page.evaluateOnNewDocument(() => {
                 localStorage.removeItem("throwWebauthnError");

--- a/test/end-to-end/webauthn.signup.test.js
+++ b/test/end-to-end/webauthn.signup.test.js
@@ -153,10 +153,7 @@ describe("SuperTokens Webauthn SignUp", () => {
             await submitFormUnsafe(page);
             await page.waitForTimeout(1000);
 
-            const errorTextContainer = await waitForSTElement(
-                page,
-                "[data-supertokens~='passkeyRecoverableErrorContainer']"
-            );
+            const errorTextContainer = await waitForSTElement(page, "[data-supertokens~='generalError']");
             const errorText = await errorTextContainer.evaluate((el) => el.textContent);
             assert.strictEqual(errorText, "Email already exists, please sign in instead.");
 
@@ -200,7 +197,7 @@ describe("SuperTokens Webauthn SignUp", () => {
             // We should be in the confirmation page now.
             await submitFormUnsafe(page);
 
-            await waitForSTElement(page, "[data-supertokens~='passkeyRecoverableErrorContainer']");
+            await waitForSTElement(page, "[data-supertokens~='generalError']");
 
             // Remove the error and retry
             await page.evaluateOnNewDocument(() => {
@@ -227,7 +224,7 @@ describe("SuperTokens Webauthn SignUp", () => {
             // We should be in the confirmation page now.
             await submitFormUnsafe(page);
 
-            await waitForSTElement(page, "[data-supertokens~='passkeyRecoverableErrorContainer']");
+            await waitForSTElement(page, "[data-supertokens~='generalError']");
 
             await page.evaluateOnNewDocument(() => {
                 localStorage.removeItem("webauthnErrorStatus");
@@ -245,10 +242,7 @@ describe("SuperTokens Webauthn SignUp", () => {
             // We should be in the confirmation page now.
             await submitFormUnsafe(page);
 
-            const errorTextContainer = await waitForSTElement(
-                page,
-                "[data-supertokens~='passkeyRecoverableErrorContainer']"
-            );
+            const errorTextContainer = await waitForSTElement(page, "[data-supertokens~='generalError']");
             const errorText = await errorTextContainer.evaluate((el) => el.textContent);
             assert.strictEqual(
                 errorText,


### PR DESCRIPTION
## Summary of change

This PR updates webauthn tests to make them pass based on the updated code changes for showBackButton and general error component usage.

## Related issues

## Test Plan

All Webauthn tests should pass

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [x] Had run `npm run build-pretty`
-   [x] Had installed and ran the pre-commit hook
-   [x] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [ ] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [ ] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`

## Remaining TODOs for this PR
