### PR TITLE
fix: Include missing webauthn type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [0.49.1] - 2025-03-27
+
+-   Fixed a type issue making the WebauthnPreBuitlUI not produce a type error when added to the prebuiltUIList
+
 ## [0.49.0] - 2025-03-20
 
 -   Added the `Webauthn` recipe and prebuilt UI with passkey, webauthn-platform, and webauthn-resident support

--- a/lib/build/genericComponentOverrideContext.js
+++ b/lib/build/genericComponentOverrideContext.js
@@ -270,7 +270,7 @@ var SSR_ERROR =
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var package_version = "0.49.0";
+var package_version = "0.49.1";
 
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *

--- a/lib/build/ui/types.d.ts
+++ b/lib/build/ui/types.d.ts
@@ -6,6 +6,7 @@ import type { PasswordlessPreBuiltUI } from "../recipe/passwordless/prebuiltui";
 import type { SessionPreBuiltUI } from "../recipe/session/prebuiltui";
 import type { ThirdPartyPreBuiltUI } from "../recipe/thirdparty/prebuiltui";
 import type { TOTPPreBuiltUI } from "../recipe/totp/prebuiltui";
+import type { WebauthnPreBuiltUI } from "../recipe/webauthn/prebuiltui";
 export declare type ReactRouterDomWithCustomHistory = {
     router: {
         Route: any;
@@ -22,4 +23,5 @@ export declare type PreBuiltRecipes = (
     | typeof TOTPPreBuiltUI
     | typeof OAuth2ProviderPreBuiltUI
     | typeof SessionPreBuiltUI
+    | typeof WebauthnPreBuiltUI
 )[];

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.49.0";
+export declare const package_version = "0.49.1";

--- a/lib/ts/ui/types.ts
+++ b/lib/ts/ui/types.ts
@@ -6,6 +6,7 @@ import type { PasswordlessPreBuiltUI } from "../recipe/passwordless/prebuiltui";
 import type { SessionPreBuiltUI } from "../recipe/session/prebuiltui";
 import type { ThirdPartyPreBuiltUI } from "../recipe/thirdparty/prebuiltui";
 import type { TOTPPreBuiltUI } from "../recipe/totp/prebuiltui";
+import type { WebauthnPreBuiltUI } from "../recipe/webauthn/prebuiltui";
 
 export type ReactRouterDomWithCustomHistory = {
     router: { Route: any };
@@ -22,4 +23,5 @@ export type PreBuiltRecipes = (
     | typeof TOTPPreBuiltUI
     | typeof OAuth2ProviderPreBuiltUI
     | typeof SessionPreBuiltUI
+    | typeof WebauthnPreBuiltUI
 )[];

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.49.0";
+export const package_version = "0.49.1";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.49.0",
+    "version": "0.49.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.49.0",
+            "version": "0.49.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@simplewebauthn/types": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.49.0",
+    "version": "0.49.1",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {


### PR DESCRIPTION
## Summary of change

Add missing type for the `getRoutingComponent` argument.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [ ] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [ ] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
