### PR TITLE
fix: prevent duplicate OAuth2 continuation on session refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.51.3] - 2026-07-30
+
+-   Prevent duplicate OAuth2 calls on session refresh
+
 ## [0.51.2] - 2026-02-13
 
 -   Include the rid header in ssr refresh requests to prevent csrf errors
@@ -803,7 +807,8 @@ EmailPassword.init({
                             value={value}
                             name={name}
                             onChange={(e) => onChange(e.target.value)}
-                            placeholder="Select Option">
+                            placeholder="Select Option"
+                        >
                             <option value="" disabled hidden>
                                 Select an option
                             </option>
@@ -834,13 +839,15 @@ ThirdPartyEmailPassword.init({
                                 display: "flex",
                                 alignItems: "center",
                                 justifyContent: "left",
-                            }}>
+                            }}
+                        >
                             <input
                                 value={value}
                                 checked={value === "true"}
                                 name={name}
                                 type="checkbox"
-                                onChange={(e) => onChange(e.target.checked.toString())}></input>
+                                onChange={(e) => onChange(e.target.checked.toString())}
+                            ></input>
                             <span style={{ marginLeft: 5 }}>I agree to the terms and conditions</span>
                         </div>
                     ),
@@ -1509,7 +1516,8 @@ function App() {
                             </div>
                         );
                     },
-                }}>
+                }}
+            >
                 {/* The rest of JSX */}
             </EmailPasswordComponentsOverrideProvider>
         </SuperTokensWrapper>

--- a/lib/build/oauth2providerprebuiltui.js
+++ b/lib/build/oauth2providerprebuiltui.js
@@ -338,58 +338,61 @@ var TryRefreshPage$1 = function (props) {
     var rethrowInRender = utils.useRethrowInRender();
     var sessionContext = React.useContext(uiEntry.SessionContext);
     var loginChallenge = (_a = utils.getQueryParams("loginChallenge")) !== null && _a !== void 0 ? _a : undefined;
+    var didContinueRef = React__namespace.useRef(false);
     var userContext = uiEntry.useUserContext();
     if (props.userContext !== undefined) {
         userContext = props.userContext;
     }
     React__namespace.useEffect(
         function () {
-            if (sessionContext.loading === false) {
-                if (loginChallenge) {
-                    (function () {
-                        return utils.__awaiter(this, void 0, void 0, function () {
-                            var frontendRedirectTo;
-                            return utils.__generator(this, function (_a) {
-                                switch (_a.label) {
-                                    case 0:
-                                        return [
-                                            4 /*yield*/,
-                                            props.recipe.webJSRecipe.getRedirectURLToContinueOAuthFlow({
-                                                loginChallenge: loginChallenge,
-                                                userContext: userContext,
-                                            }),
-                                        ];
-                                    case 1:
-                                        frontendRedirectTo = _a.sent().frontendRedirectTo;
-                                        return [
-                                            2 /*return*/,
-                                            props.recipe.redirect(
-                                                {
-                                                    action: "CONTINUE_OAUTH2_AFTER_REFRESH",
-                                                    frontendRedirectTo: frontendRedirectTo,
-                                                    tenantIdFromQueryParams: utils.getTenantIdFromQueryParams(),
-                                                    recipeId: "oauth2provider",
-                                                },
-                                                props.navigate,
-                                                {},
-                                                userContext
-                                            ),
-                                        ];
-                                }
-                            });
+            if (sessionContext.loading || didContinueRef.current) {
+                return;
+            }
+            didContinueRef.current = true;
+            if (loginChallenge) {
+                (function () {
+                    return utils.__awaiter(this, void 0, void 0, function () {
+                        var frontendRedirectTo;
+                        return utils.__generator(this, function (_a) {
+                            switch (_a.label) {
+                                case 0:
+                                    return [
+                                        4 /*yield*/,
+                                        props.recipe.webJSRecipe.getRedirectURLToContinueOAuthFlow({
+                                            loginChallenge: loginChallenge,
+                                            userContext: userContext,
+                                        }),
+                                    ];
+                                case 1:
+                                    frontendRedirectTo = _a.sent().frontendRedirectTo;
+                                    return [
+                                        2 /*return*/,
+                                        props.recipe.redirect(
+                                            {
+                                                action: "CONTINUE_OAUTH2_AFTER_REFRESH",
+                                                frontendRedirectTo: frontendRedirectTo,
+                                                tenantIdFromQueryParams: utils.getTenantIdFromQueryParams(),
+                                                recipeId: "oauth2provider",
+                                            },
+                                            props.navigate,
+                                            {},
+                                            userContext
+                                        ),
+                                    ];
+                            }
                         });
-                    })().catch(rethrowInRender);
-                } else {
-                    void superTokens.SuperTokens.getInstanceOrThrow()
-                        .redirectToAuth({
-                            userContext: userContext,
-                            redirectBack: false,
-                        })
-                        .catch(rethrowInRender);
-                }
+                    });
+                })().catch(rethrowInRender);
+            } else {
+                void superTokens.SuperTokens.getInstanceOrThrow()
+                    .redirectToAuth({
+                        userContext: userContext,
+                        redirectBack: false,
+                    })
+                    .catch(rethrowInRender);
             }
         },
-        [loginChallenge, props.recipe, props.navigate, userContext, sessionContext]
+        [loginChallenge, props.recipe, props.navigate, userContext, sessionContext.loading, rethrowInRender]
     );
     var childProps = {
         config: props.recipe.config,

--- a/lib/ts/recipe/oauth2provider/components/features/tryRefreshPage/index.tsx
+++ b/lib/ts/recipe/oauth2provider/components/features/tryRefreshPage/index.tsx
@@ -41,41 +41,46 @@ export const TryRefreshPage: React.FC<Prop> = (props) => {
     const rethrowInRender = useRethrowInRender();
     const sessionContext = useContext(SessionContext);
     const loginChallenge = getQueryParams("loginChallenge") ?? undefined;
+    const didContinueRef = React.useRef(false);
     let userContext = useUserContext();
     if (props.userContext !== undefined) {
         userContext = props.userContext;
     }
 
     React.useEffect(() => {
-        if (sessionContext.loading === false) {
-            if (loginChallenge) {
-                (async function () {
-                    const { frontendRedirectTo } = await props.recipe.webJSRecipe.getRedirectURLToContinueOAuthFlow({
-                        loginChallenge,
-                        userContext,
-                    });
-                    return props.recipe.redirect(
-                        {
-                            action: "CONTINUE_OAUTH2_AFTER_REFRESH",
-                            frontendRedirectTo,
-                            tenantIdFromQueryParams: getTenantIdFromQueryParams(),
-                            recipeId: "oauth2provider",
-                        },
-                        props.navigate,
-                        {},
-                        userContext
-                    );
-                })().catch(rethrowInRender);
-            } else {
-                void SuperTokens.getInstanceOrThrow()
-                    .redirectToAuth({
-                        userContext,
-                        redirectBack: false,
-                    })
-                    .catch(rethrowInRender);
-            }
+        if (sessionContext.loading || didContinueRef.current) {
+            return;
         }
-    }, [loginChallenge, props.recipe, props.navigate, userContext, sessionContext]);
+
+        didContinueRef.current = true;
+
+        if (loginChallenge) {
+            (async function () {
+                const { frontendRedirectTo } = await props.recipe.webJSRecipe.getRedirectURLToContinueOAuthFlow({
+                    loginChallenge,
+                    userContext,
+                });
+                return props.recipe.redirect(
+                    {
+                        action: "CONTINUE_OAUTH2_AFTER_REFRESH",
+                        frontendRedirectTo,
+                        tenantIdFromQueryParams: getTenantIdFromQueryParams(),
+                        recipeId: "oauth2provider",
+                    },
+                    props.navigate,
+                    {},
+                    userContext
+                );
+            })().catch(rethrowInRender);
+        } else {
+            void SuperTokens.getInstanceOrThrow()
+                .redirectToAuth({
+                    userContext,
+                    redirectBack: false,
+                })
+                .catch(rethrowInRender);
+        }
+    }, [loginChallenge, props.recipe, props.navigate, userContext, sessionContext.loading, rethrowInRender]);
 
     const childProps = {
         config: props.recipe.config,

--- a/test/unit/recipe/oauth2provider/tryRefreshPage.test.tsx
+++ b/test/unit/recipe/oauth2provider/tryRefreshPage.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { act, render, waitFor } from "@testing-library/react";
+
+import SuperTokens from "../../../../lib/ts/superTokens";
+import OAuth2Provider from "../../../../lib/ts/recipe/oauth2provider/recipe";
+import TryRefreshPage from "../../../../lib/ts/recipe/oauth2provider/components/features/tryRefreshPage";
+import SessionContext from "../../../../lib/ts/recipe/session/sessionContext";
+import type { SessionContextType } from "../../../../lib/ts/recipe/session";
+
+describe("TryRefreshPage", () => {
+    beforeEach(() => {
+        OAuth2Provider.reset();
+        SuperTokens.reset();
+
+        SuperTokens.init({
+            appInfo: {
+                appName: "JestTest",
+                apiDomain: "http://localhost:3001",
+                apiBasePath: "/auth",
+                websiteDomain: "http://localhost:3000",
+                websiteBasePath: "/auth",
+            },
+            recipeList: [OAuth2Provider.init()],
+            useShadowDom: false,
+        });
+
+        window.history.pushState({}, "", "/auth/try-refresh?loginChallenge=test-challenge");
+    });
+
+    it("continues the OAuth flow only once when the session context updates twice", async () => {
+        const recipe = OAuth2Provider.getInstanceOrThrow();
+        const getRedirectURLToContinueOAuthFlow = jest
+            .spyOn(recipe.webJSRecipe, "getRedirectURLToContinueOAuthFlow")
+            .mockResolvedValue({
+                status: "OK",
+                frontendRedirectTo: "https://client.example.com/callback",
+                fetchResponse: {} as Response,
+            });
+        jest.spyOn(recipe, "redirect").mockResolvedValue(undefined);
+
+        const sessionContext: SessionContextType = {
+            loading: false,
+            doesSessionExist: true,
+            userId: "user-id",
+            accessTokenPayload: { iat: 1 },
+            invalidClaims: [],
+        };
+
+        const { rerender } = render(
+            <SessionContext.Provider value={sessionContext}>
+                <TryRefreshPage
+                    recipe={recipe}
+                    userContext={{}}
+                    useComponentOverrides={() => ({})}
+                    navigate={() => undefined}
+                />
+            </SessionContext.Provider>
+        );
+
+        await waitFor(() => {
+            expect(getRedirectURLToContinueOAuthFlow).toHaveBeenCalledTimes(1);
+        });
+
+        act(() => {
+            rerender(
+                <SessionContext.Provider value={{ ...sessionContext, accessTokenPayload: { iat: 2 } }}>
+                    <TryRefreshPage
+                        recipe={recipe}
+                        userContext={{}}
+                        useComponentOverrides={() => ({})}
+                        navigate={() => undefined}
+                    />
+                </SessionContext.Provider>
+            );
+        });
+
+        await act(async () => undefined);
+        expect(getRedirectURLToContinueOAuthFlow).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

-   Link to issue1 here
-   Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `lib/ts/version.ts`
-   [ ] Had run `npm run build-pretty`
-   [ ] Had installed and ran the pre-commit hook
-   [ ] Issue this PR against the latest non released version branch.
    -   To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    -   If no such branch exists, then create one from the latest released branch.
-   [ ] If added a new recipe interface, then make sure that the implementation of it uses NON arrow functions only (like `someFunc: function () {..}`).
-   [ ] If I added a new recipe, I also added the recipe entry point into the `size-limit` section of `package.json` with the size limit set to the current size rounded up.
-   [ ] If I added a new recipe, I also added the recipe entry point into the `rollup.config.mjs`
-   [ ] If I added a new login method, I modified the list in `lib/ts/types.ts`
-   [ ] If I added a factor id, I modified the list in `lib/ts/recipe/multifactorauth/types.ts`

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
