### PR TITLE
fix: Include the rid header in ssr refresh requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## [unreleased]
+## [0.51.2] - 2026-02-13
+
+-   Include the rid header in ssr refresh requests to prevent csrf errors
 
 ## [0.51.1] - 2026-01-09
 

--- a/lib/build/nextjsmiddleware.js
+++ b/lib/build/nextjsmiddleware.js
@@ -168,7 +168,7 @@ function refreshSession(request) {
 }
 function revokeSession(request) {
     return utils.__awaiter(this, void 0, void 0, function () {
-        var response, accessToken, signOutURL, signoutRequestHeaders, err_2;
+        var response, accessToken, signOutURL, signoutRequestHeaders, rid, err_2;
         return utils.__generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
@@ -193,6 +193,10 @@ function revokeSession(request) {
                         "".concat(constants.ACCESS_TOKEN_COOKIE_SESSION_COOKIE_NAME, "=").concat(accessToken)
                     );
                     signoutRequestHeaders.append("Authorization", "Bearer ".concat(accessToken));
+                    rid = request.headers.get("rid");
+                    if (rid) {
+                        signoutRequestHeaders.append("rid", rid);
+                    }
                     return [
                         4 /*yield*/,
                         fetch(signOutURL, {
@@ -329,6 +333,7 @@ function fetchNewTokens(request) {
             cookieRefreshToken,
             headerRefreshToken,
             refreshRequestHeaders,
+            rid,
             refreshResponse,
             setCookieHeaders,
             tokenTransferMethod,
@@ -352,6 +357,10 @@ function fetchNewTokens(request) {
                     headerRefreshToken = getCookie(request, constants.REFRESH_TOKEN_HEADER_SESSION_COOKIE_NAME);
                     refreshRequestHeaders = new Headers();
                     refreshRequestHeaders.append("Content-Type", "application/json");
+                    rid = request.headers.get("rid");
+                    if (rid) {
+                        refreshRequestHeaders.append("rid", rid);
+                    }
                     if (cookieRefreshToken) {
                         refreshRequestHeaders.append(
                             "Cookie",

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -262,7 +262,7 @@ var SSR_ERROR =
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-var package_version = "0.51.1";
+var package_version = "0.51.2";
 
 /* Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
  *

--- a/lib/build/version.d.ts
+++ b/lib/build/version.d.ts
@@ -1,1 +1,1 @@
-export declare const package_version = "0.51.1";
+export declare const package_version = "0.51.2";

--- a/lib/ts/nextjs/middleware.ts
+++ b/lib/ts/nextjs/middleware.ts
@@ -180,10 +180,15 @@ async function revokeSession(request: Request): Promise<Response | void> {
             `${AppInfo.apiBasePath.getAsStringDangerous()}/signout`,
             AppInfo.apiDomain.getAsStringDangerous()
         );
+
         const signoutRequestHeaders = new Headers();
         signoutRequestHeaders.append("Content-Type", "application/json");
         signoutRequestHeaders.append("Cookie", `${ACCESS_TOKEN_COOKIE_SESSION_COOKIE_NAME}=${accessToken}`);
         signoutRequestHeaders.append("Authorization", `Bearer ${accessToken}`);
+        const rid = request.headers.get("rid");
+        if (rid) {
+            signoutRequestHeaders.append("rid", rid);
+        }
 
         await fetch(signOutURL, {
             method: "POST",
@@ -322,6 +327,10 @@ async function fetchNewTokens(request: Request): Promise<{
     const headerRefreshToken = getCookie(request, REFRESH_TOKEN_HEADER_SESSION_COOKIE_NAME);
     const refreshRequestHeaders = new Headers();
     refreshRequestHeaders.append("Content-Type", "application/json");
+    const rid = request.headers.get("rid");
+    if (rid) {
+        refreshRequestHeaders.append("rid", rid);
+    }
     if (cookieRefreshToken) {
         refreshRequestHeaders.append("Cookie", `${REFRESH_TOKEN_COOKIE_SESSION_COOKIE_NAME}=${cookieRefreshToken}`);
     } else if (headerRefreshToken) {

--- a/lib/ts/version.ts
+++ b/lib/ts/version.ts
@@ -12,4 +12,4 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-export const package_version = "0.51.1";
+export const package_version = "0.51.2";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.51.1",
+    "version": "0.51.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "supertokens-auth-react",
-            "version": "0.51.1",
+            "version": "0.51.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@simplewebauthn/types": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supertokens-auth-react",
-    "version": "0.51.1",
+    "version": "0.51.2",
     "description": "ReactJS SDK that provides login functionality with SuperTokens.",
     "main": "./index.js",
     "engines": {

--- a/test/unit/nextjs/middleware.test.ts
+++ b/test/unit/nextjs/middleware.test.ts
@@ -1,0 +1,60 @@
+/** @jest-environment node */
+
+import { superTokensMiddleware } from "../../../lib/ts/nextjs/middleware";
+
+describe("Next.js middleware", () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        jest.restoreAllMocks();
+    });
+
+    it("forwards rid header when middleware refreshes session", async () => {
+        const fetchMock = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            headers: {
+                getSetCookie: () => [
+                    "sAccessToken=access-token; Path=/; HttpOnly",
+                    "sRefreshToken=refresh-token; Path=/; HttpOnly",
+                    "sAntiCsrf=anti-csrf; Path=/; HttpOnly",
+                ],
+                get: (name: string) => {
+                    if (name === "front-token") {
+                        return "front-token-value";
+                    }
+                    return null;
+                },
+            },
+        });
+        global.fetch = fetchMock;
+
+        const middleware = superTokensMiddleware({
+            appInfo: {
+                appName: "test",
+                apiDomain: "http://localhost:3031",
+                websiteDomain: "http://localhost:3031",
+                apiBasePath: "/api/auth",
+                websiteBasePath: "/auth",
+            },
+        });
+
+        const response = await middleware(
+            new Request("http://localhost:3031/api/auth/session/refresh", {
+                method: "GET",
+                headers: {
+                    cookie: "sRefreshToken=refresh-token",
+                    rid: "session",
+                },
+            })
+        );
+
+        expect(response?.status).toBe(302);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        const fetchOptions = fetchMock.mock.calls[0][1] as RequestInit;
+        const headers = fetchOptions.headers as Headers;
+        expect(headers.get("rid")).toBe("session");
+    });
+});


### PR DESCRIPTION
## Summary of change

Updates the ssr session refresh behavior to include the rid header in the request. This way the backend sdk will not through csrf related errors during refresh attempts.

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [ ] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [ ] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
